### PR TITLE
adding Microplanning v0.1 localisations in release kit

### DIFF
--- a/localisation/Microplanning/v0.1/en_MZ/hcm-admin-schemas.json
+++ b/localisation/Microplanning/v0.1/en_MZ/hcm-admin-schemas.json
@@ -1,0 +1,2468 @@
+[
+  {
+    "code": "ADMIN10_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN10_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN10_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN10_POST ADMINISTRATIVO",
+    "message": "Post Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN10_STATE",
+    "message": "State",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN11_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN11_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN11_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN11_POST ADMINISTRATIVO",
+    "message": "Post Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN11_STATE",
+    "message": "State",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_PROVINCIA",
+    "message": "Provincia",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_PROVINCIA",
+    "message": "Provincia",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_POST ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_PROVINCIA",
+    "message": "Provincia",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMINE_QA",
+    "message": "QA",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMINU_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_ALDEIA",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_CONSOLE_TARGET",
+    "message": "Household Target at village level (Mandatory and to be entered by the user)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_LOCALIDADE",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_POST ADMINISTRATIVO",
+    "message": "Administrative Post",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_POSTO ADMINISTRATIVO",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_PROVINCIA",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_STATE",
+    "message": "State",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AGE",
+    "message": "Age",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.Country",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.Distrito",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.Localidade",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.Post Administrativo",
+    "message": "Post Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.PostAdministrativo",
+    "message": "Post Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.State",
+    "message": "State",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Setting total & target population once the template is downloaded :",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "Go to the district’s sheet you want to set targets for and add total and target population data for each village.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Enter target and total population for each village in each district’s sheet. If any village does not have targets set, the sheet will have errors.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Save the sheet with the updated target and total population for each village on the excel template.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Press the 'Browse In My Files' button on the population upload screen and select the saved file with all target and total population from the system.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2",
+    "message": "Cases for common errors :",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2_DESC_1",
+    "message": "If the user has not set targets or total population for each village, the system will throw an error with the line number where the target or total population is missing.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2_DESC_2",
+    "message": "If the user deletes any village from the sheet or deletes a complete district sheet and uploads the sheet, the system will throw an error. The user will have to download the template again and reupload the correct sheet with the corrected data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2_DESC_3",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet, the system will throw an error. The user will have to download the template again and reupload the correct sheet with the corrected data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1",
+    "message": "Downloading excel templates for setting targets:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Download the excel template by clicking on the “Download Template” button.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Open the excel template that was downloaded in the previous step and the first sheet you will see is a “Read Me” sheet. The remaining sheets will be named after the name of the districts selected in the “Boundary Selection” step with each district Sheets having a list of all the villages mapped to that district.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2",
+    "message": "Setting targets once the template is downloaded:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_1",
+    "message": "Go to the district’s sheet you want to set targets for and add numbers in the “Targets” Column for each Village. ",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Enter targets for each village in each district’s sheet under the “Target at the Selected Boundary level” Column. If any village does not have targets set, the sheet will have errors.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Save the sheet with the updated targets for each village on the excel template .",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Target” screen and select the saved file with all targets from the system.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3",
+    "message": "Cases for common errors:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_1",
+    "message": "If the user has not set targets for each village the system will throw an error with line number where the targets are missing.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_2",
+    "message": "If the user deletes any village from the sheet or deletes a complete district sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_3",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_MAINHEADER",
+    "message": "Read me instructions for target upload",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": "Number of bed nets per household",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Number of individuals per bed net",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_BEFORE_ERROR",
+    "message": "End date of the campaign cannot be before the start date of the campaign.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_ERROR",
+    "message": "Mandatory field !",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_MANDATORY",
+    "message": "Mandatory field !",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE_ERROR",
+    "message": "Mandatory field !",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_MZ_capacity",
+    "message": "Capacity ( Units: Bales )",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_mz_capacity",
+    "message": "Capacity ( Units: Bales )",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIN_mz_capacity",
+    "message": "Capacity ( Units: Bales )",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN__capacity",
+    "message": "Capacity",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN_capacity",
+    "message": "Capacity ( Units: SPAQ Blister )",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_boundaryCode",
+    "message": "Catchment Boundary Code ( Mandatory )",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityUsage",
+    "message": "Facility Usage",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EDIT_MICROPLANS_TEXT",
+    "message": "Edit microplan",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EQUAL_TO",
+    "message": "equal to",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_LOADING_BASE_MAP",
+    "message": "Cant find required base map, Please contact admin.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_READ_ME_MISSING",
+    "message": "Please do not change the sheet names.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_TIMELINE",
+    "message": "Timeline",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_1",
+    "message": "If there are no Facilities available for selection, the “List of Available Facilities“ tab in the template will be empty. To create new facility data, add the name of the Facility Name, Facility Type, Facility Status, Capacity. The “Facility Code” column needs to be left empty if this is a new facility. If it is a facility being reused (which is available in the template after downloading) the user only needs to do step 2.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_2",
+    "message": "To map the facility to the correct boundary, the user needs to copy the correct boundary code of the boundary from the “List of Campaign Boundaries“ sheet that the facility needs to be mapped to. If there is a facility that is mapped to multiple boundaries, the System Admin will have to add the boundary codes of all the boundaries that facility is mapped to by separating them by commas in the cell to add Boundary Codes for that Facility.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Creating new facility data/using existing facility data once the template is downloaded :",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "If there are no Facilities available for selection, the “List of Available Facilities“ tab in the template will be empty. To create new facility data, add the name of the Facility Name, Facility Type, Facility Status, Capacity and Facility usage.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "To map the facility to the correct boundary, the user needs to copy the correct boundary code of the boundary from the “Boundary Data“ sheet that the facility needs to be mapped to.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Save the sheet with the entered facility details in the excel template.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Facility Data” screen and select the saved file with all facility data from the system.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_2",
+    "message": "Deactivating existing facilities for a campaign",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_2_DESC_1",
+    "message": "After the user has downloaded the template for facilities, if the system has existing facility data to be reused, the template will be pre populated with those list of facilities.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_2_DESC_2",
+    "message": "If the user then chooses not use specific facilities, they can deactivate that facility by marking the 'Facility usage' field as 'Inactive'.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3",
+    "message": "Cases for common errors :",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3_DESC_1",
+    "message": "If the user has removed Facility boundary code for an existing facility in the list then system will throw an error message.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3_DESC_2",
+    "message": "If the user deletes any columns from the “List of Available Facilities” from the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3_DESC_3",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1",
+    "message": "Downloading excel templates for setting facilities:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Download the excel template by clicking on the “Download Template” button.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Open the Template that was downloaded in the previous step will have 3 sheets and the first sheet you will see is a “Read Me” sheet. The second Sheet named “List of Available Facilities“ will have a list of all the available facilities that can be used in the campaign. If there is no facility available, this sheet will be empty. The third sheet will be named “List of Campaign Boundaries“ which will have all the boundaries with their respective Boundary Codes.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2",
+    "message": "Creating new facility data/using existing facility data once the template is downloaded:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "If there are no Facilities available for selection, the “List of Available Facilities“ tab in the template will be empty. To create new facility data, add the name of the Facility Name, Facility Type, Facility Status, Capacity. The “Facility Code” column needs to be left empty if this is a new facility. If it is a facility being reused (which is available in the template after downloading) the user only needs to do step 2.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "To map the facility to the correct boundary, the user needs to copy the correct boundary code of the boundary from the “List of Campaign Boundaries“ sheet that the facility needs to be mapped to. If there is a facility that is mapped to multiple boundaries, the System Admin will have to add the boundary codes of all the boundaries that facility is mapped to by separating them by commas in the cell to add Boundary Codes for that Facility.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Save the sheet with the updated targets for each village on the excel template.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Facility Data” screen and select the saved file with all targets from the system.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_5",
+    "message": "Deactivating existing Facilities for a campaign.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_6",
+    "message": "After the user has downloaded the template for facilities, if the system has existing facility data to be reused, the template will be pre populated with those list of facilities.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_7",
+    "message": "If the user then chooses not use specific facilities, they can delete those lines of data for those specific facilities that need to be removed and upload the sheet with only those facilities that are needed for the campaign with the correct boundary codes mapped to those facilities.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1",
+    "message": "Case when there is no facility data in the system:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_1",
+    "message": "Step 1: When there is no facility data in the system, the “List of available facility” template will be empty. For every facility added the user needs to input the Facility Name (must be unique), Facility Type (Warehouse/Health Facility), Facility Status (Temporary/Permanent), Capacity (Number input)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_2",
+    "message": "Step 2: To map the facilities to a given boundary the user needs to copy the correct Boundary Code from the “Boundary Data” sheet. If there are more than one boundaries that a facility needs to be mapped to, the user can add all the boundary codes separated by commas",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_3",
+    "message": "Step 3: For every facility, the user needs to add Active or Inactive for all facilities under the “Facility Usage” column. All the Facilities marked as “Active” will be used in the campaign being created the ones marked “Inactive” will not be used in the campaign being created.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_4",
+    "message": "Step 4: Once all the facilities are added the user needs to save the file on their system and upload the file by pressing “Browse in My Files” option.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2",
+    "message": "Case when there is existing facility data in the system:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_1",
+    "message": "Step 1: When you open the downloaded facility template, please refer to the List of available Facility sheet. For existing facilities, kindly add entries in the Boundary Code column. You can find the boundary codes in the Boundary Data sheet. If a facility maps to multiple boundaries, please separate the codes with commas.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_2",
+    "message": "Step 2: In this step the user will have to add entries in the Facility Usage column with valid entries being either Active or Inactive where the user can set the usage for a facility to Active if the facility is being is used for a campaign or else can be set to Inactive. The inputs in the Facility Usage column need to be added for all entries.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_3",
+    "message": "Step 3: For adding new Facilities which are not present in the list of existing facilities, the user needs to input the Facility Name (must be unique), Facility Type (Warehouse/Health Facility), Facility Status (Temporary/Permanent), Capacity (Number input), Boundary Code(from the Boundary Data Sheet) and Facility Usage (Active/Inactive) as explained previously",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_4",
+    "message": "Step 4: Once all the facilities are added the user needs to save the file on their system and upload the file by pressing “Browse in My Files” option.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3",
+    "message": "Cases for common errors:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "If the user has removed Facility codes for an existing facility in the list then system will create a duplicate facility with those column values.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "If the user deletes any columns from the “List of Available Facilities” from the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_3",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_MAINHEADER",
+    "message": "Read me instructions for facility upload",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER",
+    "message": "Facility boundary assigner",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FEMALE",
+    "message": "Female",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FROM",
+    "message": "from",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GENDER",
+    "message": "Gender",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GREATER_THAN",
+    "message": "greater than",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GREATER_THAN_EQUAL_TO",
+    "message": "greater than or equal to",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POST ADMINISTRATIVO",
+    "message": "Post Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_PROVINCIA",
+    "message": "Provincia",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Boundary Code",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY",
+    "message": "Boundary Code (Mandatory)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY_ERROR",
+    "message": "is invalid. It should be taken from 'Boundary Data' sheet",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_OLD",
+    "message": "Boundary Code Old",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Boundary Data",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITIES",
+    "message": "List of Available Facilities",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY",
+    "message": "Capacity (Units: Bales for Bednets/ SPAQ Blister for SMC)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_ERROR",
+    "message": "should not be empty and should be a number from 1 to 10 million",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN",
+    "message": "Capacity (Units: Bales for Bednets/",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_LLIN-mz",
+    "message": "Capacity (Units: Bales)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_MR-DN",
+    "message": "Capacity (Units: Blisters)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CODE",
+    "message": "Facility Code",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_FIXED_POST_MICROPLAN",
+    "message": "Is fixed post (Yes/No)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LATITUDE_OPTIONAL_MICROPLAN",
+    "message": "Latitude (Optional)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LONGITUDE_OPTIONAL_MICROPLAN",
+    "message": "Longitude (Optional)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME",
+    "message": "Facility Name",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME_MICROPLAN",
+    "message": "Facility Name",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS",
+    "message": "Facility Status",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS_MICROPLAN",
+    "message": "Facility Status",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE",
+    "message": "Facility Type",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE_MICROPLAN",
+    "message": "Facility Type",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE",
+    "message": "Facility Usage",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE_MICROPLAN",
+    "message": "Facility Usage",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LAT",
+    "message": "Latitude",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LONG",
+    "message": "Longitude",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_RESIDING_BOUNDARY_CODE_MICROPLAN",
+    "message": "Residing boundary code",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET",
+    "message": "Household Target at village level (Mandatory and to be entered by the user)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_AT_THE_SELECTED_BOUNDARY_LEVEL",
+    "message": "Household Target at village level (Mandatory and to be entered by the user)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_1",
+    "message": "Household Target at a village level",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_2",
+    "message": "Room Target at a village level",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LAT_OPT",
+    "message": "Latitude (Optional)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LONG_OPT",
+    "message": "Longitude (Optional)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Target population",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Target Population (Age 12-59 months)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Target Population (Age 3-11 months)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC",
+    "message": "Target at village level (Mandatory and to be entered by the user)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_12_TO_59",
+    "message": "Target at village level - Age 12 to 59 Months (Mandatory and to be entered by the user)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_3_TO_11",
+    "message": "Target at village level - Age 3 to 11 Months (Mandatory and to be entered by the user)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Total population",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMAIL_MICROPLAN",
+    "message": "Email",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMPLOYMENT_TYPE",
+    "message": "Employment Type (Mandatory)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LIST",
+    "message": "Create List of Users",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Name of the Person (Mandatory)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME_MICROPLAN",
+    "message": "Name",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER",
+    "message": "Phone Number (Mandatory)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_ERROR",
+    "message": "must be provided and should be a phone number of 10 digits",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_MICROPLAN",
+    "message": "Contact number",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_ROLE",
+    "message": "Role (Mandatory)",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_USAGE",
+    "message": "Active / Inactive",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_README_SHEETNAME",
+    "message": "Read Me",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_TIMELINE",
+    "message": "Timeline",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_POST ADMINISTRATIVE",
+    "message": "Administrative Post",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEIGHT",
+    "message": "Height",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_ADMINISTRATIVEPOST",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_POST ADMINISTRATIVE",
+    "message": "Administrative Post",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_CAN_BE_ONLY_APPLIED_ON_ADMIN_LEVEL_ZORO",
+    "message": "Filters can only be applied at level 0",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "IN_BETWEEN",
+    "message": "in between",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LESS_THAN",
+    "message": "less than",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LESS_THAN_EQUAL_TO",
+    "message": "less than or equal to",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIM_MZ_capacity",
+    "message": "Capacity",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIM_mz_capacity",
+    "message": "Capacity",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "If there are no Facilities available for selection, the “List of Available Facilities“ tab in the template will be empty. To create new facility data, add the name of the Facility Name, Facility Type, Facility Status, Capacity. The “Facility Code” column needs to be left empty if this is a new facility. If it is a facility being reused (which is available in the template after downloading) the user only needs to do step 2.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "To map the facility to the correct boundary, the user needs to copy the correct boundary code of the boundary from the “List of Campaign Boundaries“ sheet that the facility needs to be mapped to. If there is a Facility that is mapped to multiple boundaries, the System Admin will have to add the boundary codes of all the boundaries that Facility is mapped to by separating them by commas in the cell to add Boundary Codes for that Facility.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Save the sheet with the updated targets for each village on the Excel Template.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Facility Data” screen and select the saved file with all targets from the system.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Deactivating existing Facilities for a campaign.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "After the user has downloaded the template for Facilities, if the system has existing facility data to be reused, the template will be pre populated with those list of Facilities.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "If the user then chooses not use specific facilities, they can delete those lines of data for those specific facilities that need to be removed and upload the sheet with only those facilities that are needed for the campaign with the correct boundary codes mapped to those facilities.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "If the user has removed Facility codes for an existing facility in the list then system will create a duplicate Facility with those column values.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "If the user deletes any columns from the “List of Available Facilities” from the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_1",
+    "message": "Creating New Facility Data/using existing facility data once the Template is Downloaded",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_2",
+    "message": "Cases for common errors:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Read me instructions for facility upload",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER",
+    "message": "Creating new facility data/using existing facility data once the template is downloaded:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_1",
+    "message": "Setting targets once the template is downloaded:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_2",
+    "message": "Cases for common errors:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Read me instructions for population upload",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Go to the district’s sheet you want to set targets for and add numbers in the “Targets” Column for each Village.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Enter targets for each village in each district’s sheet under the “Target at the Selected Boundary level” Column. If any village does not have targets set, the sheet will have errors.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_3",
+    "message": "If the user has not set targets for each village the system will throw an error with line number where the targets are missing.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_4",
+    "message": "If the user deletes any village from the sheet or deletes a complete district sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_5",
+    "message": "If the user has not set targets for each village the system will throw an error with line number where the targets are missing.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_6",
+    "message": "If the user deletes any village from the sheet or deletes a complete district sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_7",
+    "message": "If the user deletes any of the headers in the sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_mz_capacity",
+    "message": "Capacity",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MALE",
+    "message": "Male",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ACTIVE",
+    "message": "Active",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVEPOST",
+    "message": "Administrative Post",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINSTRATIVEPOST",
+    "message": "Administrative Post",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_BOUNDARY_DATA_SHEET",
+    "message": "Boundary Data",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_COLUMN",
+    "message": "Error Details",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_COLUMN",
+    "message": "Status",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_INVALID",
+    "message": "INVALID",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_DATA_SHEET",
+    "message": "Facility Data",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_READ_ME_SHEET",
+    "message": "Read Me",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEMPLATE_README_MAIN_HEADER",
+    "message": "Read me instructions for target upload",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "If there are no Facilities available for selection, the “List of Available Facilities“ tab in the template will be empty. To create new facility data, add the name of the Facility Name, Facility Type, Facility Status, Capacity. The “Facility Code” column needs to be left empty if this is a new facility. If it is a facility being reused (which is available in the template after downloading) the user only needs to do step 2.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "To map the facility to the correct boundary, the user needs to copy the correct boundary code of the boundary from the “List of Campaign Boundaries“ sheet that the facility needs to be mapped to. If there is a Facility that is mapped to multiple boundaries, the System Admin will have to add the boundary codes of all the boundaries that Facility is mapped to by separating them by commas in the cell to add Boundary Codes for that Facility.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Save the sheet with the updated targets for each village on the Excel Template.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Facility Data” screen and select the saved file with all targets from the system.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Deactivating existing Facilities for a campaign.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "After the user has downloaded the template for Facilities, if the system has existing facility data to be reused, the template will be pre populated with those list of Facilities.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "If the user then chooses not use specific facilities, they can delete those lines of data for those specific facilities that need to be removed and upload the sheet with only those facilities that are needed for the campaign with the correct boundary codes mapped to those facilities.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "If the user has removed Facility codes for an existing facility in the list then system will create a duplicate Facility with those column values.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "If the user deletes any columns from the “List of Available Facilities” from the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_1",
+    "message": "Creating New Facility Data/using existing facility data once the Template is Downloaded",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_2",
+    "message": "Cases for common errors:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Read me instructions for facility upload",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_1",
+    "message": "Setting Targets once the Template is Downloaded:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_2",
+    "message": "Cases for common errors:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Read me instructions for population upload",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Go to the district’s sheet you want to set targets for and add numbers in the “Targets” Column for each Village.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Enter targets for each village in each district’s sheet under the “Targets” Column. If any village does not have targets set the sheet will have errors.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_3",
+    "message": "Save the sheet with the updated targets for each village on the Excel Template .",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Target” screen and select the saved file with all targets from the system.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_5",
+    "message": "If the user has not set targets for each village the system will throw an error with line number where the targets are missing.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_6",
+    "message": "If the user deletes any village from the sheet or deletes a complete district sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_7",
+    "message": "If the user deletes any of the headers in the sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_capacity",
+    "message": "Capacity",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW BOUNDARY_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEWTEST0005_ADMINISTRATIVEPOST",
+    "message": "Administrative Post",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEWTEST0005_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEWTEST0005_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEWTEST0005_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEWTEST0005_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEWTEST0005_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_POST ADMINISTRATIVO",
+    "message": "Post Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_STATE",
+    "message": "State",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "OTHER_TARGETS",
+    "message": "Other targets",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER",
+    "message": "Plan estimation approver",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER",
+    "message": "Population data approver",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Root facility boundary assigner",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Root plan estimation approver",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER",
+    "message": "Root population data approver",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Svefewg4YCb",
+    "message": "Murrupula",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TARGET_HOUSEHOLDS",
+    "message": "Target Households",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_CITY",
+    "message": "City",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_REGION",
+    "message": "Region",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_STATE",
+    "message": "State",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_WARD",
+    "message": "Ward",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_ZONE",
+    "message": "Zone",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TESTD_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TO",
+    "message": "to",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Guidelines for filling the user sheet",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "Please go through the 'User roles' sheet to read and understand the accessibility of each role.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Please fill the user details (Name, contact number and email) in each of the sheets belonging to the role accordingly.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Please don't assign the duplicate user in both Microplan estimation approver and National microplan estimation approver roles.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Please don't assign duplicate users in both Facility boundary assigner and National facility boundary assigner roles.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_5",
+    "message": "Please don't assign duplicate users in both Population data approver and National population data approver roles.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1",
+    "message": "Downloading excel templates for creating users:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Download the excel template by clicking on the “Download Template” button.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Open the excel template that was downloaded in the previous step will have 3 sheets and the first sheet you will see is a “Read Me” sheet. The second Sheet named “Create List of Users“ that will be an empty sheet where the user needs to enter data to create users for the campaign. The third sheet will be named “List of Campaign Boundaries“ which will have all the boundaries selected in the “Boundary Details“ step with their respective boundary codes.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2",
+    "message": "Creating users for the campaign:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "The System Admin will have to create a separate entry for each user. The System Admin will have to add The Name of the User (Mandatory), Phone Number (Mandatory),Role (Mandatory) Employment Type (Mandatory), Boundary Code (Mandatory). If there is a user who is mapped to multiple roles, the System Admin will have to add all the roles that user is mapped to by separating them by commas in the cell to add Roles for that user.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Each user being created needs to be assigned to a boundary using the Boundary Code of the required boundary which can be found in the “List of Campaign Boundaries“. If there is a user who is mapped to multiple boundaries, the System Admin will have to add the boundary codes of all the boundaries that user is mapped to by separating them by commas in the cell to add Boundary Codes for that user.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Save the sheet with the updated targets for each village on the excel template .",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Target” screen and select the saved file with all targets from the system.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3",
+    "message": "Cases for common errors:",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "If the user has not added boundary codes for all user entries, the system will throw an error with line number where the boundary code is missing",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_MAINHEADER",
+    "message": "Read me instructions for user upload",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN1",
+    "message": "User role",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN2",
+    "message": "Description",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_ROLES",
+    "message": "User roles",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE1",
+    "message": "Plan estimation approver",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE10",
+    "message": "This role will have access to assign the facility to the catchment areas of assigned administrative boundary",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE11",
+    "message": "Root facility boundary assigner",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE12",
+    "message": "This role will have access to assign & finalize the facility to the catchment areas of the country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE13",
+    "message": "Microplan viewer",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE14",
+    "message": "This role will have access to view microplan estimations of the assigned administrative boundary.",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE2",
+    "message": "This role will have access to edit microplan assumptions and approve microplan estimation for all villages of the assigned administrative boundary",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE3",
+    "message": "Root plan estimation approver",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE4",
+    "message": "This role will have access to edit microplan assumptions, approve and finalize microplan estimation for all villages of the country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE5",
+    "message": "Population data approver",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE6",
+    "message": "This role will have access to validate & approve the population data for the villages of assigned administrative boundary",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE7",
+    "message": "Root population data approver",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE8",
+    "message": "This role will have access to validate, approve and finalise the population data for all the villages of the country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE9",
+    "message": "Facility boundary assigner",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_LOCALITY",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VFTw0jbRf1y",
+    "message": "Cavina1",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WEIGHT",
+    "message": "Weight",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "f5F6xAskA05",
+    "message": "Nampula",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "facilityUsage",
+    "message": "Facility Usage",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_Country",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_District",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_Locality",
+    "message": "Locality",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_Post administrative",
+    "message": "Post administrative",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_Province",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_Village",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_country",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mz",
+    "message": "Mocambique",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "w22L4En0Zgg",
+    "message": "Nihessiue",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "{{hierarchytype}}_COUNTRY",
+    "message": "Country",
+    "module": "hcm-admin-schemas",
+    "locale": "en_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/en_MZ/hcm_admin_schemas.json
+++ b/localisation/Microplanning/v0.1/en_MZ/hcm_admin_schemas.json
@@ -1,0 +1,38 @@
+[
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Guidelines for filling the user sheet",
+    "module": "hcm_admin_schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "Please go through the 'User roles' sheet to read and understand the accessibility of each role.",
+    "module": "hcm_admin_schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Please fill the user details (Name, contact number and email) in each of the sheets belonging to the role accordingly.",
+    "module": "hcm_admin_schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Please don't assign the duplicate user in both Microplan estimation approver and National microplan estimation approver roles.",
+    "module": "hcm_admin_schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Please don't assign duplicate users in both Facility boundary assigner and National facility boundary assigner roles.",
+    "module": "hcm_admin_schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_5",
+    "message": "Please don't assign duplicate users in both Population data approver and National population data approver roles.",
+    "module": "hcm_admin_schemas",
+    "locale": "en_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/en_MZ/rainmaker-campaignmanager.json
+++ b/localisation/Microplanning/v0.1/en_MZ/rainmaker-campaignmanager.json
@@ -1,0 +1,4244 @@
+[
+  {
+    "code": " CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR",
+    "message": "Please fill all the mandatory fields.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR ",
+    "message": "Please fill all the mandatory fields.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " EQUAL_TO",
+    "message": "equal to",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " GREATER_THAN",
+    "message": "greater than",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " GREATER_THAN_EQUAL_TO",
+    "message": "greater than or equal to",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Boundary Code",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Boundary Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Name of the Person (Mandatory)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " HCM_PLEASE_WAIT_LOADING_BOUNDARY",
+    "message": "Please wait",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " IN_BETWEEN",
+    "message": "in between",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " LESSER_THAN_EQUAL_TO",
+    "message": "lesser than or equal to",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": " LESS_THAN",
+    "message": "less than",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_DISTRIBUTOR",
+    "message": "Distributor",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_DISTRICT_SUPERVISOR",
+    "message": "District Supervisor",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_HEALTH_FACILITY_WORKER",
+    "message": "Health Facility Worker",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_NATIONAL_SUPERVISOR",
+    "message": "National Supervisor",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_PROVINCIAL_SUPERVISOR",
+    "message": "Provincial Supervisor",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_TEAM_SUPERVISOR",
+    "message": "Team Supervisor",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_WAREHOUSE_MANAGER",
+    "message": "Warehouse Manager",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION",
+    "message": "Action",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_CREATE_CHECKLIST",
+    "message": "Create Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_CONFIGURE_APP",
+    "message": "Configure App",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_RETRY",
+    "message": "Retry",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_UPDATE_BOUNDARY_DETAILS",
+    "message": "Update campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_UPDATE_DATES",
+    "message": "Update dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_VIEW_TIMELINE",
+    "message": "Download user credentials",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_",
+    "message": "Setup Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_0HOME",
+    "message": "Home",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_1CAMPAIGN",
+    "message": "My Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CAMPAIGN_CYCLE",
+    "message": "Cycle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CAMPAIGN_HOME",
+    "message": "Home",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CAMPAIGN_MANAGER",
+    "message": "Campaign Manager",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CREATECAMPAIGN",
+    "message": "My Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CREATE_NEW_HIERARCHY",
+    "message": "Manage boundaries",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_LOCALISATION",
+    "message": "Localisation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MDMS",
+    "message": "MDMS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MY_CAMPAIGN",
+    "message": "My Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_NATIONAL",
+    "message": "National",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_PREVIEW_CAMPAIGN",
+    "message": "Preview Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_PROVINCIAL",
+    "message": "Provincial",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_CAMPAIGN",
+    "message": "Create New Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_CAMPAIGN_FROM_MICROPLAN",
+    "message": "Setup campaign from Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_CAMPAIGN_FROM_MICROPLAN ",
+    "message": "Setup campaign from Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_UPDATE_CHECKLIST",
+    "message": "Update Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_VIEW_CHECKLIST",
+    "message": "View Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_BOUNDARY_HIERARCHY_LEVEL",
+    "message": "Add boundary hierarchy level",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_COMMENT",
+    "message": "Add Comment",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_COMMENT_(OR)",
+    "message": "Add Comment (or)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_HIERARCHY_LEVEL",
+    "message": "Add hierarchy level",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_NEW_CHECKLIST",
+    "message": "Add New Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_OPTIONS",
+    "message": "Add Options for Question",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_QUESTION",
+    "message": "Add Question",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AT_LEAST_ONE_FILE_REQUIRED_ERROR",
+    "message": "Error: At Least One File Required",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BACK",
+    "message": "Back",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BAD_REQUEST",
+    "message": "Internal error. Please try again.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BEDNET",
+    "message": "Bednet",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_DATA_FROM_GEOPODE",
+    "message": "Boundary Data from GeoPoDe.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_DATA_MANAGEMENT",
+    "message": "Boundary Data Management",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_DOWNLOADED",
+    "message": "Boundary data Downloaded",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_DOWNLOAD_MESSAGE",
+    "message": "Download the Excel template which has the selected boundary data. Once downloaded, Please populate the template with correct target data and upload the sheet.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_HIERARCHY_INFO_MSG",
+    "message": "Add your boundary hierarchy levels by clicking on rhe “Add New Boundary Hierarchy Level” button. If you want to remove a level, click on the delete icon next to level you want to delete.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_LOCALISATION_ERROR",
+    "message": "Boundary creation failed. Localisation Error.!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MANAGEMENT",
+    "message": "Boundary Management",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Validations are only for Boundary code column and Target at the Selected Boundary level column.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_SHEET_UPLOADED_INVALID_ERROR",
+    "message": "Invlid Sheet",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMAPAIGN_DELIVERY_TAB_TEXT",
+    "message": "Delivery",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ACTIONS",
+    "message": "Actions",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_MORE_ATTRIBUTE_TEXT",
+    "message": "Add More Attributes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_MORE_DELIVERY_BUTTON",
+    "message": "Add More Delivery Conditions",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_MORE_PRODUCT_BUTTON",
+    "message": "Add Resources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCTS_BUTTON_TEXT",
+    "message": "Add Resources To Be Delivered",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCTS_LABEL",
+    "message": "Resources to be delivered",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR",
+    "message": "Please fill the mandatory fields.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR ",
+    "message": "Please fill all the mandatory fields.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_START_END_DATE_TEXT",
+    "message": "Add start and end dates for cycles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_AGE",
+    "message": "Age (in months)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": " Number of bed nets per household",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Number of individuals per bed net",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_GENDER",
+    "message": "Gender (Male or Female)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_HEIGHT",
+    "message": "Height (in cms)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_LABEL",
+    "message": "Attribute",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_MEMBERCOUNT",
+    "message": "Number of bed nets per household",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_TYPE_OF_STRUCTURE",
+    "message": "Type of structure",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_WEIGHT",
+    "message": "Weight (in Kgs)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": " Number of bed nets per household",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Number of individuals per bed net",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE",
+    "message": "Beneficiary type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_PLEASE_WAIT",
+    "message": "Please wait for sometime.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CANNOT_REMOVE_PREVIOUS_BOUNDARIES",
+    "message": "Cannot remove previous boundaries.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_COMPLETED",
+    "message": "Completed",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CONDITION",
+    "message": "Condition",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_COUNT_LABEL",
+    "message": "Count",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CREATION_TAKES_SOME_TIME_PLEASE_WAIT",
+    "message": "Campaign creation takes some time. Please wait!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE",
+    "message": "Cycle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING",
+    "message": "The number of cycles and deliveries in each cycles are preloaded for SMC campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_IRS-MZ",
+    "message": "Configuration for IRS Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_LLIN-MOZ",
+    "message": "Mozambique specific configuration for LLIN Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_LLIN-MZ",
+    "message": "Configuration for LLIN campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_MR-DN",
+    "message": "Configuration for multi round campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_IRS-MZ",
+    "message": "The cycles and deliveries in each cycle are set up according to WHO guidelines for ‘Indoor Residual Spraying’ campaigns. ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_IRS_MZ",
+    "message": "The cycles and deliveries in each cycle are set up according to WHO guidelines for ‘Indoor Residual Spraying’ campaigns. ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_LLIN-MZ",
+    "message": "According to the WHO guidelines, LLINs should be distributed every three years. This recommendation is based on the average lifespan of LLINs. Based on this guideline, the number of cycles and deliveries are set to 1 each.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_MR-DN",
+    "message": "Please be informed that the number of cycles and deliveries in each cycle listed below are configured according to the guidelines provided by the WHO for 'Seasonal Malaria Chemoprevention' campaigns. If you wish to modify the number of cycles or deliveries in each cycle, you are welcome to do so by pressing on the “+” or “-” icons for cycles and deliveries according to your preferences.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_TAB_TEXT",
+    "message": "Cycle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELETE_CONDITION_LABEL",
+    "message": "Delete condition",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELETE_QUESTION",
+    "message": "Delete Question",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELETE_ROW_TEXT",
+    "message": "Delete",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY",
+    "message": "Delivery",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_DETAILS",
+    "message": "Delivery details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_RULE_LABEL",
+    "message": "Delivery condition",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_IRS",
+    "message": "Configure delivery condition for IRS Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_IRS-MZ",
+    "message": "Configure delivery condition for IRS Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_LLIN-MZ",
+    "message": "Configure delivery condition for LLIN Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_MR-DN",
+    "message": "Configure delivery condition for MR-DN Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DETAILS",
+    "message": "Campaign details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DOWNLOAD_USER_CRED",
+    "message": "Download User Credentials",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DRAFTS",
+    "message": "Drafts",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_EDIT",
+    "message": "Edit",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE",
+    "message": "Campaign end date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_BEFORE_ERROR",
+    "message": "End date of the campaign cannot be before the start date of the campaign.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_ERROR",
+    "message": "Mandatory field !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_SAME_ERROR",
+    "message": "The start and end date for a campaign cannot be same !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FAILED",
+    "message": "Failed",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_ERROR_MANDATORY",
+    "message": "Mandatory field !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_MANDATORY",
+    "message": "Mandatory field !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FROM_LABEL",
+    "message": "From",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_HOME",
+    "message": "Home",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_IN_BETWEEN_ERROR",
+    "message": "From field must be less than To field for In between operator selection.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME",
+    "message": "Campaign Name",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_ERROR",
+    "message": "This campaign name already exists! Try with another valid name.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_FIELD_ERROR",
+    "message": "Mandatory field !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_FIELD_ERROR ",
+    "message": "Mandatory field !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_LONG_ERROR",
+    "message": "Error! Long Campaign Name ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_MISSING_TYPE_ERROR",
+    "message": "Please enter a campaign name !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_TOO_LONG_ERROR",
+    "message": "Campaign name cannot be more than 250 characters.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NEW_PRODUCT_TEXT",
+    "message": "Can’t find your resource on the resource list ?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_CYCLE",
+    "message": "Number of cycles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_CYCLES",
+    "message": "Number of cycles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_DELIVERIES",
+    "message": "Number of deliveries",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_DELIVERY",
+    "message": "Number of deliveries",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ONGOING",
+    "message": "Ongoing",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_OPERATOR_LABEL",
+    "message": "Operator",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCTS_MODAL_HEADER_TEXT",
+    "message": "Configure resources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCTS_MODAL_SECONDARY_ACTION",
+    "message": "Add Resources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCTS_MODAL_SUBMIT_TEXT",
+    "message": "Confirm Resources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_LABEL",
+    "message": "Resource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_MISSING_ERROR",
+    "message": "Please fill the resources to be delivered.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_NAME_ERROR",
+    "message": "Mandatory fields should be between 2 to 100 characters only.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_VARIANT_ERROR",
+    "message": "Mandatory fields should be between 2 to 100 characters only.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_DEFAULT1",
+    "message": "Configuration for Default type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_IRS-MZ",
+    "message": "IRS Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_IRS_MZ",
+    "message": "IRS Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-MOZ",
+    "message": "Mozambique specific configuration for LLIN Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-MZ",
+    "message": "Configuration for LLIN campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-Moz",
+    "message": "Mozambique specific configuration for LLIN Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-mz",
+    "message": "Mozambique specific configuration for LLIN Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN_MOZ",
+    "message": "Mozambique Specific Configuration for LLIN Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN_MZ",
+    "message": "Configuration for LLIN campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_MR-DN",
+    "message": "Configuration for multi round campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_MR_DN",
+    "message": "Configuration for multi round campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_SMC",
+    "message": "SMC",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_RESOURCE",
+    "message": "Resource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SEARCH_NAME",
+    "message": "Campaign name",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SEARCH_TITLE",
+    "message": "My Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SEARCH_TYPE",
+    "message": "Campaign type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Boundaries are the administrative areas defined that you want to run a campaign in. Start selecting boundaries from the first level so that the boundaries present in the next level are available for selection.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARY",
+    "message": "Select the boundaries where you want to run the campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARY_BUTTON",
+    "message": "Confirm Boundary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_HIERARCHY",
+    "message": "Select hierarchy",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE",
+    "message": "Campaign start date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE_ERROR",
+    "message": "Start date should be before End date only.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_STATUS_CREATING_MESSAGE",
+    "message": "List of users for the campaign are being created. Please try again after some time.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_ATTRIBUTES_ACTION",
+    "message": "Add Attributes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_DATE_ACTION",
+    "message": "Add Date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_DELIVERY_TYPE_ACTION",
+    "message": "Add Delivery Type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_PRODUCT_ACTION",
+    "message": "Add Product",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_VALUES_ACTION",
+    "message": "Add Values",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ATTRIBUTES_MISSING_ERROR",
+    "message": "Attributes are missing in cycle {CYCLE_NO} delivery {DELIVERY_NO} for delivery condition {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_DATE_MISSING_ERROR",
+    "message": "Dates are missing in cycle {CYCLE_NO}",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_DELIVERY_TYPE_MISSING_ERROR",
+    "message": "Delivery Type missing in cycle {CYCLE_NO} delivery {DELIVERY_NO} for delivery condition {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_NA",
+    "message": "To be updated",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_PRODUCT_MISSING_ERROR",
+    "message": "Products are missing in cycle {CYCLE_NO} delivery {DELIVERY_NO} for delivery condition {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_VALUES_MISSING_ERROR",
+    "message": "Values are missing in cycle {CYCLE_NO} delivery {DELIVERY_NO} for delivery condition {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_INFO_TEXT_IRS-MZ",
+    "message": "The cycles and deliveries in each cycle are set up according to WHO guidelines for ‘Indoor Residual Spraying’ campaigns. ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_INFO_TEXT_LLIN-MZ",
+    "message": "The value of 1.8 for the parameter 'Number of beneficiary per bednet' is based on WHO guidelines. The user can choose change this value if it doesn't work for their country's use case.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_INFO_TEXT_MR-DN",
+    "message": "Please be informed that the conditions listed below are configured according to the guidelines provided by the WHO for 'Seasonal Malaria Chemoprevention' campaigns. If you wish to modify any specific conditions or resources to be delivered, you are welcome to do so by editing the delivery rules according to your preferences.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT",
+    "message": "The conditions of delivery you configure on this step will decide eligibility criteria for your beneficiaries. You can configure multiple conditions for delivery based on different eligibility criteria being followed in the campaign. Each eligibility criteria should be created as a separate delivery condition. Each condition for an individual beneficiary type can be created by using 4 attributes i.e. Age, Weight, Height and Gender.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_IRS-MZ",
+    "message": "Configuration for IRS Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-MOZ",
+    "message": "Mozambique specific configuration for LLIN Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-MZ",
+    "message": "Configuration for LLIN campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-Moz",
+    "message": "Mozambique specific configuration for LLIN Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-mz",
+    "message": "Mozambique specific configuration for LLIN Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_MR-DN",
+    "message": "Configuration for multi round campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_TEXT",
+    "message": "Configure conditions for delivery",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TO_LABEL",
+    "message": "To",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE",
+    "message": "Campaign type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_HOUSEHOLD",
+    "message": "Household",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_INDIVIDUAL",
+    "message": "Individual",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_UPCOMING",
+    "message": "Upcoming",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_UPDATE_DATES",
+    "message": "Update campaign dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_UPDATE_DATE_SUBMIT",
+    "message": "Confirm Date Change",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_USER_GENERATION_SUCCESS",
+    "message": "User credential generated successfully. Please download.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VALIDATION_INPROGRESS",
+    "message": "Please wait. Validation is in progress.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VALUE_LABEL",
+    "message": "Value",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VALUE_ZERO_ERROR",
+    "message": "Value cannot be zero for the delivery conditions.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CANCEL",
+    "message": "Cancel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CEMENT",
+    "message": "Cement",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHECKLIST_CREATED_FAILED",
+    "message": "Checklist Creation Failed",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHECKLIST_CREATED_LOCALISATION_ERROR",
+    "message": "Checklist Created Localisation Failed",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHECKLIST_NAME",
+    "message": "Checklist Name",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHECKLIST_PREVIEW",
+    "message": "Checklist Preview",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHECKLIST_ROLE",
+    "message": "Role",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHECKLIST_TOBE_CONFIGURED",
+    "message": "To be configured",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHECKLIST_TYPE",
+    "message": "Checklist Type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHECKLIST_UPDATE_FAILED",
+    "message": "Checklist Updation Failed",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHECKLIST_UPDATE_LOCALISATION_ERROR",
+    "message": "Checklist Updated Localisation Failed",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHOOSE_MEANS_TO_CREATE_BOUNDARY",
+    "message": "Choose means to create boundary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CLAY",
+    "message": "Clay",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CLEAR",
+    "message": "Clear",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CLOSE",
+    "message": "Close",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CMN_ALL_DATA_FETCH_DONE",
+    "message": "All mapping completed",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CMN_ATLEAST_ONE_HIERARCHY",
+    "message": "Please enter at least one hierarchy level",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_CREATE",
+    "message": "Create Hierarchy type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_DATA_CREAT",
+    "message": "Crete boundary data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_DATA_CREATE",
+    "message": "Create boundary data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_DATA_CREATE_PREVIEW",
+    "message": "Next",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CMN_FILLORDELETE_CREATED_HIERARCHY",
+    "message": "Please fill the all fields ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CMN_NOOPTION",
+    "message": "No options available",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CM_CREATE_REQUEST",
+    "message": "Create",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CM_DRAFT_TYPE",
+    "message": "Draft type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CM_UPDATE_REQUEST",
+    "message": "Update",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COMMON_BACK",
+    "message": "Back",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COMMON_NO_RESULTS_FOUND",
+    "message": "No results found for this search criteria.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIGURE_CHECKLIST",
+    "message": "Configure Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIRM_BOUNDARY_DATA",
+    "message": "Confirm boundary data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIRM_BOUNDARY_HIERARCHY_LEVEL",
+    "message": "Confirm boundary hierarchy level",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE",
+    "message": "Create",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE_BOUNDARY_HIERARCHY",
+    "message": "Create boundary hierarchy",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE_BOUNDARY_HIERARCHY_TYPE",
+    "message": "Manage boundaries",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE_CHECKLIST",
+    "message": "Configure",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE_MY_OWN_BOUNDARY_DATA",
+    "message": "Create my own boundary data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE_NEW_BOUNDARY_DATA",
+    "message": "Create new boundary data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE_NEW_CAMPAIGN",
+    "message": "Setup Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE_NEW_CHECKLIST",
+    "message": "Create New Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATING_CAMPAIGN_BASED_ON_MICROPLAN",
+    "message": "Creating new campaign based on the selected Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATION_DATE",
+    "message": "Creation Date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_ACTION_CONFIGURE_APP",
+    "message": "Configure app",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_ACTION_HCM_CONFIGURE_APP",
+    "message": "Configure app",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_ACTION_HCM_UPDATE_CAMPAIGN",
+    "message": "Update campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_ACTION_HCM_UPDATE_DATES",
+    "message": "Update dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_ACTION_UPDATE_DATES",
+    "message": "Change campaign dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_BOUNDARY_dATA_NEW_RESPONSE_ACTION",
+    "message": "View Boundary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_CHECKLIST_NEW_RESPONSE_ACTION",
+    "message": "Configure App",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_COMMON_ROWS_PER_PAGE",
+    "message": "Rows per page",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_COMMON_ROWS_PER_PAGE :",
+    "message": "Rows per page",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_HOME",
+    "message": "Home",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CURRENT_HIERARCHIES",
+    "message": "Current hierarchies",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CYCLE",
+    "message": "Cycle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CYCLE 1",
+    "message": "Cycle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CYCLE_NUMBER",
+    "message": "Number of cycles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Campaign_name_missing_type_error",
+    "message": "Please fill the mandatory field to move ahead.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Confirm Addition of Products",
+    "message": "Confirm Addition Of Resources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Create_New_Checklist",
+    "message": "Create New Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DATA_CREATION_IN_PROGRESS",
+    "message": "Data creation in progress",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DATA_FECTHING_FROM_SERVER",
+    "message": "Microplan data getting fetched",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DATA_SYNC_WITH_SERVER",
+    "message": "Loading...",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DELETE",
+    "message": "Delete",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_DATE_ERROR",
+    "message": "Delivery cycles start and end dates are empty. Please fill the values.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_DETAILS",
+    "message": "Delivery Details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_EMPTY_ERROR",
+    "message": "Number of cycles and deliveries are empty. Please fill the values.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_MISMATCH_LENGTH_ERROR",
+    "message": "Delivery cycles Start and End dates are empty. Please fill the values.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DELIVERY_NUMBER",
+    "message": "Number of deliveries per cycle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DELIVERY_RULES_ERROR",
+    "message": "Please fill all the values in delivery conditions along with resources to be delivered.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DIGIT_CLOSE",
+    "message": "Close",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DIGIT_CONFIRM_SELECTION",
+    "message": "Confirm selection",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DIGIT_SELECT",
+    "message": "Selected",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DIRECT",
+    "message": "Direct delivery",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISTRICT",
+    "message": "District",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD",
+    "message": "Download",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_EXCEL_TEMPLATE",
+    "message": "Download excel template",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_EXCEL_TEMPLATE_FOR_BOUNDARY",
+    "message": "Download excel template for boundary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_TEMPLATE_BOUNDARY",
+    "message": "Download Template",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_THE_FACILITY_TEMPLATE",
+    "message": "Downloading the Facility Template",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_THE_TARGET_TEMPLATE",
+    "message": "Downloading the target template",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_THE_USER_TEMPLATE",
+    "message": "Downloading the User template ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DRUG",
+    "message": "Drug",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DUPLICATE_RECORD",
+    "message": "Boundary hierarchy with the provided tenantId and hierarchy type already exists",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EDIT_BOUNDARY_DATA",
+    "message": "Edit boundary data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EMPTY_TEMPLATE_GENERTAION_NOTCOMPLETED_STILL_PROCEEDING",
+    "message": "Generation of template timed out, proceeding to fetch Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "END_DATE",
+    "message": "End date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EQUAL_TO",
+    "message": "Equal to",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_FETCHING_CAMPAIGN",
+    "message": "Error fetching campaign data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_WHILE_DOWNLOADING",
+    "message": "There is some issue found during downloading template. Please try again later.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_HRMS_INVALID_CITY",
+    "message": "Please select valid city name.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_ADD_PRODUCT_TITLE",
+    "message": "Resource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_BOUNDARY_DATA_CREATED_SUCCESS_RESPONSE",
+    "message": "Boundary Data created successfully!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_BOUNDARY_SUMMARY_HEADING",
+    "message": "Boundary Details Summary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_ADD_PRODUCT_BUTTON",
+    "message": "Confirm Addition Of Resources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_ADD_PRODUCT_LINK",
+    "message": "Add New Resource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_BOUNDARY_MODAL_BACK",
+    "message": "Yes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_BOUNDARY_MODAL_SUBMIT",
+    "message": "No",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_CHANGE_DATE_CONFIRM",
+    "message": "Are your sure you want to change the dates?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_CREATE_SUCCESS_RESPONSE",
+    "message": "Campaign data recorded successfully!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_CREATE_SUCCESS_RESPONSE_TEXT",
+    "message": "The campaign data has been captured successfully and it will take a few minutes to create campaign. Once the campaign is created you can download the user credentials and other campaign data from the 'My Campaigns' screen.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_DATE_CHANGE_SUCCESS",
+    "message": "Date changed successfully",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_DATE_CHANGE_WITH_BOUNDARY_SUCCESS",
+    "message": "Date changed successfully for the selected boundaries!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_DOWNLOAD_USER_DETAILS",
+    "message": "Download User Credentials",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_NO_DOCUMENTS_AVAILABLE",
+    "message": "Please upload valid excel sheet.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_RESPONSE_ACTION",
+    "message": "Go Home",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_SUCCESS_INFO_TEXT",
+    "message": "Campaign ID",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_TIMELINE",
+    "message": "Timeline",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_BOUNDARY_MODAL_HEADER",
+    "message": "Are you sure you want to update your campaign limits?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_BOUNDARY_MODAL_TEXT",
+    "message": "If you change the campaign limit data in this step, the file(s) uploaded for the following steps will be deleted",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_TYPE_MODAL_HEADER",
+    "message": "Are you sure you want to update the campaign type?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_TYPE_MODAL_TEXT",
+    "message": "If you change the campaign type in this step, all the data will be deleted.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_HEADER",
+    "message": "Download Excel template for target",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_TEXT",
+    "message": "Download the Excel template which has the selected boundary data. Once downloaded,please populate the template with correct target data and upload the sheet.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_HEADER",
+    "message": "Download Excel template for facility data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_TEXT",
+    "message": "Download the Excel template which has the list of permanent facilities and list of selected boundary data. Once downloaded, please populate the template with correct facility data and upload the sheet.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_FACILITY_DATA_TEXT",
+    "message": "Download the Excel template which has the list of permanent facilities and list of selected boundary data. Once downloaded, please populate the template with correct facility data and upload the sheet.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_USER_DATA_MODAL_HEADER",
+    "message": "Download Excel template for user details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_USER_DATA_MODAL_TEXT",
+    "message": "Download the Excel template which has the selected boundary data. Once downloaded, please populate the template with correct user data and upload the sheet.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_USER_DATA_MODAL_TEXT ",
+    "message": "Download the Excel template which has the selected boundary data. Once downloaded, please populate the template with correct user data and upload the sheet.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CHECKLIST_CREATE_SUCCESS_RESPONSE",
+    "message": "Checklist Created Successfully",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CHECKLIST_RESPONSE_ACTION",
+    "message": "Go To My Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CHECKLIST_UPDATE_SUCCESS_RESPONSE",
+    "message": "Checklist Updated Successfully",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_SEARCH",
+    "message": "Clear",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_PLEASE_ENTER_ALL_MANDATORY_FIELDS",
+    "message": "Please enter valid Campaign name to move to the next step.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_SEARCH",
+    "message": "Search",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_TAKE_ACTION",
+    "message": "Take Action",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_FORGOT_PASSWORD_DESC",
+    "message": "Please enter user mobile number.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE",
+    "message": "Resource created successfully!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_BOLD_TEXT",
+    "message": "\" Resource to be delivered\"",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_POST_TEXT",
+    "message": "dropdown in the resource configuration popup.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_PRE_TEXT",
+    "message": "The newly created resources will be populated in the ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_TEXT",
+    "message": "The newly created resources will be populated in in the “ Resource to be delivered” dropdown in the resource configuration popup.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_RESPONSE_ACTION",
+    "message": "Go back",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_REQUIRED",
+    "message": "Required",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_TQM_SUMMARY_HEADING",
+    "message": "Summary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "End Date",
+    "message": "End date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1",
+    "message": "Case when there is no facility data in the system:",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_1",
+    "message": "Step 1: When there is no facility data in the system, the “List of available facility” template will be empty. For every facility added the user needs to input the Facility Name (must be unique), Facility Type (Warehouse/Health Facility), Facility Status (Temporary/Permanent), Capacity (Number input)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_2",
+    "message": "Step 2: To map the facilities to a given boundary the user needs to copy the correct Boundary Code from the “Boundary Data” sheet. If there are more than one boundaries that a facility needs to be mapped to, the user can add all the boundary codes separated by commas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_3",
+    "message": "Step 3: For every facility, the user needs to add Active or Inactive for all facilities under the “Facility Usage” column. All the Facilities marked as “Active” will be used in the campaign being created the ones marked “Inactive” will not be used in the campaign being created.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_4",
+    "message": "Step 4: Once all the facilities are added the user needs to save the file on their system and upload the file by pressing “Browse in My Files” option.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2",
+    "message": "Case when there is existing facility data in the system:",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_1",
+    "message": "Step 1: When you open the downloaded facility template, please refer to the List of available Facility sheet. For existing facilities, kindly add entries in the Boundary Code column. You can find the boundary codes in the Boundary Data sheet. If a facility maps to multiple boundaries, please separate the codes with commas.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_2",
+    "message": "Step 2: In this step the user will have to add entries in the Facility Usage column with valid entries being either Active or Inactive where the user can set the usage for a facility to Active if the facility is being is used for a campaign or else can be set to Inactive. The inputs in the Facility Usage column need to be added for all entries.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_3",
+    "message": "Step 3: For adding new Facilities which are not present in the list of existing facilities, the user needs to input the Facility Name (must be unique), Facility Type (Warehouse/Health Facility), Facility Status (Temporary/Permanent), Capacity (Number input), Boundary Code(from the Boundary Data Sheet) and Facility Usage (Active/Inactive) as explained previously",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_4",
+    "message": "Step 4: Once all the facilities are added the user needs to save the file on their system and upload the file by pressing “Browse in My Files” option.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITY_DETAILS",
+    "message": "Facility details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITY_DETAILS_ERROR",
+    "message": "Please add facility details excel file.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITY_FILE_MISSING",
+    "message": "Facility sheet is missing.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FEMALE",
+    "message": "Female",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FETCHED_ALLMAPPING_DATA_FROM_MICROPLAN",
+    "message": "Fetched all maping data from Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_BOUNDARIRES_FROM_MICROPLAN",
+    "message": "Fetching campaign boundaries from Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_DATA_FROM_MICROPLAN",
+    "message": "Fetching campaign data from Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_FACILITY_FROM_MICROPLAN",
+    "message": "Fetching facility data from Microplan's facility catchment mapping",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_TARGET_FROM_MICROPLAN",
+    "message": "Fetching approved target data from Microplan's census data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_TYPE_FROM_MICROPLAN",
+    "message": "Fetching campaign type from Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_USER_FROM_MICROPLAN",
+    "message": "Fetching campaign users required for the campaign based on Microplan's formula and assumptions ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FETCHING_MICROPLAN_DATA",
+    "message": "Fetching Microplan data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FILE_UPLOADED_SUCCESSFULLY",
+    "message": "File uploaded successfully!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FILE_UPLOAD_FAILED",
+    "message": "File upload failed",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FILLING_CAMPAIGN_FACILITY_DATA_FROM_MICROPLAN",
+    "message": "Filling Facility data from Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FILLING_CAMPAIGN_TARGET_DATA_FROM_MICROPLAN",
+    "message": "Filling canpaign target data from Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FILLING_CAMPAIGN_USER_DATA_FROM_MICROPLAN",
+    "message": "Filling Campaign user data from Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FROM_DATE",
+    "message": "Start date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "From_date",
+    "message": "From date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GENERATING_ALL_THE_TEMPLATES",
+    "message": "Generating all the templates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GET_BOUNDARY_DATA_FROM_GEOPODE",
+    "message": "Get boundary data from GeoPoDe",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GLASS",
+    "message": "Glass",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GREATER_THAN",
+    "message": "Greater than",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GREATER_THAN_EQUAL_TO",
+    "message": "Greater than or equal to",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_AVAILABLE_FACILITIES",
+    "message": "List of Available Facilities",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Boundary Code",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_OLD",
+    "message": "Boundary Code Old",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Boundary Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY",
+    "message": "Capacity (Units: Bales for Bednets/ SPAQ Blister for SMC)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CODE",
+    "message": "Facility Code",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME",
+    "message": "Facility Name",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS",
+    "message": "Facility Status",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE",
+    "message": "Facility Type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE",
+    "message": "Facility Usage",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LAT",
+    "message": "Latitude",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LONG",
+    "message": "Longitude",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_AT_THE_SELECTED_BOUNDARY_LEVEL",
+    "message": "Target at the Selected Boundary level",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LAT_OPT",
+    "message": "Latitude (Optional)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LONG_OPT",
+    "message": "Longitude (Optional)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Target population",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Target Population (Age 12-59 months)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Target Population (Age 3-11 months)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC",
+    "message": "Target at village level (Mandatory and to be entered by the user)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Total population",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMPLOYMENT_TYPE",
+    "message": "Employment Type (Mandatory)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LIST",
+    "message": "Create List of Users",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LISTTTTTTTT",
+    "message": "List of Users",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Name of the Person (Mandatory)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER",
+    "message": "Phone Number (Mandatory)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBERRR",
+    "message": "Phone Number (Mandatory)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_ROLE",
+    "message": "Role (Mandatory)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BACK",
+    "message": "Back",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BENEFICIARY_TYPE",
+    "message": "Beneficiary type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_CLOSE",
+    "message": "Close",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_DETAILS",
+    "message": "Boundary Details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_DETAILS_VERTICAL",
+    "message": "Boundary details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INF0",
+    "message": "If you can’t find your boundary hierarchy please contact the L1 team at ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INF0 ",
+    "message": "If you can’t find your boundary hierarchy please contact the L1 team at ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INFO",
+    "message": "If you can’t find your boundary hierarchy please contact the L1 team at ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INFO ",
+    "message": "If you can’t find your boundary hierarchy please contact the L1 team at ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_MESSAGE",
+    "message": "Please populate the downloaded template with target data and upload the Excel sheet.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION",
+    "message": "Please add your new resources.The newly created resources will be populated in the “Resources to be delivered” dropdown in the resource configuration popup.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION_BOLD_TEXT",
+    "message": "\"Resource to be delivered\" ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION_POST_TEXT",
+    "message": "dropdown in the resource configuration popup.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION_PRE_TEXT",
+    "message": "Please add your new resources.The newly created resources will be populated in the ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_HEADER",
+    "message": "Add new resource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ALL_THE_LEVELS_ARE_MANDATORY",
+    "message": "Please fill all the mandatory fields.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CHILD_NOT_PRESENT",
+    "message": "the lower level boundaries are missing. Please select boundaries till the lowest level.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CREATION",
+    "message": "Campaign successfully created",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CREATION_PROGRESS",
+    "message": "Campaign creation progress",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATE",
+    "message": "Campaign date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES",
+    "message": "Campaign dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_CHANGE_BOUNDARY_HEADER",
+    "message": "Change campaign dates for specific boundaries",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_CHANGE_BOUNDARY_SUB_TEXT",
+    "message": "Select your boundaries to change dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_DESCRIPTION",
+    "message": "Choose your campaign 'Start date' and 'End date'. Dates once selected will reflect on the upcoming steps to configure the campaign.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_HEADER",
+    "message": "What is the start and end date of the campaign?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATE_MISSING",
+    "message": "Please enter start and end date for the campaign !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS",
+    "message": "Campaign Details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS_SUMMARY",
+    "message": "Campaign Detail Summary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DOWNLOAD_TEMPLATE",
+    "message": "Download Template",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_END_DATE_BEFORE_START_DATE",
+    "message": "Start date of the campaign cannot be after the end date of the campaign.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_END_DATE_EQUAL_START_DATE",
+    "message": "The start and end date for a campaign cannot be same.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_FOR",
+    "message": "For",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME",
+    "message": "Name of the campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME_DESCRIPTION",
+    "message": "Please name your campaign. The best practice to name your campaign is by using a combination of the type of campaign being configured, months and years of the campaign and the boundary where the campaign is being run.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME_EXAMPLE",
+    "message": "Example Name: CampaignType_Boundary_Dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME_HEADER",
+    "message": "What is the name of your campaign?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SELECT_BOUNDARY_DATA_LABEL",
+    "message": "Select boundary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SELECT_BOUNDARY_HIERARCHY_LEVEL",
+    "message": "Select a hierarchy level",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SETUP_DETAILS",
+    "message": "Campaign Details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SUCCESS_RESPONSE_ACTION",
+    "message": "Go To My Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE",
+    "message": "Campaign type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE_DESCRIPTION",
+    "message": "Campaign type will determine  the beneficiary type  for your campaign. Your  delivery rules will be pre loaded based on the campaign type you select.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE_HEADER",
+    "message": "What is the type of campaign you want to run?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_UPLOAD_CANCEL",
+    "message": "Cancel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_ACTION",
+    "message": "Action",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_CLEAR",
+    "message": "Clear",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_CREATE",
+    "message": "Configure",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_OPTION",
+    "message": "Option",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_QUESTION",
+    "message": "Question",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_ROLE",
+    "message": "Select Role",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_STATUS",
+    "message": "Status",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_ELIGIBILITY",
+    "message": "Eligibility",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_ASMT",
+    "message": "Health Facility Assessment",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_DRUG_SE_CC",
+    "message": "Health facility Referral: Drug side effect from current cycle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_DRUG_SE_PC",
+    "message": "Health facility Referral: Drug side effect from previous cycle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_FEVER",
+    "message": "Health Facility Referral: Fever",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_SICK",
+    "message": "Health Facility Referral: Sick",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_IEC",
+    "message": "IEC",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_TEAM_FORMATION",
+    "message": "Team Formation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_TRAINING_SUPERVISION",
+    "message": "Training Supervision",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_WAREHOUSE",
+    "message": "Warehouse",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_VIEW",
+    "message": "View",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CHECK_FILE_AGAIN",
+    "message": "There are some errors in the sheet. Please download the uploaded file again.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CLEAR_ALL",
+    "message": "Clear All",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CONFIGURE_APP",
+    "message": "Configure App",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CONFIGURE_APP_RESPONSE_ACTION",
+    "message": "Configure App",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CONFIRMING_RESOURCE_CREATION",
+    "message": "Resource creation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CREATE_BOUNDARY_HIERARCHY",
+    "message": "Create A New Boundary Hierarchy",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CURRENT",
+    "message": "Current",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CYCLES",
+    "message": "Cycles & Deliveries",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DATA_ALLOWED_VALUES_ARE",
+    "message": ". Allowed values are :",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DATA_AT_ROW",
+    "message": "Data at row",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_10_DIGIT",
+    "message": "Phone Number (Mandatory)' should be a 10 digit number.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_GREATER_THAN_ZERO",
+    "message": "should be greater than 0",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_LESS_THAN_MAXIMUM",
+    "message": "should be less than one hundred million",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_NUMBER",
+    "message": "should be a number",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_NOT_BE_EMPTY",
+    "message": "should not be empty",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DATA_UPLOAD",
+    "message": "Data Upload",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DATA_UPLOAD_SUMMARY",
+    "message": "Data upload summary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DATE_CHANGE_SUCCESS_RESPONSE_ACTION",
+    "message": "Back to Campaign Summary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_DETAILS",
+    "message": "Delivery Details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_DETAILS_SUMMARY",
+    "message": "Delivery details summary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_RULES",
+    "message": "Delivery Rules",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_TYPE",
+    "message": "Delivery type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_EMPTY_SHEET",
+    "message": "Sheet uploaded should not be empty.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_END_DATE",
+    "message": "End Date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ERROR",
+    "message": "Error",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ERROR_INVALID_FILE_TYPE",
+    "message": "Please upload valid excel file as per template only.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ERROR_MORE_THAN_ONE_FILE",
+    "message": "Only one valid file of excel sheet can be uploaded.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_CREATION",
+    "message": "Facility creation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_DETAILS",
+    "message": "Facility Details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_MAPPING",
+    "message": "Facilities mapped to campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_MESSAGE",
+    "message": "Please populate the downloaded template with facility data and upload the Excel sheet.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_USAGE_VALIDATION",
+    "message": "Please fill the required 'Facility Usage' column with Active/Inactive only. Atleast one 'Facility usage' must be Active.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_FETCH_FROM_PLAN_INFO",
+    "message": "Generating a campaign object from the selected Microplan, fetching the Microplan data, creating an empty campaign template, adding dates to the generated sheet, validating field data, and updating the sheets with campaign details—please wait while the data-fetching process is finalized.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_FILE_VALIDATION",
+    "message": "File validation has failed. Please upload correct data file.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_FILE_VALIDATION_ERROR",
+    "message": "Please upload valid file.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_FILE_VALIDATION_PROGRESS",
+    "message": "File validation is under progress.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_HIERARCHY_TYPE",
+    "message": "Hierarchy type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_INVALID_BOUNDARY_SHEET",
+    "message": "One of the sheets in the uploaded file seems to have an incorrect name. Please download the template again and upload it with correct data.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_INVALID_FACILITY_SHEET",
+    "message": "One of the sheets in the uploaded file seems to have an incorrect name. Please download the template again and upload it with correct data.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_INVALID_USER_SHEET",
+    "message": "One of the sheets in the uploaded file seems to have an incorrect name. Please download the template again and upload it with correct data.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_IN_COLUMN",
+    "message": "in column",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_IS_INVALID",
+    "message": "is invalid.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_IS_MAXIMUM_VALUE",
+    "message": "should be less than 100 million",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_LEVEL",
+    "message": "Level",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_LEVEL_IS_MANDATORY",
+    "message": "Please fill the mandatory fields.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MANAGE_CHECKLIST",
+    "message": "Manage checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MISSING_HEADERS",
+    "message": "One or more columns or headers are missing in the uploaded file and are not as per template. Please download the template again and upload the correct template with data.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MISSING_TARGET",
+    "message": "Target column values are missing or incorrect. Please fill the values from 1 to 100000 only.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_NEXT",
+    "message": "Next",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_PLEASE_WAIT",
+    "message": "Please wait",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_PLEASE_WAIT_LOADING_BOUNDARY",
+    "message": "Please wait for sometime.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_PLEASE_WAIT_TRY_IN_SOME_TIME",
+    "message": "Please wait.Template generation is in progress.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_PRODUCT_NAME",
+    "message": "Resource name",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_PRODUCT_TYPE",
+    "message": "Resource type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_PRODUCT_VARIANT",
+    "message": "Resource variant",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_RESOURCE_MAPPING",
+    "message": "Resources added to campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_REVIEW_DETAILS",
+    "message": "Summary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_SELECTED",
+    "message": "Selected",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_SELECT_BOUNDARY",
+    "message": "Please select boundary hierarchy to move ahead.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_SHOW_LESS",
+    "message": "View less steps",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_SHOW_LESS_ALL",
+    "message": "Show Less",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_SHOW_LESS_SELECTED",
+    "message": "Show Less Selected",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_SHOW_MORE",
+    "message": "View more steps",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_SHOW_MORE_ALL",
+    "message": "Show More",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_STAFF_CREATION",
+    "message": "App user creation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_STAFF_MAPPING",
+    "message": "App users mapped to campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_START_DATE",
+    "message": "Start Date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_SUBMIT",
+    "message": "Create Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_SUMMARY",
+    "message": "Summary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_TARGETS",
+    "message": "Target Details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_TARGET_AND_DELIVERY_RULES_CREATION",
+    "message": "Target and delivery rules creation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_TARGET_VALIDATION_ERROR",
+    "message": "Target values should be greater than 0 and less than 100000.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_TIMELINE",
+    "message": "Timeline",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPCOMING",
+    "message": "Upcoming",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPDATE",
+    "message": "Update Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPDATE_DATE",
+    "message": "Update Campaign Dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPDATE_DATE_INFO",
+    "message": "The selected start date has already passed, so you have been redirected to the Campaign Dates screen. Click 'Next' to save any changes you’ve made",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_BOUNDARY",
+    "message": "Manage boundaries",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_DATA",
+    "message": "Upload Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_FACILITY",
+    "message": "Upload Facility Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_FACILITY_DATA",
+    "message": "Upload Facility Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_TARGET",
+    "message": "Upload Target Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_TARGET_DATA",
+    "message": "Upload Target Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_USER",
+    "message": "Upload User Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_USER_DATA",
+    "message": "Upload User Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_USER_DETAILS",
+    "message": "User Details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_USER_MESSAGE",
+    "message": "Please populate the downloaded template with user data and upload the Excel sheet.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_COMPLETED",
+    "message": "File validation has been completed and is successful.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_FAILED",
+    "message": "File validation process has failed.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_IN_PROGRESS",
+    "message": "Validation in progress",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_VIEW_PROGRESS",
+    "message": "View Progress",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHY",
+    "message": "Boundary Hierarchy Type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_ADMINISTRATIVEPOST",
+    "message": "Administrative post",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHY_CREATED_SUCCESSFULLY",
+    "message": "Hierarchy created successfully",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHY_CREATION_FAILED",
+    "message": "Hierarchy creation failed ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHY_NAME",
+    "message": "Hierarchy Name",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHY_PLEASE_WAIT",
+    "message": "Please wait for a few mins as boundary hierarchy is being created",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHY_PLEASE_WAIT ",
+    "message": "Creating hierarchy",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HOUSEHOLD",
+    "message": "Household",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INDIRECT",
+    "message": "Indirect delivery",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INDIVIDUAL",
+    "message": "Individual",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INTERNAL_SERVER_ERROR",
+    "message": "Internal Server Error",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INVALID_FILE_FORMAT",
+    "message": "Invalid file format. Please upload .xlsx or .xls file",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "IN_BETWEEN",
+    "message": "In between",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "IRS-mz",
+    "message": "IRS Campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LAST_MODIFIED_TIME",
+    "message": "Last modified time",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LESSER_THAN_EQUAL_TO",
+    "message": "Lesser than or equal to",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LESS_THAN",
+    "message": "Less than",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LESS_THAN_EQUAL_TO",
+    "message": "Lesser than or equal to",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LEVEL",
+    "message": "Level",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LEVELS",
+    "message": "Levels",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LEVELS_CANNOT_BE_EMPTY",
+    "message": "Levels cannot be empty.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LINK_NESTED_CHECKLIST",
+    "message": "Link Nested Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN-Moz",
+    "message": "Mozambique specific configuration for LLIN Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN-mz",
+    "message": "Configuration for LLIN campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MALE",
+    "message": "Male",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MASTER_LANDING_SCREEN_BOUNDARY_SETTINGS",
+    "message": "Boundary Setting",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MASTER_LANDING_SCREEN_CHECKLIST",
+    "message": "Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MASTER_LANDING_SCREEN_MASTER_LANDING_SETTING",
+    "message": "Master Setting",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "METAL",
+    "message": "Metal",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "METAL/GLASS",
+    "message": "Metal / Glass",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "METAL_OR_GLASS",
+    "message": "Metal / Glass",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_COMPELTED_STEPS",
+    "message": "Completed ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_OUT_OFF",
+    "message": "step out of ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR-DN",
+    "message": "Configuration for multi round campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MSG",
+    "message": "Add your boundary hierarchy levels by clicking on rhe “Add New Boundary Hierarchy Level” button. If you want to remove a level, click on the delete icon next to level you want to delete.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MY_CAMPAIGN",
+    "message": "My Campaigns",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MY_FETCH_FROM_MICROPLAN_HEADING",
+    "message": "Fetching Data From Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MY_MICROPLANS_HEADING",
+    "message": "Approved Microplans",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MultiValueList",
+    "message": "Checkbox",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NAME_OF_CHECKLIST",
+    "message": "Name of Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NAME_OF_MICROPLAN",
+    "message": "Microplan  Name",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW13_ADMINISTRATIVEPOST",
+    "message": "POAST ADMINISTRATIVE",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW13_COUNTRY",
+    "message": "COUNTRY",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW13_DISTRICT",
+    "message": "DISTRICT",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW13_LOCALITY",
+    "message": "LOCALITY",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW13_PROVINCE",
+    "message": "PROVINCE",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW13_VILLAGE",
+    "message": "VILLAGE",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEWLY_ADDED_BOUNDARY_DATA",
+    "message": "Newly added boundary data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEXT",
+    "message": "Next",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO",
+    "message": "No",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_CAMPAIGN_DETAILS_FOUND_FOR_GIVEN_CAMPAIGN_ID",
+    "message": "Please try again clicking on 'Save And Proceed' button.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_DOCUMENTS_AVAILABLE",
+    "message": "No documents available for credentials.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Number of Individuals per bed net",
+    "message": "Number of individuals per bed net",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "OTHER",
+    "message": "Other",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "OTHERS",
+    "message": "Others",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "OTHER_TARGETS",
+    "message": "Other targets",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLEASE_WAIT_AND_RETRY_AFTER_SOME_TIME",
+    "message": "Generation is in progress. Please retry after some time",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLS_WAIT_UNTIL_PAGE_REDIRECTS",
+    "message": "Screen get auto redirect to setup campaign, Please wait data fetching is inprogress",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PREVIEW_CHECKLIST",
+    "message": "Preview Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PREVIEW_ON_MAP",
+    "message": "Preview on map",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PROJECT_TYPE_UNDEFINED_ERROR",
+    "message": "Please select a campaign type to move to the next step.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "QUESTION",
+    "message": "Question",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "REEDS",
+    "message": "Reeds",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "REQUIRED",
+    "message": "Required",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESIDUAL_SPRAY",
+    "message": "Spray",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROLE",
+    "message": "Role",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_BOUNDARY_LEVEL_ERROR",
+    "message": "Please select boundaries first.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_CHECKLIST_TYPE",
+    "message": "Select Checklist Type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_HIERARCHY_AND_BOUNDARY_ERROR",
+    "message": "Please select Hierarchy and boundary first.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SHORT_ANSWER",
+    "message": "Short Answer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SOME_ERROR_OCCURED_IN_FETCH",
+    "message": "Error while fetching",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SOME_ERROR_OCCURED_IN_FETCH_RETRYING",
+    "message": "Error while fetching, Retrying!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "START_DATE",
+    "message": "Start date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "STATUS",
+    "message": "Status",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SingleValueList",
+    "message": "Radio button",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Start Date",
+    "message": "Start date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TABLET",
+    "message": "Tablet",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TARGET_DETAILS",
+    "message": "Target details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TARGET_DETAILS_ERROR",
+    "message": "Please add target details excel file.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TARGET_FILE_MISSING",
+    "message": "Target sheet is missing",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATED_SUCCESSFULLY",
+    "message": "Template generated successfully",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATED_SUCCESSFULLY ",
+    "message": "Template generated successfully",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_FAILED",
+    "message": "Template generation Failed",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_IN_PROGRESS",
+    "message": "Template generation in progress",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_IN_PROGRESS ",
+    "message": "Creating hierarchy template",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_TIMEOUT",
+    "message": "Template generation Failed. Time Out Error!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TONIC",
+    "message": "Tonic",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TO_DATE",
+    "message": "End date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TRANSGENDER",
+    "message": "Transgender",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TYPE_OF_CHECKLIST",
+    "message": "Type of Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TYPE_OF_STRUCTURE",
+    "message": "Type of structure",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TYPE_YOUR_QUESTION_HERE",
+    "message": "Type your question here ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "To_date",
+    "message": "To date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPDATED_CAMPAIGN_WITH_UPLODAED_DATA",
+    "message": "Updated camapaign with uploaded resources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPDATE_CAMPAIGN",
+    "message": "Update campaign",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPDATE_CHECKLIST",
+    "message": "Update Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_AND_CYCLE_HEADER",
+    "message": "Update dates and cycle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE",
+    "message": "Change Campaign Dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE_INFO_TEXT",
+    "message": "1.Campaign start date and end date cannot be updated if  it is at least 24 hours in advance from the current time and start after the next day onwards.                           2.Cycle dates cannot be chosen as past dates from today's date.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE_INFO_TEXT1",
+    "message": "1.Campaign start date and end date cannot be updated if it is at least 24 hours in advance from the current time and start after the next day onwards.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE_INFO_TEXT2",
+    "message": "2.Cycle dates cannot be chosen as past dates from today's date.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_MANDATORY_FIELDS_MISSING",
+    "message": "Please fill all mandatory fields.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOAD_EXCEL",
+    "message": "Upload excel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOAD_EXCEL_FOR_ALL_BOUNDARIES",
+    "message": "Upload excel for all boundaries",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOAD_GEOJSONS",
+    "message": "Upload geojson",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_DETAILS",
+    "message": "User details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_DETAILS_ERROR",
+    "message": "Please add user details excel file.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_FILE_MISSING",
+    "message": "User sheet is missing",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_GENERATE_DETAILS",
+    "message": "User credential details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USE_TEMPLATE",
+    "message": "Use Template",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VALIDATING_THE_USER_TEMPLATE",
+    "message": "Validating all the filed sheets",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VALIDATION_ERROR",
+    "message": "Boundary already present in the system",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VIEW",
+    "message": "View",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VIEW_CHECKLIST",
+    "message": "View Checklist",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VIEW_EXISTING_BOUNDARY_DATA",
+    "message": "View existing boundary data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WAREHOUSE",
+    "message": "Warehouse",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_ADD_LEVEL",
+    "message": "Add level",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_FAIL",
+    "message": "Error in boundary creation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_FAIL: DUPLICATE_RECORD.",
+    "message": "Oops! Looks like you've already entered that. Please enter a different hierarchy name.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_FAIL: INTERNAL_SERVER_ERROR.",
+    "message": "Uploaded file is not as per the template",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_TIMEOUT",
+    "message": "Boundary data creation failed. Time Out Error!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_BULK_BROWSE_FILES",
+    "message": "Browse in my files",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_CAMPAIGN_CREATED",
+    "message": "File uploaded successfully.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_CREATE_HIERARCHY",
+    "message": "Create Hierarchy",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DELETE",
+    "message": "Delete",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DOWLOAD_TEMPLATE",
+    "message": "Download Template",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD",
+    "message": "Download",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_FACILITY",
+    "message": "Download Current Facility",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_TARGET",
+    "message": "Download Current Target",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_USER",
+    "message": "Download Current User Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_USERDATA",
+    "message": "Download Current User Data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_TEMPLATE",
+    "message": "Download Template",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DRAG_DROP",
+    "message": "Drag and drop your filled excel sheet or",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_ERROR_MORE_THAN_ONE_FILE",
+    "message": "Cannot add more than one file",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_CREATED",
+    "message": "Hierarchy and Boundary created successfully",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_DETAILS",
+    "message": "Hierarchy Details",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_NAME",
+    "message": "Hierarchy name",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_STATUS_COMPLETED",
+    "message": "Hierarchy created successfully",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_TYPE",
+    "message": "Select hierarchy type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_LOC_BULK_UPLOAD_XLS",
+    "message": "Bulk Upload Boundaries",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_OPERATION_INCOMPLETE",
+    "message": "Boundary creation failed.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_UNABLE_TO_FIND_HIERARCHY_TYPE",
+    "message": "Create new hierarchy type",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_BOUNDARY",
+    "message": "Upload boundary",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_FACILITY",
+    "message": "Upload facility data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_Facility",
+    "message": "Upload facility data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_TARGET",
+    "message": "Upload target data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_USER",
+    "message": "Upload user data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "YES",
+    "message": "Yes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "YOU_WON'T_BE_ABLE_TO_UNDO_THIS_STEP_OF_CREATING_HIERARCHY",
+    "message": "You won't be able to undo this step of creating hierarchy",
+    "module": "rainmaker-campaignmanager",
+    "locale": "en_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/en_MZ/rainmaker-common.json
+++ b/localisation/Microplanning/v0.1/en_MZ/rainmaker-common.json
@@ -1,0 +1,62 @@
+[
+  {
+    "code": "MICROPLAN_MODULE_SETUP",
+    "message": "Microplan Setup",
+    "module": "rainmaker-common",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SETUP_MICROPLAN",
+    "message": "Set Up Microplan",
+    "module": "rainmaker-common",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEARCH_MICROPLANS",
+    "message": "Open Microplans",
+    "module": "rainmaker-common",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MANAGEMENT",
+    "message": "User Management",
+    "module": "rainmaker-common",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_MODULE_PROCESS",
+    "message": "Microplan Process",
+    "module": "rainmaker-common",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MY_MICROPLANS",
+    "message": "My Microplans",
+    "module": "rainmaker-common",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_MICROPLAN",
+    "message": "Setup Microplan",
+    "module": "rainmaker-common",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_OPEN_MICROPLAN",
+    "message": "Open Microplan",
+    "module": "rainmaker-common",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_USER_MANAGEMENT",
+    "message": "User Management",
+    "module": "rainmaker-common",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MY_MICROPLAN",
+    "message": "My Microplans",
+    "module": "rainmaker-common",
+    "locale": "en_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/en_MZ/rainmaker-hcm-admin-schemas.json
+++ b/localisation/Microplanning/v0.1/en_MZ/rainmaker-hcm-admin-schemas.json
@@ -1,0 +1,2222 @@
+[
+  {
+    "code": "ADMIN10_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN10_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN10_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN10_POST ADMINISTRATIVO",
+    "message": "Post Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN10_STATE",
+    "message": "State",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN11_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN11_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN11_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN11_POST ADMINISTRATIVO",
+    "message": "Post Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN11_STATE",
+    "message": "State",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN1_PROVINCIA",
+    "message": "Provincia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN2_PROVINCIA",
+    "message": "Provincia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_POST ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN3_PROVINCIA",
+    "message": "Provincia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMINE_QA",
+    "message": "QA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMINU_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_ALDEIA",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_CONSOLE_TARGET",
+    "message": "Household Target at village level (Mandatory and to be entered by the user)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_LOCALIDADE",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_POST ADMINISTRATIVO",
+    "message": "Administrative Post",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_POSTO ADMINISTRATIVO",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_PROVINCIA",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_STATE",
+    "message": "State",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AGE",
+    "message": "Age",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AU_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.Country",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.Distrito",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.Localidade",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.Post Administrativo",
+    "message": "Post Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.PostAdministrativo",
+    "message": "Post Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Admin9.State",
+    "message": "State",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1",
+    "message": "Downloading excel templates for setting targets:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Download the excel template by clicking on the “Download Template” button.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Open the excel template that was downloaded in the previous step and the first sheet you will see is a “Read Me” sheet. The remaining sheets will be named after the name of the districts selected in the “Boundary Selection” step with each district Sheets having a list of all the villages mapped to that district.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2",
+    "message": "Setting targets once the template is downloaded:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_1",
+    "message": "Go to the district’s sheet you want to set targets for and add numbers in the “Targets” Column for each Village. ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Enter targets for each village in each district’s sheet under the “Target at the Selected Boundary level” Column. If any village does not have targets set, the sheet will have errors.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Save the sheet with the updated targets for each village on the excel template .",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Target” screen and select the saved file with all targets from the system.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3",
+    "message": "Cases for common errors:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_1",
+    "message": "If the user has not set targets for each village the system will throw an error with line number where the targets are missing.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_2",
+    "message": "If the user deletes any village from the sheet or deletes a complete district sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_3",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_MAINHEADER",
+    "message": "Read me instructions for target upload",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": "Number of bed nets per household",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Number of individuals per bed net",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_BEFORE_ERROR",
+    "message": "End date of the campaign cannot be before the start date of the campaign.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_ERROR",
+    "message": "Mandatory field !",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_MANDATORY",
+    "message": "Mandatory field !",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE_ERROR",
+    "message": "Mandatory field !",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CC_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_MZ_capacity",
+    "message": "Capacity ( Units: Bales )",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_mz_capacity",
+    "message": "Capacity ( Units: Bales )",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIN_mz_capacity",
+    "message": "Capacity ( Units: Bales )",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN__capacity",
+    "message": "Capacity",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN_capacity",
+    "message": "Capacity ( Units: SPAQ Blister )",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_boundaryCode",
+    "message": "Catchment Boundary Code ( Mandatory )",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityUsage",
+    "message": "Facility Usage",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EDIT_MICROPLANS_TEXT",
+    "message": "Edit microplan",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EQUAL_TO",
+    "message": "equal to",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_LOADING_BASE_MAP",
+    "message": "Cant find required base map, Please contact admin.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_READ_ME_MISSING",
+    "message": "Please do not change the sheet names.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_TIMELINE",
+    "message": "Timeline",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_1",
+    "message": "If there are no Facilities available for selection, the “List of Available Facilities“ tab in the template will be empty. To create new facility data, add the name of the Facility Name, Facility Type, Facility Status, Capacity. The “Facility Code” column needs to be left empty if this is a new facility. If it is a facility being reused (which is available in the template after downloading) the user only needs to do step 2.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_2",
+    "message": "To map the facility to the correct boundary, the user needs to copy the correct boundary code of the boundary from the “List of Campaign Boundaries“ sheet that the facility needs to be mapped to. If there is a facility that is mapped to multiple boundaries, the System Admin will have to add the boundary codes of all the boundaries that facility is mapped to by separating them by commas in the cell to add Boundary Codes for that Facility.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1",
+    "message": "Downloading excel templates for setting facilities:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Download the excel template by clicking on the “Download Template” button.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Open the Template that was downloaded in the previous step will have 3 sheets and the first sheet you will see is a “Read Me” sheet. The second Sheet named “List of Available Facilities“ will have a list of all the available facilities that can be used in the campaign. If there is no facility available, this sheet will be empty. The third sheet will be named “List of Campaign Boundaries“ which will have all the boundaries with their respective Boundary Codes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2",
+    "message": "Creating new facility data/using existing facility data once the template is downloaded:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "If there are no Facilities available for selection, the “List of Available Facilities“ tab in the template will be empty. To create new facility data, add the name of the Facility Name, Facility Type, Facility Status, Capacity. The “Facility Code” column needs to be left empty if this is a new facility. If it is a facility being reused (which is available in the template after downloading) the user only needs to do step 2.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "To map the facility to the correct boundary, the user needs to copy the correct boundary code of the boundary from the “List of Campaign Boundaries“ sheet that the facility needs to be mapped to. If there is a facility that is mapped to multiple boundaries, the System Admin will have to add the boundary codes of all the boundaries that facility is mapped to by separating them by commas in the cell to add Boundary Codes for that Facility.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Save the sheet with the updated targets for each village on the excel template.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Facility Data” screen and select the saved file with all targets from the system.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_5",
+    "message": "Deactivating existing Facilities for a campaign.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_6",
+    "message": "After the user has downloaded the template for facilities, if the system has existing facility data to be reused, the template will be pre populated with those list of facilities.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_7",
+    "message": "If the user then chooses not use specific facilities, they can delete those lines of data for those specific facilities that need to be removed and upload the sheet with only those facilities that are needed for the campaign with the correct boundary codes mapped to those facilities.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1",
+    "message": "Case when there is no facility data in the system:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_1",
+    "message": "Step 1: When there is no facility data in the system, the “List of available facility” template will be empty. For every facility added the user needs to input the Facility Name (must be unique), Facility Type (Warehouse/Health Facility), Facility Status (Temporary/Permanent), Capacity (Number input)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_2",
+    "message": "Step 2: To map the facilities to a given boundary the user needs to copy the correct Boundary Code from the “Boundary Data” sheet. If there are more than one boundaries that a facility needs to be mapped to, the user can add all the boundary codes separated by commas",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_3",
+    "message": "Step 3: For every facility, the user needs to add Active or Inactive for all facilities under the “Facility Usage” column. All the Facilities marked as “Active” will be used in the campaign being created the ones marked “Inactive” will not be used in the campaign being created.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_4",
+    "message": "Step 4: Once all the facilities are added the user needs to save the file on their system and upload the file by pressing “Browse in My Files” option.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2",
+    "message": "Case when there is existing facility data in the system:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_1",
+    "message": "Step 1: When you open the downloaded facility template, please refer to the List of available Facility sheet. For existing facilities, kindly add entries in the Boundary Code column. You can find the boundary codes in the Boundary Data sheet. If a facility maps to multiple boundaries, please separate the codes with commas.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_2",
+    "message": "Step 2: In this step the user will have to add entries in the Facility Usage column with valid entries being either Active or Inactive where the user can set the usage for a facility to Active if the facility is being is used for a campaign or else can be set to Inactive. The inputs in the Facility Usage column need to be added for all entries.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_3",
+    "message": "Step 3: For adding new Facilities which are not present in the list of existing facilities, the user needs to input the Facility Name (must be unique), Facility Type (Warehouse/Health Facility), Facility Status (Temporary/Permanent), Capacity (Number input), Boundary Code(from the Boundary Data Sheet) and Facility Usage (Active/Inactive) as explained previously",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_4",
+    "message": "Step 4: Once all the facilities are added the user needs to save the file on their system and upload the file by pressing “Browse in My Files” option.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3",
+    "message": "Cases for common errors:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "If the user has removed Facility codes for an existing facility in the list then system will create a duplicate facility with those column values.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "If the user deletes any columns from the “List of Available Facilities” from the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_3",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_MAINHEADER",
+    "message": "Read me instructions for facility upload",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FEMALE",
+    "message": "Female",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FROM",
+    "message": "from",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GENDER",
+    "message": "Gender",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GP_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GREATER_THAN",
+    "message": "greater than",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GREATER_THAN_EQUAL_TO",
+    "message": "greater than or equal to",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POST ADMINISTRATIVO",
+    "message": "Post Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_PROVINCIA",
+    "message": "Provincia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Boundary Code",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY",
+    "message": "Boundary Code (Mandatory)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY_ERROR",
+    "message": "is invalid. It should be taken from 'Boundary Data' sheet",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_OLD",
+    "message": "Boundary Code Old",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Boundary Data",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITIES",
+    "message": "List of Available Facilities",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY",
+    "message": "Capacity (Units: Bales for Bednets/ SPAQ Blister for SMC)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_ERROR",
+    "message": "should not be empty and should be a number from 1 to 10 million",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN",
+    "message": "Capacity (Units: Bales for Bednets/",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_LLIN-mz",
+    "message": "Capacity (Units: Bales)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_MR-DN",
+    "message": "Capacity (Units: Blisters)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CODE",
+    "message": "Facility Code",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_FIXED_POST_MICROPLAN",
+    "message": "Is fixed post (Yes/No)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LATITUDE_OPTIONAL_MICROPLAN",
+    "message": "Latitude (Optional)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LONGITUDE_OPTIONAL_MICROPLAN",
+    "message": "Longitude (Optional)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME",
+    "message": "Facility Name",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME_MICROPLAN",
+    "message": "Facility Name",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS",
+    "message": "Facility Status",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS_MICROPLAN",
+    "message": "Status da instalação",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE",
+    "message": "Facility Type",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE_MICROPLAN",
+    "message": "Tipo de instalação",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE",
+    "message": "Facility Usage",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE_MICROPLAN",
+    "message": "Facility Usage",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_RESIDING_BOUNDARY_CODE_MICROPLAN",
+    "message": "Residing boundary code",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET",
+    "message": "Household Target at village level (Mandatory and to be entered by the user)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_AT_THE_SELECTED_BOUNDARY_LEVEL",
+    "message": "Household Target at village level (Mandatory and to be entered by the user)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_1",
+    "message": "Household Target at a village level",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_2",
+    "message": "Room Target at a village level",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LAT_OPT",
+    "message": "Latitude (Optional)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LONG_OPT",
+    "message": "Longitude (Optional)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Target population",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Target Population (Age 12-59 months)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Target Population (Age 3-11 months)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC",
+    "message": "Target at village level (Mandatory and to be entered by the user)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_12_TO_59",
+    "message": "Target at village level - Age 12 to 59 Months (Mandatory and to be entered by the user)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_3_TO_11",
+    "message": "Target at village level - Age 3 to 11 Months (Mandatory and to be entered by the user)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Total population",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMAIL_MICROPLAN",
+    "message": "Email",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMPLOYMENT_TYPE",
+    "message": "Employment Type (Mandatory)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LIST",
+    "message": "Create List of Users",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Name of the Person (Mandatory)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME_MICROPLAN",
+    "message": "Name",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER",
+    "message": "Phone Number (Mandatory)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_ERROR",
+    "message": "must be provided and should be a phone number of 10 digits",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_MICROPLAN",
+    "message": "Contact number",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_ROLE",
+    "message": "Role (Mandatory)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_USAGE",
+    "message": "Active / Inactive",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_README_SHEETNAME",
+    "message": "Read Me",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_TIMELINE",
+    "message": "Timeline",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_POST ADMINISTRATIVE",
+    "message": "Administrative Post",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEALTH_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEIGHT",
+    "message": "Height",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_ADMINISTRATIVEPOST",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_POST ADMINISTRATIVE",
+    "message": "Administrative Post",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_CAN_BE_ONLY_APPLIED_ON_ADMIN_LEVEL_ZORO",
+    "message": "Filters can only be applied at level 0",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ID_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "IN_BETWEEN",
+    "message": "in between",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LESS_THAN",
+    "message": "less than",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LESS_THAN_EQUAL_TO",
+    "message": "less than or equal to",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIM_MZ_capacity",
+    "message": "Capacity",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIM_mz_capacity",
+    "message": "Capacity",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "If there are no Facilities available for selection, the “List of Available Facilities“ tab in the template will be empty. To create new facility data, add the name of the Facility Name, Facility Type, Facility Status, Capacity. The “Facility Code” column needs to be left empty if this is a new facility. If it is a facility being reused (which is available in the template after downloading) the user only needs to do step 2.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "To map the facility to the correct boundary, the user needs to copy the correct boundary code of the boundary from the “List of Campaign Boundaries“ sheet that the facility needs to be mapped to. If there is a Facility that is mapped to multiple boundaries, the System Admin will have to add the boundary codes of all the boundaries that Facility is mapped to by separating them by commas in the cell to add Boundary Codes for that Facility.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Save the sheet with the updated targets for each village on the Excel Template.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Facility Data” screen and select the saved file with all targets from the system.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Deactivating existing Facilities for a campaign.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "After the user has downloaded the template for Facilities, if the system has existing facility data to be reused, the template will be pre populated with those list of Facilities.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "If the user then chooses not use specific facilities, they can delete those lines of data for those specific facilities that need to be removed and upload the sheet with only those facilities that are needed for the campaign with the correct boundary codes mapped to those facilities.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "If the user has removed Facility codes for an existing facility in the list then system will create a duplicate Facility with those column values.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "If the user deletes any columns from the “List of Available Facilities” from the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_1",
+    "message": "Creating New Facility Data/using existing facility data once the Template is Downloaded",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_2",
+    "message": "Cases for common errors:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Read me instructions for facility upload",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER",
+    "message": "Creating new facility data/using existing facility data once the template is downloaded:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_1",
+    "message": "Setting targets once the template is downloaded:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_2",
+    "message": "Cases for common errors:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Read me instructions for population upload",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Go to the district’s sheet you want to set targets for and add numbers in the “Targets” Column for each Village.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Enter targets for each village in each district’s sheet under the “Target at the Selected Boundary level” Column. If any village does not have targets set, the sheet will have errors.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_3",
+    "message": "If the user has not set targets for each village the system will throw an error with line number where the targets are missing.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_4",
+    "message": "If the user deletes any village from the sheet or deletes a complete district sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_5",
+    "message": "If the user has not set targets for each village the system will throw an error with line number where the targets are missing.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_6",
+    "message": "If the user deletes any village from the sheet or deletes a complete district sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_7",
+    "message": "If the user deletes any of the headers in the sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_mz_capacity",
+    "message": "Capacity",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MALE",
+    "message": "Male",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MH_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ACTIVE",
+    "message": "Active",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVEPOST",
+    "message": "Administrative Post",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINSTRATIVEPOST",
+    "message": "Administrative Post",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_BOUNDARY_DATA_SHEET",
+    "message": "Boundary Data",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_COLUMN",
+    "message": "Error Details",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_COLUMN",
+    "message": "Status",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_INVALID",
+    "message": "INVALID",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_DATA_SHEET",
+    "message": "Facility Data",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_READ_ME_SHEET",
+    "message": "Read Me",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEMPLATE_README_MAIN_HEADER",
+    "message": "Read me instructions for target upload",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "If there are no Facilities available for selection, the “List of Available Facilities“ tab in the template will be empty. To create new facility data, add the name of the Facility Name, Facility Type, Facility Status, Capacity. The “Facility Code” column needs to be left empty if this is a new facility. If it is a facility being reused (which is available in the template after downloading) the user only needs to do step 2.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "To map the facility to the correct boundary, the user needs to copy the correct boundary code of the boundary from the “List of Campaign Boundaries“ sheet that the facility needs to be mapped to. If there is a Facility that is mapped to multiple boundaries, the System Admin will have to add the boundary codes of all the boundaries that Facility is mapped to by separating them by commas in the cell to add Boundary Codes for that Facility.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Save the sheet with the updated targets for each village on the Excel Template.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Facility Data” screen and select the saved file with all targets from the system.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Deactivating existing Facilities for a campaign.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "After the user has downloaded the template for Facilities, if the system has existing facility data to be reused, the template will be pre populated with those list of Facilities.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "If the user then chooses not use specific facilities, they can delete those lines of data for those specific facilities that need to be removed and upload the sheet with only those facilities that are needed for the campaign with the correct boundary codes mapped to those facilities.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "If the user has removed Facility codes for an existing facility in the list then system will create a duplicate Facility with those column values.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "If the user deletes any columns from the “List of Available Facilities” from the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_1",
+    "message": "Creating New Facility Data/using existing facility data once the Template is Downloaded",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_2",
+    "message": "Cases for common errors:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Read me instructions for facility upload",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_1",
+    "message": "Setting Targets once the Template is Downloaded:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_2",
+    "message": "Cases for common errors:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Read me instructions for population upload",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Go to the district’s sheet you want to set targets for and add numbers in the “Targets” Column for each Village.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Enter targets for each village in each district’s sheet under the “Targets” Column. If any village does not have targets set the sheet will have errors.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_3",
+    "message": "Save the sheet with the updated targets for each village on the Excel Template .",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Target” screen and select the saved file with all targets from the system.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_5",
+    "message": "If the user has not set targets for each village the system will throw an error with line number where the targets are missing.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_6",
+    "message": "If the user deletes any village from the sheet or deletes a complete district sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_7",
+    "message": "If the user deletes any of the headers in the sheet and uplaods the sheet the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_capacity",
+    "message": "Capacity",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW BOUNDARY_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NG_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_POST ADMINISTRATIVO",
+    "message": "Post Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NITISH_STATE",
+    "message": "State",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "OTHER_TARGETS",
+    "message": "Other targets",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SV_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Svefewg4YCb",
+    "message": "Murrupula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TARGET_HOUSEHOLDS",
+    "message": "Target Households",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_CITY",
+    "message": "City",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_REGION",
+    "message": "Region",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_STATE",
+    "message": "State",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_WARD",
+    "message": "Ward",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_ZONE",
+    "message": "Zone",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TESTD_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TO",
+    "message": "to",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1",
+    "message": "Downloading excel templates for creating users:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Download the excel template by clicking on the “Download Template” button.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Open the excel template that was downloaded in the previous step will have 3 sheets and the first sheet you will see is a “Read Me” sheet. The second Sheet named “Create List of Users“ that will be an empty sheet where the user needs to enter data to create users for the campaign. The third sheet will be named “List of Campaign Boundaries“ which will have all the boundaries selected in the “Boundary Details“ step with their respective boundary codes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2",
+    "message": "Creating users for the campaign:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "The System Admin will have to create a separate entry for each user. The System Admin will have to add The Name of the User (Mandatory), Phone Number (Mandatory),Role (Mandatory) Employment Type (Mandatory), Boundary Code (Mandatory). If there is a user who is mapped to multiple roles, the System Admin will have to add all the roles that user is mapped to by separating them by commas in the cell to add Roles for that user.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Each user being created needs to be assigned to a boundary using the Boundary Code of the required boundary which can be found in the “List of Campaign Boundaries“. If there is a user who is mapped to multiple boundaries, the System Admin will have to add the boundary codes of all the boundaries that user is mapped to by separating them by commas in the cell to add Boundary Codes for that user.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Save the sheet with the updated targets for each village on the excel template .",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Press the “Browse In My Files” button on the “Upload Target” screen and select the saved file with all targets from the system.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3",
+    "message": "Cases for common errors:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "If the user has not added boundary codes for all user entries, the system will throw an error with line number where the boundary code is missing",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "If the user deletes any of the headers in the sheet and uploads the sheet, the system will throw an error and the user will have to download the template again and reupload the correct sheet with the correct data.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_MAINHEADER",
+    "message": "Read me instructions for user upload",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN1",
+    "message": "User role",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN2",
+    "message": "Description",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_ROLES",
+    "message": "User roles",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE1",
+    "message": "Plan estimation approver",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE10",
+    "message": "This role will have access to assign the facility to the catchment areas of assigned administrative boundary",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE11",
+    "message": "Root facility catchment mapper",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE12",
+    "message": "This role will have access to assign & finalize the facility to the catchment areas of the country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE13",
+    "message": "Microplan viewer",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE14",
+    "message": "This role will have access to view microplan estimations of the assigned administrative boundary.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE2",
+    "message": "This role will have access to edit microplan assumptions and approve microplan estimation for all villages of the assigned administrative boundary",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE3",
+    "message": "Root plan estimation approver",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE4",
+    "message": "This role will have access to edit microplan assumptions, approve and finalize microplan estimation for all villages of the country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE5",
+    "message": "Population data approver",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE6",
+    "message": "This role will have access to validate & approve the population data for the villages of assigned administrative boundary",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE7",
+    "message": "Root population data approver",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE8",
+    "message": "This role will have access to validate, approve and finalise the population data for all the villages of the country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE9",
+    "message": "Facility catchment mapper",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_POST ADMINISTRATIVE",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UY_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VFTw0jbRf1y",
+    "message": "Cavina1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WEIGHT",
+    "message": "Weight",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "f5F6xAskA05",
+    "message": "Nampula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "facilityUsage",
+    "message": "Facility Usage",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_Country",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_District",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_Locality",
+    "message": "Locality",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_Post administrative",
+    "message": "Post administrative",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_Province",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_Village",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mobile_country",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "mz",
+    "message": "Mocambique",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "w22L4En0Zgg",
+    "message": "Nihessiue",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "{{hierarchytype}}_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "en_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/en_MZ/rainmaker-hr.json
+++ b/localisation/Microplanning/v0.1/en_MZ/rainmaker-hr.json
@@ -1,0 +1,8 @@
+[
+  {
+    "code": "HEALTH_HRMS_EMAIL_CODE",
+    "message": "<h2>Dashboard login credentials</h2><p>Hi {User's name},<br>Your profile has been created to access the dashboard. Please find your login credentials below -<br>URL: {website URL}<br>Username: {Username}<br>Password: {Password}<br>Thank you,<br>{Implementation partner}</p>",
+    "module": "rainmaker-hr",
+    "locale": "en_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/en_MZ/rainmaker-microplanning.json
+++ b/localisation/Microplanning/v0.1/en_MZ/rainmaker-microplanning.json
@@ -1,0 +1,9482 @@
+[
+  {
+    "code": " HCM_SELECTED",
+    "message": "Selected",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "1",
+    "message": "1",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "2",
+    "message": "2",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "3",
+    "message": "3",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "4",
+    "message": "4",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "5",
+    "message": "5",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACCESSIBILITY_DETAILS_UPDATE_SUCCESS",
+    "message": "Accessibility details are updated successfully",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION",
+    "message": "Action",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTIONS",
+    "message": "Action",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MY_MICROPLAN",
+    "message": "My Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_OPEN_MICROPLAN",
+    "message": "Open Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_MICROPLAN",
+    "message": "Setup Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTION_TEST_USER_MANAGEMENT",
+    "message": "User Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ACTIVA",
+    "message": "Activa",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD",
+    "message": "Add",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADDITION",
+    "message": "Addition",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_ASSUMPTION",
+    "message": "Add Assumption",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_ASSUMPTION_CAMPAIGN_VEHICLES",
+    "message": "Add Vehicle",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_FORMULA",
+    "message": "Add Formula",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_NEW_FORMULA",
+    "message": "Add Formula",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADD_ROW",
+    "message": "Add Row",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMINISTRATIVEPOST",
+    "message": "Administrative Post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMINISTRATIVE_BOUNDARY",
+    "message": "Administrative Area",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMINISTRATIVE_HIERARCHY",
+    "message": "Administrative Hierarchy",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ADMIN_PROVINCIA",
+    "message": "Province",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ALERT_HEADER_CAMPAIGN",
+    "message": "Are you sure you want to proceed?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ALERT_HEADER_MICROPLAN",
+    "message": "Are you sure you want to proceed?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ALERT_MESSAGE_CAMPAIGN",
+    "message": "The campaign details cannot be changed once saved. Please make sure you have finalised the campaign details before proceeding",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ALERT_MESSAGE_MICROPLAN",
+    "message": "The campaign details cannot be changed once saved. Please make sure you have finalised the campaign details before proceeding.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ALL_THE_TIME",
+    "message": "All the time (Atleast once a month)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ALREADY_HAVE_IT",
+    "message": "Already Have It",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ALREDY_HAVE_IT",
+    "message": "Already Have It",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AND",
+    "message": "and",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ANSWER_TO_PROVIDE_ESTIMATE",
+    "message": "Please answer the following questions with appropriate answers for us to provide an ideal estimate assumption form for you.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "APPROVE",
+    "message": "Approve",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGN",
+    "message": "Assign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGNED_SUCCESSFULLY",
+    "message": "User has been assigned to the selected role successfully",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGNED_SUCESS",
+    "message": "Villages have been assigned successfully to Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGNED_TO_ALL",
+    "message": "Assigned to all",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGNED_TO_ME",
+    "message": "Assigned to me",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGN_FACILITIES_TO_VILLAGE",
+    "message": "Assign Facilities To Village",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGN_FACILITIES_TO_VILLAGES",
+    "message": "Assign Facilities to Villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGN_FACILITY_CATCHMENT_MAPPER",
+    "message": "Assign Facility Boundary Assigner",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGN_MICROPLAN_VIEWER",
+    "message": "Assign Microplan Viewer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGN_PLAN_ESTIMATION_APPROVER",
+    "message": "Assign Microplan Estimation Approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGN_POPULATION_DATA_APPROVER",
+    "message": "Assign Population Data Approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGN_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Assign National Facility Boundary Assigner",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGN_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Assign National Microplan Estimation Approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSIGN_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Assign National Population Data Approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSUMPTION_NAME",
+    "message": "Assumption name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ASSUMPTION_VEHICLE_DESCRIPTION",
+    "message": "Please enter vehicle load assumptions value by adding vehicles.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ATLEAST_ONE_FORMULA",
+    "message": "Atleast one formula should be present to move ahead.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ATLEAST_ONE_MDMS_ASSUMPTION",
+    "message": "Atleast one of the pre-populated assumption input field in this category should be present.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ATLEAST_ONE_MDMS_FORMULA",
+    "message": "Atleast one of the pre-populated formula input field in this category should be present.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_CHILDREN_REACHED_BY_ONE_TEAM_PER_DAY",
+    "message": "Average number of children reached by one team per day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_HOUSEHOLDS_COVERED_BY_ONE_DISTRIBUTOR",
+    "message": "Average number of households covered by one distributor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_HOUSEHOLDS_COVERED_BY_ONE_SPRAY_TECHNICIAN",
+    "message": "Average number of households covered by spray technician",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_HOUSEHOLD_COVERED_BY_ONE_DISTRIBUTORS",
+    "message": "Average number of households covered by one distributor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "Average people in a household",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "AVERAGE_PEOPLE_PER_HH",
+    "message": "Average people per household",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BACK",
+    "message": "Back",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BACK_TO_HOME",
+    "message": "Go Back To Home",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BAD_REQUEST",
+    "message": "There was some error. Please try again.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOLERO",
+    "message": "Bolero",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MP_README_HEADER_1_DESC_1",
+    "message": "The mandatory fields such as total population and target population data must be a whole number (For example, population can be 1234 and not 123.5).",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_MP_README_HEADER_1_DESC_2",
+    "message": "The Latitude & Longitude fields should have data in Degree Decimal and Degree Minute Seconds (Value should be 12.3455 & not 12° 20' 43.7994').",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BOUNDARY_SELECTION",
+    "message": "Select the campaign boundary for microplaning",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BUFFER",
+    "message": "Buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BULK_UPLOAD_USERS",
+    "message": "Bulk Upload Users",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BUTTON",
+    "message": "button",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BUTTON_BACK",
+    "message": "Back",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BUTTON_DOWNLOAD",
+    "message": "Download",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "BUTTON_FILTER_BY_BOUNDARY",
+    "message": "Filter By Boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGNS_ASSIGNED",
+    "message": "Campaigned assigned",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE",
+    "message": "Beneficiary type",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPEHOUSEHOLD",
+    "message": "Household",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPEINDIVIDUAL",
+    "message": "Individual",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE_HOUSEHOLD",
+    "message": "Household",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE_INDIVIDUAL",
+    "message": "Individual",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY",
+    "message": "Campaign Boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_ADMIN_MO",
+    "message": "Admin",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_CAMP",
+    "message": "Campaign boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_MZ",
+    "message": "Mozambique",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_COMMODITIES",
+    "message": "Commodities assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DATE",
+    "message": "Campaign date",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DETAILS",
+    "message": "Campaign details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DISEASE",
+    "message": "Campaign Disease",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE",
+    "message": "Campaign end date",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME",
+    "message": "Campaign name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Boundaries are the administrative areas defined that you want to run a campaign in. Start selecting boundaries from the first level so that the boundaries present in the next level are available for selection.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARY",
+    "message": "Select the boundaries where you want to run the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SETUP_DETAILS",
+    "message": "The name you have entered, has already been used. Please try a different name.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE",
+    "message": "Campaign start date",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE",
+    "message": "Campaign Type",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE-SMC",
+    "message": "SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_IRS_MZ",
+    "message": "IRS Campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN-MZ",
+    "message": "LLIN-MZ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN-mz",
+    "message": "LLIN-MZ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN_DEFAULT_TESTING",
+    "message": "LLIN Default testing Campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN_MOZ",
+    "message": "LLIN-Moz",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN_MZ",
+    "message": "Bednet Campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_MR-DN",
+    "message": "MR-DN",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_MR_DN",
+    "message": "SMC Campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_SMC",
+    "message": "SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_XVZ",
+    "message": "XVZ Campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VEHICLES",
+    "message": "Vehicle assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CANCEL",
+    "message": "Cancel",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CANCLE",
+    "message": "Cancle",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAPACITY_OF_VEHICLE_1_BALES",
+    "message": "Capacity of vehicle 1 (bales)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CAPACITY_OF_VEHICLE_2_BALES",
+    "message": "Capacity of vehicle 2 (bales)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CATEGORY_",
+    "message": "Catergory-",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CATEGORY_1",
+    "message": "Category 1",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CATEGORY_2",
+    "message": "Category 2",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TARGET_POPULATION",
+    "message": "Confirmed Target Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "Confirmed Target Population(Age 12 to 59)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "Confirmed Target Population(Age 3 to 11)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TOTAL_POPULATION",
+    "message": "Confirmed Total Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_DATA_APPROVAL_IN_PROGRESS",
+    "message": "Validation in progress",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_DATA_APPROVED",
+    "message": "Validation in progress",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TARGET_POPULATION",
+    "message": "Uploaded Target Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "Uploaded Target Population(Age 12 to 59)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "Uploaded Target Population(Age 3 to 11)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TOTAL_POPULATION",
+    "message": "Uploaded Total Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CENSUS_VALIDATED_LABEL",
+    "message": "Finalized Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHOOSE_ASSUMPTION",
+    "message": "Choose assumption",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHOOSE_VEHICLE",
+    "message": "Choose vehicle",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CHOROPLETH_INDEX_COVERAGE",
+    "message": "Coverage",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CLEAR",
+    "message": "Clear",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CLEAR_ALL",
+    "message": "Clear All",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CLEAR_ALL_CONFIRMATION_MSG",
+    "message": "Are you sure you want to clear all selections?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CLEAR_ALL_FILTERS",
+    "message": "Clear All Filters",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CLEAR_FILTER",
+    "message": "Clear Filter",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CLOSE",
+    "message": "Close",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CMAPAIGN_DISEASE",
+    "message": "Campaign disease",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COLUMNS",
+    "message": "Columns",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COLUMNS_IN_TEMPLATE",
+    "message": "Column in template",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COLUMNS_IN_USER_UPLOAD",
+    "message": "Column in your uploaded file",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COMMENT_PREFIX",
+    "message": "Comment",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COMMON_NO_RESULTS_FOUND",
+    "message": "No Results found",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COMMON_SELECTED",
+    "message": "Selected",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COMPLETE_MAPPING",
+    "message": "Complete Mapping",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONCRETE",
+    "message": "Concrete",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Confirmed target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Confirmed Target Population(Age 12 to 59 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Confirmed Target Population(Age 3 to 11 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Confirmed total population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIRM_NEW_ASSUMPTION",
+    "message": "Are you sure you want to add an assumption?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIRM_NEW_ASSUMPTION_CAMPAIGN_VEHICLES",
+    "message": "Are you sure you want to add a vehicle?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIRM_NEW_FORMULA",
+    "message": "Are you sure you want to add a formula?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONFIRM_TO_DELETE",
+    "message": "Are you sure you want to delete?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CONTACT_NUMBER",
+    "message": "Contact Number",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CORE_COMMON_EMAIL_ID",
+    "message": "Email Address",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CORE_COMMON_STATUS",
+    "message": "Facility Status",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CORE_COMMON_STATUS_LABEL",
+    "message": "Facility status",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CORE_SOMETHING_WENT_WRONG",
+    "message": "Something went wrong!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "COVERAGE_PERCENTAGE",
+    "message": "Coverage percentage",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE_MICROPLAN",
+    "message": "Create microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE_MICROPLAN_GUIDELINES",
+    "message": "Notice / Instructions before starting",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CREATE_NEW_MICROPLAN",
+    "message": "Create New Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "CS_INBOX_SEARCH",
+    "message": "Search",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Camapaign Type",
+    "message": "Campaign Type",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DATA_MGMT",
+    "message": "Data Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DATA_VALIDATION_RULE",
+    "message": "Data validation rule",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DELETE",
+    "message": "Delete",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DESERT",
+    "message": "Desert",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DEVIDED_BY",
+    "message": "Divided by",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DIGIT_CLOSE",
+    "message": "Close",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DIGIT_CONFIRM_SELECTION",
+    "message": "Confirm Selection",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DIGIT_SELECT",
+    "message": "Selected",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DIRT",
+    "message": "Dirt",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAYING_DATA_ONLY_FOR_UPLOADED_BOUNDARIES",
+    "message": "Displaying data only for the boundaries for which data has been uploaded.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_capacity",
+    "message": "Capacity ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityCode",
+    "message": "Facility code ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityName",
+    "message": "Facility name ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityStatus",
+    "message": "Facility status ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityType",
+    "message": "Facility type ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_lat",
+    "message": "Lat ( Optional )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_long",
+    "message": "Long ( Optional )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_targetHouseholds",
+    "message": "Target households ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_targetPopulation",
+    "message": "Target population ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_targetPopulationAge3To11",
+    "message": "Target population (Age 3 months - 11 months) ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_targetpopulationAge12To59",
+    "message": "Target population (Age 12 months - 59 months) ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISPLAY_totalTargetPopulation",
+    "message": "Total target population ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISTIRBUTION_STRATEGY",
+    "message": "Distribution Strategy",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISTRIBUTION_PROCESS",
+    "message": "How is the campaign distribution process happening?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DISTRICT",
+    "message": "District",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DIVIDED_BY",
+    "message": "Divided by",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOADING",
+    "message": "Downloading",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_DESC",
+    "message": "Download the user data from the list below",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_IT",
+    "message": "Download It",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_MICROPLAN",
+    "message": "Download microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_TEMPLATE",
+    "message": "Download Template",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DOWNLOAD_USER_DATA",
+    "message": "Download User Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DRAFT",
+    "message": "Drafted Setup",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "DRAFTED_SETUP",
+    "message": "Drafted Setup",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Data Mgmt",
+    "message": "Data Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Sent for approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EDIT_AND_VALIDATE",
+    "message": "Validate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EDIT_POPULATION",
+    "message": "Edit",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EDIT_ROW",
+    "message": "Edit Row {{rowNumber}}",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EMAIL",
+    "message": "Email Address",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EMPLOYEES_NOT_FOUND",
+    "message": "Please assign the users to move ahead.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND",
+    "message": "Please assign the users to move ahead.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Please assign at least one user for the National facility boundary assigner role",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Please assign at least one user for the National microplan estimation approver role",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Please assign at least one user for the National population data approver role",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_ACTIVE_INACTIVE_COLUMN_MISSING",
+    "message": "Column {{columnName}} cannot be empty. If it is empty system will not be able to process the uploaded data.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_ADDITIONAL_PROPERTIES",
+    "message": "Uploaded data has additional fields",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_BOUNDARY_CODE_INVALID",
+    "message": "{{boundaryCode}} is invalid",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_BOUNDARY_DATA_COLUMNS_ABSENT",
+    "message": "Partial or whole boundary data is missing. Please don't remove or alter the boundary data in the template",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_BOUNDARY_SELECTION",
+    "message": "Please select boundaries till the Village level.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_CAMPAIGN_DETAILS_MANDATORY",
+    "message": "Please fill all the mandatory fields to move ahead.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_CANNOT_DELETE_LAST_HYPOTHESIS",
+    "message": "Deletion of last hypothesis is not prohibited",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_COLUMNS_DO_NOT_MATCH_TEMPLATE",
+    "message": "The columns {{columns}} do not match template requirements!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_CONTENT_NAMING_CONVENSION",
+    "message": "System will not be able to process this file. Please refer to the naming convention, rename the sub-files and then upload",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_CORRUPTED_FILE",
+    "message": "The uploaded file is corrupted. Please upload a valid file.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_DATA_EXCEEDS_LIMIT_CONSTRAINTS",
+    "message": "Please enter data in the given limits.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_DATA_INCOMPLETE",
+    "message": "Please fill all the fields before moving to the next step",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_DATA_NOT_PRESENT",
+    "message": "Incorrect or absent data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_DATA_NOT_SAVED",
+    "message": "Data not saved. Please ensure all required sections are filled, the file is uploaded, the hypothesis is defined, and the rule engine is configured.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_DATA_TYPE",
+    "message": "Please enter a number",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_DBF_MISSING",
+    "message": "Please view the data upload guidelines. The DBF subfile is missing in the uploaded shapefile. Please check and reupload.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_DOWNLOADING_TEMPLATE",
+    "message": "Error downloading template.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_DUPLICATE_MICROPLAN_NAME",
+    "message": "The name you have entered, has already been used. Please try a different name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_EXCEL_EXTENSION",
+    "message": "Please upload a .xlsx file with the right naming convention",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_FEATURECOLLECTION",
+    "message": "The top-level element should be of type “FeatureCollection”",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_FIELD_LENGTH",
+    "message": "Please view the data upload guidelines. Minimun length for any field should be 2.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_FIELD_NAME",
+    "message": "Field names should not exceed 10 characters.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_FILE_SIZE",
+    "message": "Please view the data upload guidelines. File size exceeds 2 GB limit. Please upload a smaller file.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_GEOJSON_EXTENSION",
+    "message": "Please upload a .geojson file with the right naming convention",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_HYPOTHESIS_VALUE_SHOULD_NOT_BE_ZERO",
+    "message": "The hypothesis value must be greater than 0",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_INCORRECT_FORMAT",
+    "message": "Please view the data upload guidelines. Invalid GeoJSON format. Please review and correct the format.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_INCORRECT_LOCATION_COORDINATES",
+    "message": "The Latitude & Longitude fields should have data in Degree Decimal and Degree Minute Seconds ( Value should be 12.3455 & not 12° 20' 43.7994\")",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_INVALID_GEOJSON",
+    "message": "The provided GeoJSON format is invalid. Please review and try again.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MANDATORY_FIELDS",
+    "message": "Please fill all the mandatory fields to move ahead.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MANDATORY_FIELDS_CANT_BE_EMPTY",
+    "message": "Mandatory field can’t be empty",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MANDATORY_FIELDS_FOR_SUBMIT",
+    "message": "There is no excel sheet uploaded. Please upload and then click on 'Submit' button.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MAP_OBJECT_MISSING",
+    "message": "Error loading the map",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_DETAILS_MANDATORY",
+    "message": "Please fill the mandatory 'Name of the microplan' field to move ahead.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_NAME_ALREADY_EXISTS",
+    "message": "The name you have entered, has already been used. Please try a different name.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_NAME_CRITERIA",
+    "message": "The name you have entered doesn’t match with the naming convention. Please try a different name.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_NAME_INVALID",
+    "message": "The name you have entered doesn’t match with the naming convention. Please try a different name.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MISSING_LOCATION_COORDINATES",
+    "message": "Location coordinates are missing for few / all data points. You will not be able to view this data on the map",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MISSING_PROPERTY",
+    "message": "The following required properties are missing: {{properties}}",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MULTIPLE_GEOMETRY_TYPES",
+    "message": "Multiple geometry types detected. Please ensure the file contains only one type of geometry.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MUST_BE_A_NUMBER",
+    "message": "must be a number",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MUST_BE_A_NUMBER ",
+    "message": "must be a number",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_MUST_BE_A_STRING",
+    "message": "must be string",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_NAMING_CONVENSION",
+    "message": "System will not be able to process this file. Please refer to the naming convention, rename the file and then upload",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_PARSING_FILE",
+    "message": "Error parsing the file.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_REFER_UPLOAD_PREVIEW_TO_SEE_THE_ERRORS",
+    "message": "To view detail errors, Please",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_REGISTRATION_AND_DISTRIBUTION_ARE_SAME",
+    "message": "The distribution and registration process cannot be same",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_SHAPE_FILE_EXTENSION",
+    "message": "Please upload a .zip file with the right naming convention",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_SHP_MISSING",
+    "message": "Please view the data upload guidelines. The SHP subfile is missing in the uploaded shapefile. Please check and reupload.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_SHX_MISSING",
+    "message": "Please view the data upload guidelines. The SHX subfile is missing in the uploaded shapefile. Please check and reupload.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_UNHANDLED_NEXT_OPERATION",
+    "message": "Error Unhandled Next Operation",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_UNKNOWN",
+    "message": "Unknown error contact admin",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_UNKNOWN_FILETYPE",
+    "message": "Unknown file type error. Please ensure you have selected a supported file type and try again.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_UPLOADED_DATA_IS_EMPTY",
+    "message": "Uploaded file doesn't have any data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_UPLOADED_FILE",
+    "message": "Error with uploaded file.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_UPLOADING_FILE",
+    "message": "Upload failed. Please upload again",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_UPLOAD_DATA_ENUM",
+    "message": "Value must be either of {{allowedValues}}",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_UPLOAD_DATA_LOCATION_AND_MESSAGE",
+    "message": "Data at row {{rowNumber}}: {{columnName}}: {{error}} at {{sheetName}} sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_UPLOAD_EXCEL_LOCATION_DATA_MISSING",
+    "message": "location coordinates are missing for few / all data points. You will not be able to view this data on the map",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_VALIDATION_SCHEMA_ABSENT",
+    "message": "Please view the data upload guidelines. Validation schema absent. Please contact the admin",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_VALID_MANDATORY_FILES",
+    "message": "Please upload valid excel file to move ahead.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_VALUE_NOT_ALLOWED",
+    "message": "Please enter a allowed value",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_VIEW_DETAIL_ERRORS",
+    "message": "View error and details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_WHILE_UPDATING_PLANFACILITY",
+    "message": "There was some error during facility assignment. Please try again.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERROR_WRONG_PRJ",
+    "message": "Please view the data upload guidelines. Wrong projection. Please use WGS 1984.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_ATLEAST_ONE_MANDATORY_FIELD",
+    "message": "There should be atleast one assumption in the category. It shouldn't be empty.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_ATLEAST_ONE_MANDATORY_FORMULA",
+    "message": "There should be atleast one formula to move ahead",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_DECIMAL_PLACES_LESS_THAN_TWO",
+    "message": "Please enter valid positive numerical value with 2 decimal points and upto 1000 only.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_FORMULA_ENTER_FORMULA_NAME",
+    "message": "Please enter formula name.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_FORMULA_SELECT_OPTION",
+    "message": "Please select formula",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_INCORRECT_FIELD",
+    "message": "Please enter valid positive numerical value with 2 decimal points and upto 1000 only.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_MANDATORY_FIELD",
+    "message": "Please fill all the mandatory fields to move ahead.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_MANDATORY_FIELD_SAME_OPERAND",
+    "message": "Operators cannot be 'Subtraction' when inputs are same.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_MIN_LENGTH_CAMPAIGN_NAME",
+    "message": "Min 2 characters are required",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_PLS_ENTER_VALID_ASSUMPTION_VALUE",
+    "message": "Please enter valid positive numerical value with 2 decimal points and upto 1000 only.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_SHOULD_NOT_EXCEED_999.99",
+    "message": "Please enter valid assumption value which should not exceed 1000",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ERR_SKIP_STEP",
+    "message": "Skipping the step is not allowed",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ESTIMATION_ASSUMPTIONS",
+    "message": "Microplan Assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_APPLY_FILTER",
+    "message": "Apply Filter",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_APPLY_FILTERS",
+    "message": "Apply Filter",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_ALL",
+    "message": "CLEAR ALL",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_FILTER",
+    "message": "Clear",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_SEARCH",
+    "message": "Clear",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_FILTER",
+    "message": "Search",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_NA",
+    "message": "NA",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_PLEASE_ENTER_ALL_MANDATORY_FIELDS",
+    "message": "Please fill the mandatory fields.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_COMMON_SEARCH",
+    "message": "Search",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ES_MORE",
+    "message": "More",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EVERYDAY",
+    "message": "Everyday",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EVERYDAY1",
+    "message": "Everyday",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EXAMPLE",
+    "message": "Example",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EXCEL",
+    "message": "Excel",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EXECUTION_IN_PROGRESS",
+    "message": "Validation in Progress",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "EXECUTION_TO_BE_DONE",
+    "message": "Completed Setup",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES",
+    "message": "Facilities",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_GUIDELINE_POINTS_1",
+    "message": "The name of the file should be 'Facilities.xlsx'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_GUIDELINE_POINTS_2",
+    "message": "The Latitude & Longitude fields should have data in Degree Decimal and Degree Minute Seconds ( Value should be 12.3455 & not 12° 20' 43.7994\")",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_1",
+    "message": "The GeoJSON file should meet the {{link}} specification.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_2",
+    "message": "The name of the file should be 'Facilities.geojson'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_3",
+    "message": "All the features in the file should have geometries of the same type (i.e. All should be points, or all should be multipolygons and so on).",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_4",
+    "message": "The coordinates should be in the valid range of Latitude & Longitude (Valid range for Latitude is -90 to +90 & Valid range of Longitude is -180 to +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_5",
+    "message": "All the features in the file should have properties with the same set of keys.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_6",
+    "message": "The file features should have important keys such as 'Facility code', 'Facility name', 'Facility type', 'Facility status', 'Capacity', 'Boundary code'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_7",
+    "message": "In the Properties object, the values for fields which represent a Numeric Value, should not be quoted with double quotes, (i.e. facility code of 10,000 should be represented as “facility code” : 10000 and not “facility code” : “10,0000”",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_SPECIFICATION",
+    "message": "RFC 7946 GeoJSON",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_1",
+    "message": "The user should zip up all the files in .zip format, and upload them into the system. At a minimum, the system needs .shp, .shx & .dbf files zipped.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_2",
+    "message": "The name of the zip file should be 'Facilities.zip'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_3",
+    "message": "The shapefile should be in the WGS 84 lat-long coordinate system for the system to accept.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_4",
+    "message": "The coordinates should be in the valid range of Latitude & Longitude (Valid range for Latitude is -90 to +90 & Valid range of Longitude is -180 to +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_5",
+    "message": "The shape file should have the important data points such as 'Facility code', 'Facility name', 'Facility type', 'Facility status', 'Capacity', 'Boundary code'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_6",
+    "message": "The total size of the zipped file should not exceed 2 GB.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITY",
+    "message": "Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MP_README_HEADER_1_DESC_1",
+    "message": "All the fields are mandatory and can't be empty, except the Latitude and Longitude fields.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MP_README_HEADER_1_DESC_2",
+    "message": "The Latitude & Longitude fields should have data in Degree Decimal and Degree Minute Seconds (Value should be 12.3455 & not 12° 20' 43.7994').",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHEMENT_DONE_LABEL",
+    "message": "Finalized Facility Assignment",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER",
+    "message": "Facility boundary assigner",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER_DESCRIPTION",
+    "message": "This user role will have access to assign the facility to the catchment areas of the assigned administrative boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER_POPUP_HEADING",
+    "message": "Select facility boundary assigner",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FILE_UPLOADED_SUCCESSFULLY",
+    "message": "File uploaded successfully.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FILE_UPLOADING",
+    "message": "File uploading....",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FILTER",
+    "message": "Filter",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FILTERS",
+    "message": "Filter",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FINALISED_MICROPLAN_SUCCESSFUL",
+    "message": "Microplan finalised successfully!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FINALIZED_MIDDLE_MASSAGE",
+    "message": "facilities and the",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FINSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_POPULATION_GEOJSON",
+    "message": " ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FIXED",
+    "message": "Fixed Post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FIXED_POST",
+    "message": "Fixed Post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FIXED_POST_DISTRIBUTION",
+    "message": "Distribution assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FIXED_POST_REGISTRATION",
+    "message": "Registration assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FIXED_POST_REGISTRATIONS",
+    "message": "Registration assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FOREST",
+    "message": "Forest",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_CAMPAIGN_COMMODITIES",
+    "message": "Commodities estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_CAMPAIGN_VEHICLES",
+    "message": "Vehicle estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_CONFIGURATION",
+    "message": "Formula Configuration",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_CONFIGURATION_DESCRIPTION",
+    "message": "Please configure the formula with respect to the assumptions considered for resource estimation.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_FIXED_POST_DISTRIBUTION",
+    "message": "Distribution estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_FIXED_POST_REGISTRATION",
+    "message": "Registration estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_GENERAL_ESTIMATION",
+    "message": "General estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_CAMPAIGN_COMMODITIES",
+    "message": "Commodities estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_CAMPAIGN_VEHICLES",
+    "message": "Vehicle estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_FIXED_POST_DISTRIBUTION",
+    "message": "Distribution estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_FIXED_POST_REGISTRATION",
+    "message": "Registration estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_GENERAL_ESTIMATION",
+    "message": "General estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_HOUSEHOLD_DISTRIBUTION",
+    "message": "Distribution estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_HOUSEHOLD_REGISTRATION",
+    "message": "Registration estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_HOUSEHOLD_DISTRIBUTION",
+    "message": "Distribution estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_HOUSEHOLD_REGISTRATION",
+    "message": "Registration estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "This indicates the estimation for the average people in a household.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BALES_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of bales required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BEDNETS_PER_BALE",
+    "message": "This indicates the estimation for the total number of bednets required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BEDNETS_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of bednets required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "This indicates the estimation for the total number of registration teams required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "This indicates the estimation for the total number of registration teams required if the campaign runs for a day.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "This indicates the estimation for the total number of fixed post distribution teams required if the campaign runs for a day.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "This indicates the estimation for the total number of fixed post distribution teams required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of fixed post distribution team members required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of supervisors required for the fixed post distribution teams",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "This indicates the estimation for the total number of fixed post registration teams required if the campaign runs for a day.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "This indicates the estimation for the total number of fixed post registration teams required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of fixed post registration team members required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of supervisors required for the fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of households.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "This indicates the estimation for the total number of distribution teams required if the campaign runs for a day.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "This indicates the estimation for the total number of distribution teams required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of distribution team members required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "This indicates the estimation for the total number of registration teams required if the campaign runs for a day.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "This indicates the estimation for the total number of registration teams required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "This indicates the estimation for the total number of monitors required for the registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of registration team members required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the estimation for the total number of registration team members required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MONITORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of monitors required for the distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MONITORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of monitors required for the registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "This indicates the estimation for the total number of supervisors required for the registration team monitors.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_PEOPLE_PER_BEDNET",
+    "message": "This indicates the estimation for the total number of bales required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_STICKERS_ROLLS_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of sticker rolls required per boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_FIXED_POST_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of supervisors required for the fixed post distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_FIXED_POST_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of supervisors required for the fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of supervisors required for the distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "This indicates the estimation for the total number of supervisors required for the registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "This indicates the estimation for the total number of fixed post distribution teams required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "This indicates the estimation for the total number of fixed post registration teams required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "This indicates the estimation for the total number of fixed post distribution teams required if the campaign runs for a day.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "This indicates the estimation for the total number of fixed post registration teams required if the campaign runs for a day.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the estimation for the total number of supervisors required for fixed post distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the estimation for the total number of supervisors required for fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the estimation for the total number of fixed post distribution team members required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the estimation for the total number of fixed post registration team members required for the entire campaign days.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the estimation for the total number of bags required per boundary for fixed post distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the estimation for the total number of bags required per boundary for fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "This indicates the estimation for the total number of bags required per boundary for house-to-house distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the estimation for the total number of bags required per boundary for house-to-house registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the estimation for the total number of chalks required per boundary for fixed post distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the estimation for the total number of chalks required per boundary for fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "This indicates the estimation for the total number of chalks required per boundary for house-to-house distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the estimation for the total number of chalks required per boundary for house-to-house registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the estimation for the total number of pens required per boundary for fixed post distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the estimation for the total number of pens required per boundary for fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "This indicates the estimation for the total number of pens required per boundary for house-to-house distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the estimation for the total number of pens required per boundary for house-to-house registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS",
+    "message": "This indicates the estimation for the required SPAQ for the target age group of 3-11 months.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS_WITH_BUFFER",
+    "message": "This indicates the buffer estimation for the required SPAQ for the target age group of 3-11 months.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS",
+    "message": "This indicates the estimation for the required SPAQ for the target age group of 12-59 months.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "This indicates the buffer estimation for the required SPAQ for the target age group of 12-59 months.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_REQUIRED",
+    "message": "This indicates the estimation for the total SPAQ required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_REQUIRED_WITH_BUFFER",
+    "message": "This indicates the buffer estimation for the total SPAQ required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_TARGET_POPULATION",
+    "message": "This indicates estimation for the total target population.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_NAME",
+    "message": "Formula name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FORMULA_PERMANENT_DELETE_CUSTOM",
+    "message": "Deleting a line item will delete the formula. Are you sure you want to delete the formula?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FOR_CONFIRM_TO_DELETE",
+    "message": "Are you sure you want to delete?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FOR_PERMANENT_DELETE",
+    "message": "Deleting a line item will delete the formula. However, you will be able to retrieve it by clicking on",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Formula Name",
+    "message": "Formula name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "FormulaConfigScreen",
+    "message": "Formula Configuration",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GENERAL_ESTIMATION",
+    "message": "General assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GENERAL_INFORMATION",
+    "message": "General Information",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GENERATED",
+    "message": "Generated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GENERATE_MICROPLAN",
+    "message": "Generate microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GEOJSON",
+    "message": "Geojson",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GEOSPATIAL_MAP_VIEW",
+    "message": "Geospatial Map View",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GO_BACK_HOME",
+    "message": "Go back to home",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GO_BACK_TO_HOME",
+    "message": "Go Back To Home",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GO_BACK_TO_MY_MICROPLAN",
+    "message": "Go Back To My Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GO_BACK_TO_USER_MANAGEMENT",
+    "message": "Go Back To User Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GO_TO_HCM",
+    "message": "Go to HCM campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GRAVEL",
+    "message": "Gravel",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "GUIDELINES_NEXT",
+    "message": "Create microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BACK",
+    "message": "Back",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_MESSAGE",
+    "message": "Please populate the downloaded template with population information and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CHILD_NOT_PRESENT",
+    "message": "below jurisdiction are not present.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS_DESC",
+    "message": "Please enter the required details to proceed with microplan set up.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS_HEADER",
+    "message": "Enter the campaign details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DISEASE",
+    "message": "Campaign disease",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_FOR",
+    "message": "For Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_RESOURCE_DIST_STRAT",
+    "message": "Campaign strategy",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE_OF",
+    "message": "Type of campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_CLEAR_ALL",
+    "message": "Clear All",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_DISEASE_TYPE",
+    "message": "Disease identified for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_ERROR_FILE_UPLOAD_FAILED",
+    "message": "There was some internal error. Please upload the file again.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_FILE_UPLOAD_ERROR",
+    "message": "Please upload valid file again.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLANNING_COMMENT_CHAR_LENGTH_ERROR_TOAST_MESSAGE",
+    "message": "Comment cannot be more than 140 characters.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLANNING_COMMENT_TOAST_MESSAGE",
+    "message": "List of assignees",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADD_COMMENT_LABEL",
+    "message": "Add comments",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADD_COMMENT_REQUIRED",
+    "message": "Comment is mandatory",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADMINISTRATIVEPOST_LABEL",
+    "message": "Adminstrative post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADMIN_POST_LABEL",
+    "message": "Admin Post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ASSIGNED_DATA_APPROVER_LABEL",
+    "message": "Assigned data approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_COMMENT_LOG_HEADING",
+    "message": "Comment Logs",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_COMMENT_LOG_VIEW_LINK_LABEL",
+    "message": "View Comment Logs",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONCRETE",
+    "message": "Concrete",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59_LABEL",
+    "message": "Confirmed target population(Age 12 to 59 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11_LABEL",
+    "message": "Confirmed target population(Age 3 to 11 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_LABEL",
+    "message": "Confirmed target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION_LABEL",
+    "message": "Confirmed total population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_TARGET_POPULATION",
+    "message": "Confirm target population of the village",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_TARGET_POPULATION_LABEL",
+    "message": "Confirmed target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_TOTAL_POPULATION_LABEL",
+    "message": "Confirmed total population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_VILLAGE_POPULATION",
+    "message": "Confirm total population of the village",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_COUNTRY_LABEL",
+    "message": "Country",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DATA_UPLOAD_GUIDELINES",
+    "message": "Data Upload Guidelines",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DESERT",
+    "message": "Desert",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DIRT",
+    "message": "Dirt",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DISCRICT_LABEL",
+    "message": "District",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DISTRICT_LABEL",
+    "message": "District",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_CONFIRM_POPULATION_LABEL",
+    "message": "Edit Confirmed Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_CLOSE",
+    "message": "Cancel",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_COMMENT_LABEL",
+    "message": "Approve data for villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_COMMENT_SUBMIT_LABEL",
+    "message": "Send For Approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Send For Approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_EDIT_AND_VALIDATE",
+    "message": "Submit And Validate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_LABEL",
+    "message": "Edit village population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_SEND_FOR_APPOVAL",
+    "message": "Send For Approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_TARGET_POPULATION",
+    "message": "Uploaded target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_VILLAGE",
+    "message": "Village name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_VILLAGE_POPULATION",
+    "message": "Uploaded village population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_WORKFLOW_UPDATED_SUCCESSFULLY",
+    "message": "The data for selected villages are successfully sent for approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Enter confirmed target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Enter confirmed target population (Age 12 to 59)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Enter confirmed target population(Age 3 to 11)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Enter confirmed total population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_TARGET_POPULATION",
+    "message": "Enter target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_VILLAGE_POPULATION",
+    "message": "Enter village population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ERRORS_FOUND",
+    "message": "found in uploaded file!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FACILITY_ACTION_ASSIGNMENT",
+    "message": "Assign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FACILITY_VIEW_ASSIGNMENT",
+    "message": "View Assignment",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT",
+    "message": "Proceed To Finalise Facility Assignment",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_HEADING",
+    "message": "Are you sure you want to finalise the facility assignment?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_MESSAGE",
+    "message": "Please make sure that you have thoroughly checked the facility assignment for all the facilities and the administrative areas under the campaign boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_PREFIX_MESSAGE",
+    "message": "Please make sure that you have thoroughly checked the facility assignment for all the",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_SUFFIX_MESSAGE",
+    "message": " administrative areas under the campaign boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_CANCEL_ACTION",
+    "message": "I Want To Re-Check",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_HEADING_LABEL",
+    "message": "Finalise facility to village assignment",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_SUBMIT_ACTION",
+    "message": "I Want To Finalise",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_SUBMIT_LABEL",
+    "message": "Assign Facilities To Villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN",
+    "message": "Proceed To Finalise Microplan Estimation",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_HEADING",
+    "message": "Are you sure you want to finalise the microplan estimation?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_MESSAGE",
+    "message": "Please make sure that you have thoroughly checked the microplan estimation for all the administrative areas under the campaign boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_PREFIX_MESSAGE",
+    "message": "Please make sure that you have thoroughly checked the microplan estimation for all the",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_SUFFIX_MESSAGE",
+    "message": " administrative areas under the campaign boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_CANCEL_ACTION",
+    "message": "I Want To Re-Check",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_HEADING_LABEL",
+    "message": "Finalize microplan estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_SUBMIT_LABEL",
+    "message": "I Want To Finalise",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_MESSAGE",
+    "message": "Please make sure that you have thoroughly checked the population data for all the administrative areas under the campaign boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_PREFIX_MESSAGE",
+    "message": "Please make sure that you have thoroughly checked the population data for all the ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_SUFFIX_MESSAGE",
+    "message": "administrative areas under the campaign boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_HEADING_MESSAGE",
+    "message": "Are you sure you want to finalize the population data?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_MESSAGE",
+    "message": "Are you sure you want to finalize the population data of the villages?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA",
+    "message": "Proceed To Finalise Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA_CANCEL_ACTION",
+    "message": "I Want To Re-Check",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA_LABEL",
+    "message": "Finalize population data for villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA_SUBMIT_ACTION",
+    "message": "I Want To Finalize",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FOREST",
+    "message": "Forest",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_GRAVEL",
+    "message": "Gravel",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_HCM_ADMIN_CONSOLE_TARGET_LAT_OPT_LABEL",
+    "message": "Latitude",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_HCM_ADMIN_CONSOLE_TARGET_LONG_OPT_LABEL",
+    "message": "Longitude",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_LOCALITY_LABEL",
+    "message": "Locality",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_MICROPLAN_NAME_LABEL",
+    "message": "Microplan Name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_MOUNTAIN",
+    "message": "Mountain",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_NOT_ABLE_TO_FETCH_DETAILS",
+    "message": "There is some issue. Boundary details are not getting fetched. ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_NO_ROAD",
+    "message": "No road",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ONLY_POSITIVE_NUMBERS",
+    "message": "Please enter positive numeric value",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ONLY_POSITIVE_NUMBERS_MAX_LIMIT_VALIDATION_ERROR",
+    "message": "Value should be a whole number which is more than 0 and less than 1,00,000.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLAIN",
+    "message": "Plain",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLAN_INBOX_BACK_BUTTON",
+    "message": "Go Back To Home",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLAN_INBOX_TOTAL_ASSIGNEES",
+    "message": "List of assignees",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLURAL_ERROR",
+    "message": "Errors",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLURAL_ERRORS",
+    "message": "Errors",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_POPULATION_DATA_HEADING",
+    "message": "Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_POP_INBOX_BACK_BUTTON",
+    "message": "Go To Home Page",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_POP_INBOX_TOTAL_ASSIGNEES",
+    "message": "List of assignes",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PROCESSED_FILE",
+    "message": "Uploaded sheet",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PROVINCE_LABEL",
+    "message": "Province",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SEARCH_JURISDICTION_INFO_DESCRIPTION",
+    "message": "Please select 'Administrative hierarchy' and then 'Administrative area' dropdown fields to search.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SECURITY_AND_ACCESSIBILITY_HEADING",
+    "message": "Security & Accessibility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SERVING_FACILITY",
+    "message": "Facility Name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SINGLE_ERROR",
+    "message": "Error",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_STATUS_LOG_FOR_LABEL",
+    "message": "Status logs for ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_STATUS_LOG_LABEL",
+    "message": "Status Logs",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_TARGET_CANNOT_EXCEED_TOTAL",
+    "message": "'Confirmed Target Population' should not exceed 'Confirmed Total Population' value.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_TOTAL_CANNOT_BE_LESS_THAN_TARGET",
+    "message": "'Confirmed Target Population' should not exceed 'Confirmed Total Population' value.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59_LABEL",
+    "message": "Uploaded target population(Age 12 to 59 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11_LABEL",
+    "message": "Uploaded target population(Age 3 to 11 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_LABEL",
+    "message": "Uploaded target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION_LABEL",
+    "message": "Uploaded total population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_TARGET_POPULATION_LABEL",
+    "message": "Uploaded target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_TOTAL_POPULATION_LABEL",
+    "message": "Uploaded total population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VALIDATE_AND_APPROVE_MICROPLAN_ESTIMATIONS",
+    "message": "Validate & Approve Microplan Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VIEW_VILLAGE_BACK",
+    "message": "Back",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_CLOSE_LABEL",
+    "message": "Close",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_DETAIL_EDIT_LINK",
+    "message": "Edit accessibillity details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_DETAIL_LINK",
+    "message": "Enter Accessibility Details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_DETAIL_VIEW_LINK",
+    "message": "View village accessibility details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_LABEL",
+    "message": "Village accessibility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_SAVE_LABEL",
+    "message": "Save",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_HIERARCHY_LABEL",
+    "message": "Boundary hierarchy details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_LABEL",
+    "message": "Village",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ROAD_CONDITION_LABEL",
+    "message": "Village road condition",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_CLOSE_LABEL",
+    "message": "Close",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_DETAIL_LINK",
+    "message": "Enter Security Details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_EDIT_LINK",
+    "message": "Edit security details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_LABEL",
+    "message": "Village security",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_LEVEL_LABEL",
+    "message": "Village Security Level",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_SAVE_LABEL",
+    "message": "Save",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_VIEW_LINK",
+    "message": "View village security details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_TERRAIN_LABEL",
+    "message": "Village terrain",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_TRANSPORTATION_MODE_LABEL",
+    "message": "Transportation mode",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_NEXT",
+    "message": "Next",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_SELECTED",
+    "message": "Selected",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_BOUNDARY_MICROPLAN",
+    "message": "Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_DATA",
+    "message": "Manage Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_FACILITY_MICROPLAN",
+    "message": "Facilities",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_COMPLETED",
+    "message": "The file has been validated successfully",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HCM_VIEW_ERROR",
+    "message": "View Errors",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DATA_UPLOAD_GUIDELINES",
+    "message": "Data upload guidelines",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DATA_WAS_UPDATED_WANT_TO_SAVE",
+    "message": "Section data was updated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DELETE_FILE_CONFIRMATION",
+    "message": "Are you sure you want to delete ?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Download excel Template for Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Download Geojson Template for Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_SHAPEFILES",
+    "message": "Download Shapefiles Template for Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_EXCEL",
+    "message": "Download Excel Template for Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_GEOJSON",
+    "message": "Download Geojson Template for Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_SHAPEFILES",
+    "message": "Download Shapefiles Template for Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATEEXCEL",
+    "message": "Download Excel Template for Incident Rate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_GEOJSON",
+    "message": "Download Geojson Template for Incident Rate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_SHAPEFILES",
+    "message": "Download Shapefiles Template for Incident Rate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Download Excel Template for Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Download Geojson Template for Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_SHAPEFILES",
+    "message": "Download Shapefiles Template for Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_EXCEL",
+    "message": "Download Excel Template for Warehouses",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_GEOJSON",
+    "message": "Download Geojson Template for Warehouses",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_SHAPEFILES",
+    "message": "Download Shapefiles Template for Warehouses",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Download Excel template for facilities",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Download Geojson template for facilities",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_FACILITIES_SHAPE_FILES",
+    "message": "Download Shapefile template for facilities",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Download excel template for population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Download Geojson template for population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_POPULATION_SHAPE_FILES",
+    "message": "Download Shapefile template for population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITIES_EXCEL",
+    "message": "Upload Excel for facilities data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITIES_GEOJSON",
+    "message": "Upload Geojson for facilities data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITIES_SHAPE_FILES",
+    "message": "Upload Shapefile for facilities data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITY_EXCEL",
+    "message": "Download Excel Template for Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITY_GEOJSON",
+    "message": "Download GeoJSON Template for Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITY_SHAPE_FILES",
+    "message": "Download Shapefiles Template for Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_INCIDENT_RATE_EXCEL",
+    "message": "Upload Excel for Incident Rate Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_INCIDENT_RATE_GEOJSON",
+    "message": "Upload Geojson for Incident Rate Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_INCIDENT_RATE_SHAPE_FILES",
+    "message": "Upload Shapefile for Incident Rate Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POLULATION_EXCEL",
+    "message": "Upload Excel for Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POLULATION_GEOJSON",
+    "message": "Upload Geojson for Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POLULATION_SHAPE_FILES",
+    "message": "Upload Shapefile for Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POPULATION_EXCEL",
+    "message": "Upload Excel for population data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POPULATION_GEOJSON",
+    "message": "Upload Geojson for population data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POPULATION_SHAPE_FILES",
+    "message": "Upload Shapefile for population data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_WARE_HOUSES_EXCEL",
+    "message": "Upload Excel for Ware Houses Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_WARE_HOUSES_GEOJSON",
+    "message": "Upload Geojson for Ware Houses Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_WARE_HOUSES_SHAPE_FILES",
+    "message": "Upload Shapefile for Ware Houses Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_HYPOTHESIS",
+    "message": "Propose your parameters for estimating targets and resources",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_MICROPLAN_GENERATION_CONFIRMATION",
+    "message": "Generate microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_PROCEED_WITH_NEW_HYPOTHESIS",
+    "message": "Do you want to proceed with the new hypothesis?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_REUPLOAD_FILE_CONFIRMATION",
+    "message": "Are you sure you want to re-upload the data?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_RULE_ENGINE",
+    "message": "Configure the rule",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_SPATIAL_DATA_PROPERTY_MAPPING",
+    "message": "Map your columns appropriately to match with the template",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_FACILITIES",
+    "message": "Select any one of the formats to upload facilities data.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_FACILITY",
+    "message": "Upload Facility Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_INCIDENT_RATE",
+    "message": "Select any one of the Formats to Upload Incident rate Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_POPULATION",
+    "message": "Select any one of the formats to upload population data.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_WARE_HOUSES",
+    "message": "Select any one of the Formats to Upload Ware Houses Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_HYPOTHESIS_ADD_BUTTON",
+    "message": "Click on “add more” to configure a new hypothesis. The dropdown values are configured per campaign type. If a new value is required, please ask L1/L2 support team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_HYPOTHESIS_DELETE_BUTTON",
+    "message": "Click on “delete” to delete a configured hypothesis which is not relevant to this microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_HYPOTHESIS_INTERACTABLE_SECTION",
+    "message": "This page helps you to set values for assumptions / hypothesis used in a microplan. In the next step, you can use these values to configure rules or formulae. These values will be used in the calculation engine to arrive at the number of resources. Few hypothesis are populated by default as per the campaign type.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_BASE_MAP",
+    "message": "Click here to select a layer - this will help you visualise streets, roads, water bodies based on the available data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_BOUNDARY_SELECTION",
+    "message": "Click here to select a boundary / geography for which you would want to see the details on the map",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_FILTER",
+    "message": "Click on filter to see points of interest and points of service",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_MAP_GEOMETRIES",
+    "message": "Hover over or select a boundary on the map to view the targets, resource estimates and teams / people assigned",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_VIRTUALIZATION",
+    "message": "Click on 'Visualizations' to see a choropleth map for the selected property.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_MICROPLAN_DETAILS_CAMPAIGN_DETAILS",
+    "message": "Campaign details are displayed here.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_MICROPLAN_DETAILS_EDIT_ROWS",
+    "message": "For editing a microplan, double click on any row and on the next section, configure new values of the calculated resources and then click on Save.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_MICROPLAN_DETAILS_MICROPLAN_NAME",
+    "message": "You can enter microplan name here.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_ADD_BUTTON",
+    "message": "Click on “add more” to configure a new formula. The dropdown values are configured per campaign type. If you think, a new formula is required, please ask L1/L2 support team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_DELETE_BUTTON",
+    "message": "Click on “delete” to delete a configured formula which is not relevant to this microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_INPUT",
+    "message": "Click on “input” to select an option that has been fetched based on your uploaded data and the prior rules.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_INTERACTABLE_SECTION",
+    "message": "This page helps you to set values for formulae used in a microplan. These formulae will be used in the calculation engine to arrive at the number of resources. Few formulae or rules are auto populated based on the campaign type.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HELP_UPLOAD_FILETYPE_OPTION_CONTAINER",
+    "message": "Select a format for upload. In the next step, please read the data guidelines related to each format in the next step. If you face any errors during upload, check the input file else contact L1/L2 support team. ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HIERARCHY",
+    "message": "Adminstrative Hierarchy",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HOME",
+    "message": "Home",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HOUSEHOLD_DISTRIBUTION",
+    "message": "Distribution assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HOUSEHOLD_REGISTRATION",
+    "message": "Registration assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HOUSEHOLD_REGISTRATION_INFORMATION",
+    "message": "Registration Information",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HOUSE_TO_HOUSE",
+    "message": "House-To-House",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "This indicates the average people in a household. This will be used to estimate the number of households.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of bags required per team per cycle for fixed post distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the number of bags required per team per cycle for fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of bags required per team per cycle for household distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the number of bags required per team per cycle for household registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BEDNETS_PER_BALE",
+    "message": "This indicates the size of a bale. This will be used to estimate the total number of bales.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "This indicates the total number of beneficiaries to be catered by a distribution team per day per cycle. This will be used to estimate the total distribution teams required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "This indicates the total number of beneficiaries to be catered by a distribution team per day per cycle. This will be used to estimate the total distribution teams required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "This indicates the number of beneficiaries or households to be registered by a registration team per day. This will be used to estimate the number of registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of chalks required per team per cycle for fixed post distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the number of chalks required per team per cycle for fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of chalks required per team per cycle for household distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the number of chalks required per team per cycle for household registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "This indicates the total number of days for distribution. This will be used to estimate the total number of distribution teams required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "This indicates the total number of days for household distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "This indicates the total number of days for registration. This will be used to estimate the total number of registration teams required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of fixed post distribution teams managed by a supervisor. This will be used in estimating the total number of supervisors for the fixed post distribution team.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of fixed post registration teams managed by a supervisor. This will be used to estimate the number of supervisors for fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "This indicates the number of households per sticker roll.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of distribution teams that can be managed by a supervisor. This will be used to estimate the total number of supervisors required for distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "This indicates the number of registration teams under a monitor. This will be used in estimating the total number of monitors for registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of registration teams that can be managed by a supervisor. This will be used to estimate the total number of supervisors required for registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the team size of a distribution team. This will be used to estimate the total members for the distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the team size of a fixed post registration team. This will be used to estimate the total members for the registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "This indicates the team size of a household distribution team. This will be used to estimate the total members for the distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the size of a registration team. This will be used to estimate the total number of registration team members.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "This indicates the number of monitors managed by a supervisor. This will be used in estimating the total number of supervisors for registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of pens required per team per cycle for fixed post distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the number of pens required per team per cycle for fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of pens required per team per cycle for household distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the number of pens required per team per cycle for household registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PEOPLE_PER_BEDNET",
+    "message": "This indicates the number of persons to be accommodated in a bednet. This will be used to estimate the total number of bednets.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "This indicates the number of bednets to be distributed by a distribution team per day. This will be used to estimate the number of distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "This indicates the number of beneficiaries or households to be registered per day at the fixed post distribution point. This will be used to estimate the number of fixed post registration teams required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "This indicates the number of registration days. This will be used to estimate the total number of fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of distribution teams under a monitor. This will be used in estimating the total number of monitors for distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the size of a distribution team. This will be used to estimate the total number of distribution team members.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_TOTAL_BUFFER_MULTIPLIER",
+    "message": "This indicates the buffer percentage that will be used to calculate the total resources required in excess.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_TOTAL_CYCLES_OF_SMC",
+    "message": "This indicates the total number of cycles in the SMC campaign. This will be used to estimate the total number of SPAQ required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS",
+    "message": "Hypothesis",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_INSTRUCTIONS_DELETE_ENTRY_CONFIRMATION",
+    "message": "Deleting a line item will permanently delete the estimate. You will not be able to retrieve it.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_KEY_HELP_TEXT",
+    "message": "This is an assumption of how many people make up a household.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "This indicates the average people in a household. This will be used to estimate the number of households.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of bags needed per team per cycle for fixed post distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the number of bags needed per team per cycle for fixed post registration.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of bags per team per cycle for house-to-house distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the number of bags per team per cycle for house-to-house registration.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BEDNETS_PER_BALE",
+    "message": "This indicates the size of a bale. This will be used to estimate the total number of bales.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BEDNETS_TO_BE_DISTRIBUTED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY",
+    "message": "This indicates the number of bednets to be distributed by a distribution team per day. This will be used to estimate the number of distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "This indicates the total number of beneficiaries to be catered by a distribution team per day per cycle. This will be used to estimate the total distribution teams required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "This indicates the number of beneficiaries to be catered per day at the fixed post distribution point. This will be used to estimate the number of distribution teams at the fixed post distribution point.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "This indicates the number of beneficiaries or household to be registered by a registration team per day. This will be used to estimate the number of registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "This indicates the number of beneficiaries to be registered per day at the fixed post distribution point. This will be used to estimate the number of registration teams at the fixed post distribution point.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of chalks needed per team per cycle for fixed post distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the number of chalks needed per team per cycle for fixed post registration.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of chalks needed per team per cycle for house-to-house distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the number of chalks needed per team per cycle for house-to-house registration.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "This indicates the number of distribution days. This will be used to estimate the total number of fixed post distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "This indicates the number of registration days. This will be used to estimate the total number of fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "This indicates the number of distribution days. This will be used to estimate the total number of distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "This indicates the number of registration days. This will be used to estimate the total number of registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of fixed post registration teams managed by a supervisor. This will be used in estimating the total number of supervisors for fixed post registration team.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of fixed post registration teams managed by a supervisor. This will be used in estimating the total number of supervisors for fixed post registration team.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "This indicates the number of households per sticker roll. This will be used to estimate sticker roll needs.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_MONITOR",
+    "message": "This indicates the number of distribution teams under a monitor. This will be used in estimating the total number of monitors for distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of distribution teams that can be managed by a supervisor. This will be used to estimate the total number of supervisors required for distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "This indicates the number of registration teams under a monitor. This will be used in estimating the total number of monitors for registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of registration teams that can be managed by a supervisor. This will be used to estimate the total number of supervisors required for registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicate the size of a fixed post distribution team. This will be used to estimate the total number of fixed post distribution team members.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicate the size of a fixed post registration team. This will be used to estimate the total number of fixed post registration team members.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": " This indicate the size of a distribution team. This will be used to estimate the total number of distribution team members.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicate the size of a registration team. This will be used to estimate the total number of registration team members.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_FIXED_POST_REGISTRATION",
+    "message": "This indicates the number of monitors managed by a supervisor. This will be used in estimating the total number of supervisors for fixed post registration team.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "This indicates the number of monitors managed by a supervisor. This will be used in estimating the total number of supervisors for distribution team.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "This indicates the number of monitors managed by a supervisor. This will be used in estimating the total number of supervisors for registration team.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of pens needed per team per cycle for fixed post distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicates the number of pens needed per team per cycle for fixed post registration.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "This indicates the number of pens needed per team per cycle for house-to-house distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "This indicates the number of pens needed per team per cycle for house-to-house registration.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PEOPLE_PER_BEDNET",
+    "message": "This indicates the number of person to be accommodated in a bednet. This will be used to estimate the total number of bednets.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_AT_THE_FIXES_POST_DISTRIBUTION_POINT_PER_DAY",
+    "message": "This indicates the number of bednets to be distributed at the fixed post distribution point per day. This will be used to estimate the number of distribution teams at the fixed post distribution point.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "This indicates the number of bednets to be distributed at the fixes post distribution point per day. This will be used to estimate the number of distribution teams at the fixed post distribution point.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "This indicates the number of beneficiaries or household to be registered per day at the fixed post distribution point. This will be used to estimate the number of registration teams at the fixed post distribution point.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "This indicates the number of distribution days. This will be used to estimate the total number of fixed post distribution teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "This indicates the number of registration days. This will be used to estimate the total number of fixed post registration teams.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_MANAGED_BY_A_SUPERVISOR",
+    "message": "This indicates the number of fixed post distribution teams managed by a supervisor. This will be used in estimating the total number of supervisors for fixed post distribution team.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of fixed post distribution teams managed by a supervisor. This will be used in estimating the total number of supervisors for fixed post distribution team.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "This indicates the number of fixed post registration teams managed by a supervisor. This will be used in estimating the total number of supervisors for fixed post registration team.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "This indicate the size of a fixed post distribution team. This will be used to estimate the total number of fixed post distribution team members.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "This indicate the size of a fixed post registration team. This will be used to estimate the total number of fixed post registration team members.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_TOTAL_BEDNET_WASTAGE",
+    "message": "This indicates the total wastage factor for bednets.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_TOTAL_BUFFER_MULTIPLIER",
+    "message": "This indicates the buffer percentage that will be used to calculate the total resources required in excess.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_TOTAL_CYCLES_OF_SMC",
+    "message": "This indicates the total number of cycles in the SMC campaign. This will be used to estimate the total number of SPAQ required.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_VALUE_HELP_TEXT",
+    "message": "Please set a value to calculate resources",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYP_CONFIRM_TO_DELETE",
+    "message": "Are you sure you want to delete?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYP_PERMANENT_DELETE",
+    "message": "Deleting a line item will delete the assumption. However, you will be able to retrieve it by clicking on",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "HYP_PERMANENT_DELETE_CUSTOM",
+    "message": "Deleting a line item will delete the assumption. Are you sure you want to delete the assumption?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Home",
+    "message": "Home",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_ASSIGNEE",
+    "message": "Assignee",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Confirmed Target Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Confirmed Target Population(Age 12 to 59)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "Confirmed Target Population(Age 12 to 59)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Confirmed Target Population(Age 3 to 11)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "Confirmed Target Population(Age 3 to 11)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Confirmed Total Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_EDITPOPULATION",
+    "message": "Edit Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_STATUSLOGS",
+    "message": "Status Logs",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_TOTAL_POPULATION",
+    "message": "Total Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Uploaded Target Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Uploaded Target Population(Age 12 to 59)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "Uploaded Target Population(Age 12 to 59)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Uploaded Target Population(Age 3 to 11)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "Uploaded Target Population(Age 3 to 11)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Uploaded Total Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INBOX_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INCIDENT_RATE",
+    "message": "Incident Rate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INCORRECT_FIELDS",
+    "message": "Please enter valid positive numerical value with 2 decimal points and upto 1000 only.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INFO",
+    "message": "Info",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INFORMATION_DESCRIPTION",
+    "message": "As per the standard data upload guide lines",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INFORMATION_DESCRIPTION_LINK",
+    "message": "here",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INITIATE",
+    "message": "Data submitted",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_FACILITIES",
+    "message": "Please select any one of the following formats to upload the facilities data required for your microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_FACILITY",
+    "message": "Please select any one of the following formats to upload the facility data required for your microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_INCIDENT_RATE",
+    "message": "Please select any one of the following formats to upload the incident rate data required for your microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_POPULATION",
+    "message": "Please select any one of the following formats to upload the population data required for your microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_WARE_HOUSES",
+    "message": "Please select any one of the following formats to upload the ware houses data required for your microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DELETE_FILE_CONFIRMATION",
+    "message": "Deleting the uploaded file will permanently erase it. You will not be able to retrieve it.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Download the Excel template for facilities. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Download the Geojson template for facilities. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_SHAPEFILES",
+    "message": "Download the Shapefiles template for facilities. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_EXCEL",
+    "message": "Download the Excel template for Facility. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_GEOJSON",
+    "message": "Download the Geojson template for Facility. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_SHAPEFILES",
+    "message": "Download the Shapefiles template for Facility. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATEEXCEL",
+    "message": "Download the Excel template for Incident Rate. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_GEOJSON",
+    "message": "Download the Geojson template for Incident Rate. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_SHAPEFILES",
+    "message": "Download the Shapefiles template for Incident Rate. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Download the Excel template which has the boundary hierarchy. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Download the Geojson template for population. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_SHAPEFILES",
+    "message": "Download the Shapefiles template for population. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_EXCEL",
+    "message": "Download the Excel template for Warehouses. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_GEOJSON",
+    "message": "Download the Geojson template for Warehouses. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_SHAPEFILES",
+    "message": "Download the Shapefiles template for Warehouses. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Download the Excel template which has the boundary hierarchy. Once downloaded, please populate the template with facilities data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Download the Geojson template which has the boundary hierarchy. Once downloaded, please populate the template with facilities data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_FACILITIES_SHAPE_FILES",
+    "message": "Download the Shapefile template which has the boundary hierarchy. Once downloaded, please populate the template with facilities data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Download the Excel template which has the boundary hierarchy. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Download the Geojson template which has the boundary hierarchy. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_POPULATION_SHAPE_FILES",
+    "message": "Download the Shapefile template which has the boundary hierarchy. Once downloaded, please populate the template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_FACILITIES",
+    "message": "Please fill the downloaded template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_FACILITIES_EXCEL",
+    "message": "Please fill the downloaded template with Facility data and upload the sheet",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_FACILITIES_GEOJSON",
+    "message": " ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_FACILITIES_SHAPE_FILES",
+    "message": " ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_FACILITY",
+    "message": "Please fill the downloaded template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_INCIDENT_RATE",
+    "message": "Please fill the downloaded template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_POPULATION",
+    "message": "Please fill the downloaded template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_POPULATION_EXCEL",
+    "message": "Please fill the downloaded template with population data and upload the sheet",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_POPULATION_GEOJSON",
+    "message": " ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_POPULATION_SHAPE_FILES",
+    "message": " ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_WARE_HOUSES",
+    "message": "Please fill the downloaded template with population data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_MICROPLAN_GENERATION_CONFIRMATION",
+    "message": "Are you sure that you want to execute the microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_REUPLOAD_FILE_CONFIRMATION",
+    "message": "Re-uploading the file will erase the previously uploaded file and you will not be able to retrieve it.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UNLOAD_EXCEL",
+    "message": "Drag and drop your filled Excel sheet or browse through my files.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UNLOAD_GEOJSON",
+    "message": "Drag and drop your filled GeoJSON file or browse through my files.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UNLOAD_SHAPE_FILES",
+    "message": "Drag and drop your filled Shapefiles or browse through my files.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_BROWSE_FILES",
+    "message": "Browse in my files",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_EXCEL",
+    "message": "Drag and drop your filled excel sheet or",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_FACILITIES",
+    "message": "Drag and drop your filled geojson file or",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_GEOJSON",
+    "message": "Drag and drop your filled geojson file or",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_SHAPE_FILES",
+    "message": "Drag and drop your filled geojson file or",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_DATA_WAS_UPDATED_WANT_TO_SAVE",
+    "message": "Want to save it?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_HYPOTHESIS",
+    "message": "The suggested keys are pre-populated. Enter values for the keys to formulate your hypothesis. This will be used for estimating of resources. ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_1",
+    "message": "You are on the BI Clients tab in the characteristic editing screen in the BW modeling tools. You have chosen Shapes or Shapes and Point Data as the geographical type.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_2",
+    "message": "Choose Upload Shapefiles under Actions. Choose Go. The BW/4 backend opens.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_3",
+    "message": "Select your shapefiles. You need the following three shapefiles: .dbf, .shp, .shx. The shapefiles must be in the Spatial Reference ID 4326 and should all have the same name before the ending.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_4",
+    "message": "Choose Update Geotable under Actions. Choose Go. You can choose either Delta Update or Full Update.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_5",
+    "message": "The uploaded shapes are transformed and stored in SRID (Spatial Reference ID) 3857. It is therefore not possible to use shapes in SAC if they exceed the limitations of this spatial reference system. This means that they must not have degrees of latitude exceeding 85.06° and -85.06°.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PREREQUISITES_1",
+    "message": "You have added a column or field with the characteristic name to the shapefiles that you want to load shapes for. If using compounding characteristics, you have added multiple columns. More Information:",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PREREQUISITES_2",
+    "message": "To update the geotable with shapes that are uploaded to the Business Document Server, you need SAP HANA 2.0 Rev 45.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PREREQUISITES_LINK",
+    "message": "Preparing shapefiles",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PROCEED_WITH_NEW_HYPOTHESIS",
+    "message": "Your hypothesis has been changed from the previously proposed one. You will not be able to edit or change your hypothesis once the microplan is generated.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_RULE_ENGINE",
+    "message": "Configure your formula for the microplan by defining your input, operators, value and keys.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INSTRUCTION_SPATIAL_DATA_PROPERTY_MAPPING",
+    "message": "The Geojson or shape file that you have uploaded has different tag names as expected. Please perform a small mapping exercise so that we know which columns to map it against.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INTERNAL_SERVER_ERROR",
+    "message": "Internal server error",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INVALID_MOBILE_NUMBER",
+    "message": "Please enter valid mobile number.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "INVALID_MOBILE_NUMBER_LENGTH",
+    "message": "Please enter valid contact number to search.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "KEY",
+    "message": "Keys",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LAYERS",
+    "message": "Layers",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_GUIDELINE_POINTS_1",
+    "message": "The name of the file should be 'Population.xlsx'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_GUIDELINE_POINTS_2",
+    "message": "The Latitude & Longitude fields should have data in Degree Decimal and Degree Minute Seconds ( Value should be 12.3455 & not 12° 20' 43.7994\")",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_1",
+    "message": "The GeoJSON file should meet the {{link}} specification.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_2",
+    "message": "The name of the file should be 'Population.geojson'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_3",
+    "message": "All the features in the file should have geometries of the same type (i.e. All should be points, or all should be multipolygons and so on).",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_4",
+    "message": "The coordinates should be in the valid range of Latitude & Longitude (Valid range for Latitude is -90 to +90 & Valid range of Longitude is -180 to +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_5",
+    "message": "All the features in the file should have properties with the same set of keys.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_6",
+    "message": "The file features should have important keys such as 'Country', 'Province', 'District', 'Administrative post', 'Locality', 'Village', 'Boundary code', 'Target population'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_7",
+    "message": "In the Properties object, the values for fields which represent a Numeric Value, should not be quoted with double quotes, (i.e. population of 10,000 should be represented as “population” : 10000 and not “population” : “10,0000”",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_SPECIFICATION",
+    "message": "RFC 7946 GeoJSON",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_1",
+    "message": "The user should zip up all the files in .zip format, and upload them into the system. At a minimum, the system needs .shp, .shx & .dbf files zipped.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_2",
+    "message": "The name of the zip file should be 'Population.zip'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_3",
+    "message": "The shapefile should be in the WGS 84 lat-long coordinate system for the system to accept.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_4",
+    "message": "The coordinates should be in the valid range of Latitude & Longitude (Valid range for Latitude is -90 to +90 & Valid range of Longitude is -180 to +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_5",
+    "message": "The shape file should have the important data points such as 'Country', 'Province', 'District', 'Administrative post', 'Locality', 'Village', 'Boundary', 'code', 'Target population'",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_6",
+    "message": "The total size of the zipped file should not exceed 2 GB.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LOADING",
+    "message": "Loading...",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LOADING_MAP",
+    "message": "Loading map...",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "LOGGED_IN_AS",
+    "message": "Logged in as",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MALARIA",
+    "message": "Malaria",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MAPPING",
+    "message": "Mapping",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_BOUNDARIES",
+    "message": "Boundaries",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_HEADING",
+    "message": "Filter",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_INSTRUCTIONS",
+    "message": "The suggested keys are pre-populated. Enter values for the keys to formulate your hypothesis. ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_LAYERS",
+    "message": "Layers",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_VIRTUALISATIONS",
+    "message": "Virtualisation",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MAPPING_NO_DATA_TO_SHOW",
+    "message": "No location data has been uploaded",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MAPPING_PARTIAL_DATA_TO_SHOW",
+    "message": "Few data points are missing location coordinates, please upload location coordinates for all the data points to view them on the map",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLANS",
+    "message": "My microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVEPOST",
+    "message": "Administrative Post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVE_AREA",
+    "message": "Adminstrative Area",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVE_BOUNDARY",
+    "message": "Adminstrative Area",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVE_HIERARCHY",
+    "message": "Adminstrative Hierarchy",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINSTRATIVEPOST",
+    "message": "Administrative Post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGN",
+    "message": "Assign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGNED_FACILITIES",
+    "message": "Assigned Villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGNMENT_FACILITY",
+    "message": "Catchment village assignment to",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGN_CATCHMENT_VILLAGES",
+    "message": "Assign catchment villages for the facilities or the points of services",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGN_FACILITY",
+    "message": "Add To Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSUMPTIONS",
+    "message": "Microplan Assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_BOUNDARY_IS_EMPTY_WARNING",
+    "message": "Please select 'Administrative hierarchy' and then 'Administrative area' dropdown fields to search.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_CAPACITY",
+    "message": "Capacity",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_CLOSE_BUTTON",
+    "message": "Close",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_COUNTRY",
+    "message": "Country",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_DATA_CONFIGURATION_HEADING",
+    "message": "Data Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_DETAILS",
+    "message": "Campaign Details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISEASE_MALARIA",
+    "message": "Malaria",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRIBUTION_FIXED_POST",
+    "message": "Fixed Post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRIBUTION_HOUSE_TO_HOUSE",
+    "message": "House-To-House",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRIBUTION_MIXED",
+    "message": "Fixed Post & House-to-House",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_ESTIMATION_ASSUMPTIONS_HEADING",
+    "message": "Microplan Assumptions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_EXECUTED",
+    "message": "Microplan Finalised",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITYNAME",
+    "message": "Facility Name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITYSTATUS",
+    "message": "Facility Status",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITYTYPE",
+    "message": "Facility Type",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_ACTION",
+    "message": "Action",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_ASSIGNED_VILLAGES",
+    "message": "Assigned Villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_CAPACITY",
+    "message": "Capacity",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_FIXEDPOST",
+    "message": "Fixed Post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_LLIN-mz_CAPACITY",
+    "message": "Capacity (Bales)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_MR-DN_CAPACITY",
+    "message": "Capacity",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_NAME",
+    "message": "Facility Name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_NAME_LABEL",
+    "message": "Facility name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_RESIDINGVILLAGE",
+    "message": "Adminstrative Area",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_SERVINGPOPULATION",
+    "message": "Serving Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_STATUS",
+    "message": "Facility Status",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_TYPE",
+    "message": "Facility Type",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_TYPE_LABEL",
+    "message": "Facility type",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FIXEDPOST",
+    "message": "Fixed Post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_FORMULA_CONFIGURATION_HEADING",
+    "message": "Formula Configuration",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY",
+    "message": "Microplan generated successfully!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY_DESCRIPTIION",
+    "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY_ID_LABEL",
+    "message": "Microplan ID",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY_NAME_LABEL",
+    "message": "Microplan name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATION",
+    "message": "Microplan generation",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_LOCALITY",
+    "message": "Locality",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_MODULE_PROCESS",
+    "message": "Microplan Process",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_MODULE_SETUP",
+    "message": "Microplan Setup",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAME",
+    "message": "Microplan name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAME_INPUT_PLACEHOLDER",
+    "message": "Example: Microplan-Country-CampaignType-Date",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINTS",
+    "message": "Microplan naming constraints",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINT_1",
+    "message": "The name should be of a minimum of two letters.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINT_2",
+    "message": "Only numeric values are not allowed",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINT_3",
+    "message": "Special characters -, _, (, ) are only allowed",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION",
+    "message": "Microplan naming format",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_1",
+    "message": "The name should be a minimum of 3 characters and a maximum of 64 characters in length",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_2",
+    "message": "Only numeric values are not allowed",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_3",
+    "message": "Special characters -, _, (, ),& are only allowed",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_4",
+    "message": "Only special characters like (-, _-) are not allowed",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NO_OF_BALES_PER_BOUNDARY",
+    "message": "Total bales",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NO_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Total bednets",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_NO_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Total households",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_PLEASE_FILL_ALL_THE_FIELDS_AND_RESOLVE_ALL_THE_ERRORS",
+    "message": "Please complete all the mandatory fields and resolve all errors before moving forward to the next step",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_APPLY",
+    "message": "Apply",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_CREATE_BY",
+    "message": "Created by dev-super1",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_HYPOTHESIS",
+    "message": "Hypothesis",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_HYPOTHESIS_HEADING",
+    "message": "Configure the hypothesis ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_HYPOTHESIS_INSTRUCTIONS",
+    "message": "Update the hypothesis to re-calculate the resource estimation for the campaign.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_RESIDINGVILLAGE",
+    "message": "Residing Village",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_RESIDING_VILLAGE",
+    "message": "Administrative Area",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_RESIDING_VILLAGE_LABEL",
+    "message": "Administrative areas",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_SEARCH",
+    "message": "Open Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECTED",
+    "message": "selected",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECTED_PLURAL",
+    "message": "Selected",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Boundaries are the administrative areas defined that you want to run a campaign in. Start selecting boundaries from the first level so that the boundaries present in the next level are available for selection.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECT_BOUNDARY",
+    "message": "Select the boundaries where you want to run the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_SERVINGPOPULATION",
+    "message": "Serving Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS",
+    "message": "Status",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_CENSUS_DATA_APPROVAL_IN_PROGRESS",
+    "message": "Validation in progress",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_CENSUS_DATA_APPROVED",
+    "message": "Validation in progress",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_COLUMN_DRAFT",
+    "message": "Draft",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_COLUMN_GENERATED",
+    "message": "Generated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_DRAFT",
+    "message": "Drafted Setup",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_EXECUTION_TO_BE_DONE",
+    "message": "Completed setup",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_RESOURCE_ESTIMATIONS_APPROVE",
+    "message": "Microplan finalised",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_RESOURCE_ESTIMATIONS_APPROVED",
+    "message": "Microplan finalised",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_RESOURCE_ESTIMATION_IN_PROGRESS",
+    "message": "Validation in progress",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_SUCCESS",
+    "message": "Validate And Approve Microplan Estimation",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_SUM_TOTAL_TARGET_POPULATION",
+    "message": "Total target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEST",
+    "message": "Test Message",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEST2",
+    "message": "Test Message",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_TYPE_LLIN_MZ",
+    "message": "Bednet Campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_TYPE_MR_DN",
+    "message": "SMC Campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_UNASSIGNED_FACILITIES",
+    "message": "Unassigned Villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_UNASSIGN_FACILITY",
+    "message": "Remove from",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_UNASSIGN_FACILITY IRS",
+    "message": "Remove from",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_VIEWER",
+    "message": "Microplan estimation viewer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_VIEWER_DESCRIPTION",
+    "message": "This role will have access to view microplan estimations of assigned administrative boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_VIEWER_POPUP_HEADING",
+    "message": "Select microplan estimation viewers ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGES_SELECTED",
+    "message": "selected",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_in",
+    "message": "tabs present in",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MICROPLAN_tabs",
+    "message": "Sheet tabs",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MIXED",
+    "message": "Fixed Post & House-to-House",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MONITORS",
+    "message": "Monitors",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MOUNTAIN",
+    "message": "Mountain",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MPAIGN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Boundaries are the administrative areas that you want to run a microplan in. Start selecting boundaries from the first level so that the boundaries available in the next level for selection",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ACK",
+    "message": "OK",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ACTIONS_EDIT_SETUP",
+    "message": "Edit Setup",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ACTIONS_FOR_MICROPLAN_SEARCH",
+    "message": "Actions",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ACTIONS_VIEW_SUMMARY",
+    "message": "View Summary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ADMINISTRATIVEPOST",
+    "message": "Adminstrative post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ASSUMPTIONS_INVALIDATION_MESSAGE",
+    "message": "Once you change it, you will have to fill the assumptions details again.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ASSUMPTION_NAME_INVALID",
+    "message": "Assumption name is invalid. Please enter valid alphanumeric name.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_BACK",
+    "message": "Back",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_BOUNDARY_SELECTION",
+    "message": "Boundary Selection",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_SETUP_DETAILS",
+    "message": "Microplan Details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_HEADER",
+    "message": "Download Excel Template for Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_TEXT",
+    "message": "Download the Excel template which has the selected boundary data. Once downloaded,please populate the template with correct target data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_HEADER",
+    "message": "Download Excel Template for Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_TEXT",
+    "message": "Download the Excel template which has the list of permanent facilities and list of selected boundary data. Once downloaded, please populate the template with correct facility data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_SKIP",
+    "message": "Skip",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_COMPLETE_SETUP",
+    "message": "Complete Setup",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION",
+    "message": "Enter the assumption value",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION_CAMPAIGN_VEHICLES",
+    "message": "Enter vehicle capacity",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION_CAMPAIGN_VEHICLES_LLIN-mz",
+    "message": "Please enter the vehicle capacity (In bales) for bednet campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION_CAMPAIGN_VEHICLES_MR-DN",
+    "message": "Enter the vehicle capacity (In blisters) for SMC campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_FACILITY_TOTALPOPULATION",
+    "message": "Approved Target Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_FACILITY_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_FAILED_USER_CREATION",
+    "message": "User creation has failed. Please try to re-upload the file.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_FILES_INVALIDATION_MESSAGE",
+    "message": "Updating boundaries will affect the uploaded population and facility data (If uploaded). Please update with caution.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_FOOTER",
+    "message": "Please give a name to the microplan. This name will be used for reference and identification in the upcoming steps.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_FORMULA_NAME_INVALID",
+    "message": "Formula name is invalid. Please enter valid alphanumeric name.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_INPROGRESS_USER_CREATION",
+    "message": "User creation is in progress. Please wait for sometime.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_MANAGING_DATA",
+    "message": "Data Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_NAME_OF_MICROPLAN_MY_MICROPLANS",
+    "message": "Microplan Name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_NAME_OF_MICROPLAN_OPEN_MICROPLANS",
+    "message": "Name of microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_NEXT",
+    "message": "Next",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_PLAN_ASSIGNED_TO_ALL",
+    "message": "Assigned to all",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_PLAN_MICROPLAN_NAME",
+    "message": "Microplan name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_POP_ASSIGNED_TO_ALL",
+    "message": "Assigned to all",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_BOUNDARY_MANAGER",
+    "message": "System Administrator",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_CAMPAIGN_MANAGER",
+    "message": "Campaign Manager",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_FACILITY_CATCHMENT_ASSIGNER",
+    "message": "Facility boundary assigner",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_FACILITY_CATCHMENT_MAPPER",
+    "message": "Facility boundary assigner",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_MICROPLAN_ADMIN",
+    "message": "Microplan Admin",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_MICROPLAN_APPROVER",
+    "message": "Microplan estimation approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_MICROPLAN_VIEWER",
+    "message": "Microplan estimation viewer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_PLAN_ESTIMATION_APPROVER",
+    "message": "Microplan estimation approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_POPULATION_DATA_APPROVER",
+    "message": "Population data approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "National facility boundary assigner",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "National microplan estimation approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_ROOT_POPULATION_DATA_APPROVER",
+    "message": "National population data approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_ROLE_SYSTEM_ADMINISTRATOR",
+    "message": "System Administrator",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_SAVE_PROCEED",
+    "message": "Save and Proceed",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_UM_FILTER",
+    "message": "Filter",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_UPLOAD_USER",
+    "message": "Bulk upload users",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_USER_CREATION",
+    "message": "User creation",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_EMAIL",
+    "message": "Email",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_FILTER",
+    "message": "Filter",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_MOBILE_NO",
+    "message": "Contact number",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_NAME",
+    "message": "Name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_ROLE",
+    "message": "Role",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_USER_MESSAGE",
+    "message": "Please fill the downloaded template with user data and upload the sheet.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_USER_TAG_CLEAR",
+    "message": "Clear",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_USER_TAG_SEARCH",
+    "message": "Search",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_VILLAGE_ACCESSIBILITY_LEVEL",
+    "message": "Village Accessibility Level",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_VILLAGE_SECURITY_LEVEL",
+    "message": "Village Security Level",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_WARNING_ASSUMPTIONS_FORM",
+    "message": "Are you sure you want to change answers for the microplan assumptions questionnaire?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_WARNING_BOUNDARIES_FORM",
+    "message": "Warning!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR-DN",
+    "message": "SMC Campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_GUIDELINE_POINTS_1",
+    "message": "The name of the file should be 'Population.xlsx'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_GUIDELINE_POINTS_2",
+    "message": "The Latitude & Longitude fields should have data in Degree Decimal and Degree Minute Seconds ( Value should be 12.3455 & not 12° 20' 43.7994\")",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_1",
+    "message": "The GeoJSON file should meet the {{link}} specification.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_2",
+    "message": "The name of the file should be 'Population.geojson'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_3",
+    "message": "All the features in the file should have geometries of the same type (i.e. All should be points, or all should be multipolygons and so on).",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_4",
+    "message": "The coordinates should be in the valid range of Latitude & Longitude (Valid range for Latitude is -90 to +90 & Valid range of Longitude is -180 to +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_5",
+    "message": "All the features in the file should have properties with the same set of keys.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_6",
+    "message": "The file features should have important keys such as 'Country', 'Province', 'District', 'Administrative post', 'Locality', 'Village', 'Boundary code', 'Target population (Age 3 months - 11 months)', 'Target population (Age 12 months - 59 months)', 'Total target population'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_7",
+    "message": "In the Properties object, the values for fields which represent a Numeric Value, should not be quoted with double quotes, (i.e. population of 10,000 should be represented as “population” : 10000 and not “population” : “10,0000”",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_SPECIFICATION",
+    "message": "RFC 7946 GeoJSON",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_1",
+    "message": "The user should zip up all the files in .zip format, and upload them into the system. At a minimum, the system needs .shp, .shx & .dbf files zipped.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_2",
+    "message": "The name of the zip file should be 'Population.zip'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_3",
+    "message": "The shapefile should be in the WGS 84 lat-long coordinate system for the system to accept.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_4",
+    "message": "The coordinates should be in the valid range of Latitude & Longitude (Valid range for Latitude is -90 to +90 & Valid range of Longitude is -180 to +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_5",
+    "message": "The shape file should have the important data points such as 'Country', 'Province', 'District', 'Administrative post', 'Locality', 'Village', 'Boundary code', 'Target population (Age 3 months - 11 months)', 'Target population (Age 12 months - 59 months)', 'Total target population'.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_6",
+    "message": "The total size of the zipped file should not exceed 2 GB.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MULTIPLIED_BY",
+    "message": "Multiplied by",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MY_MICROPLAN",
+    "message": "All",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MY_MICROPLANS",
+    "message": "My Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MY_MICROPLANS_HEADING",
+    "message": "My Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Microplan Country",
+    "message": "Country",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NAME",
+    "message": "Name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NAME_OF_MICROPLAN",
+    "message": "Name of Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NAME_OF_MP",
+    "message": "Name of the microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NAME_YOUR_MP",
+    "message": "Enter the microplan name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEVER",
+    "message": "Never",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEVER1",
+    "message": "Never",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW_ASSUMPTION",
+    "message": "Add new assumption",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW_FORMULA",
+    "message": "Add new formula",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEW_VALUE",
+    "message": "New value",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NEXT",
+    "message": "Next",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO",
+    "message": "No",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_CAMPAIGN_DETAILS_FOUND_FOR_GIVEN_CAMPAIGN_ID",
+    "message": "There was some issue. Please try again.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_DATA",
+    "message": "NA",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_DATA_AVAILABLE",
+    "message": "No data available. Please upload valid data, if you already have and it is still not appearing here please contact admin",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_NAME_AVAILABLE",
+    "message": "No name available",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Number of bags per team per cycle for fixed post distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Number of bags per team per cycle for fixed post registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Number of bags per team per cycle for house-to-house distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Number of bags per team per cycle for house-to-house registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BALES_PER_BOUNDARY",
+    "message": "Total number of bales per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_PER_BALE",
+    "message": "Number of bednets per bale",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Total number of bednets per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_PER_HOUSEHOLD",
+    "message": "Number of bednets per household",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_REQUIRED",
+    "message": "Number of bednets required",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_TO_BE_DISTRIBUTED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY",
+    "message": "Number of bednets to be distributed by a distribution team per day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNET_PER_HOUSEHOLD",
+    "message": "Number of bednets per household",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNET_REQUIRED",
+    "message": "Number of bednets required",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Number of beneficiaries to be catered by a distribution team per day per cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Number beneficiaries to be catered by distribution team per day per cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_CATERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Number of beneficiaries to be catered per team per day at the fixed post distribution point per cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "Number of beneficiaries or household to be registered by a registration team per day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Number of beneficiaries to be registered by a registration team per day per cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Number of beneficiaries to be registered per team per day at the fixed post distribution point per cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Number of chalks per team per cycle for fixed post distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Number of chalks per team per cycle for fixed post registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Number of chalks per team per cycle for house-to-house distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Number of chalks per team per cycle for  house-to-house registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_CYCLES",
+    "message": "Number of cycles",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Number of days for fixed post distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Number of days for fixed post registration",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Number of days for distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Number of days for registration",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_OF_THE_CAMPAIGN_AT_THAT_BOUNDRY_LEVEL",
+    "message": "Number of days of the campaign at that boundary level",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_DISTRIBUTORS",
+    "message": "Number of distributors",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_DISTRIBUTORS_PER_BOUNDARY",
+    "message": "Number of distributors per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_DISTRIBUTORS_PER_MONITOR",
+    "message": "Number of distributors per monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Total number of fixed post distribution teams per boundary for 1 day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Total number of fixed post distribution teams per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Number of fixed post distribution teams per supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Total number of fixed post distribution team members per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "Total number of fixed post distribution team supervisors per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Total number of fixed post registration teams per boundary for 1 day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Total number of fixed post registration teams per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Number of fixed post registration teams per supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Total number of fixed post registration team members per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "Total number of fixed post registration team supervisors per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD",
+    "message": "Number of households",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Total number of households per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "Number of households per sticker roll",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Total number of distribution teams per boundary for 1 day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Total number of distribution teams per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_MONITOR",
+    "message": "Number of distribution teams per monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Number of distribution teams per supervisors",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Total number of distribution team members per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Total number of registration teams per boundary for 1 day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Total number of registration teams per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Number of registration teams per monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Number of registration teams per supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Total number of registration team members per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_TO_BE_COVERED",
+    "message": "Number of households to be covered",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Number of members per fixed post distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Number of members per fixed post registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Number of members per distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Number of members per registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Total number of monitors for distribution team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Total number of monitors for registration team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Number of monitors per supervisor for distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Number of monitors per supervisor for registration",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Number of pens per team per cycle for fixed post distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Number of pens per team per cycle for fixed post registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Number of pens per team per cycle for house-to-house distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Number of pens per team per cycle for house-to-house registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_PEOPLE_PER_BEDNET",
+    "message": "Number of persons per bednet",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_PEOPLE_PER_HOUSEHOLD",
+    "message": "Number of people per household",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_POPULATION_TARGETTED_FOR_COVERAGE",
+    "message": "Number of population targeted for coverage",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_POPULATION_TO_BE_COVERED",
+    "message": "Number of population to be covered",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SOAK_PITS",
+    "message": "Number of soak pits",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_1_REQUIRED_FOR_AGE_3_TO_11_MONTHS",
+    "message": "Total SPAQ-1 required for age 3 months - 11 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_1_REQUIRED_FOR_AGE_3_TO_11_MONTHS_WITH_BUFFER",
+    "message": "Total SPAQ-1 required for age 3 months - 11 months with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_2_REQUIRED_FOR_AGE_12_TO_59_MONTHS",
+    "message": "Total SPAQ-2 required for age 12 months - 59 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_2_REQUIRED_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "Total SPAQ-2 required for age 12 months - 59 months with buffer ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_1",
+    "message": "Number of SPAQs required per cycle for demographic 1",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_1_WITH_BUFFER",
+    "message": "Number of SPAQs required per cycle for demographic 1 with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_2",
+    "message": "Number of SPAQs required per cycle for demographic 1",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_2_WITH_BUFFER",
+    "message": "Number of SPAQs required per cycle for demographic 2 with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQ_PER_CYCLE",
+    "message": "Number of SPAQ per cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_STICKERS_ROLLS_PER_BOUNDARY",
+    "message": "Total number of stickers rolls per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES",
+    "message": "Number of structures",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES_PER_UNIT_OF_INSECTICIDE",
+    "message": "Number of structures sprayed per day per operator",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES_SPRAYED_PER_DAY_PER_OPERATOR",
+    "message": "Number of spray operator per monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES_THAT_ARE_SPRAYABLE",
+    "message": "Number of structures that are sprayable",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERIORS",
+    "message": "Number of superiors",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS",
+    "message": "Number of supervisors",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Total number of supervisors for distribution team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Total number of supervisors for registration team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS_PER_BOUNDARY",
+    "message": "Number of supervisors per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_TEAMS_PER_BOUNDARY",
+    "message": "Number of teams per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_OF_TEAMS_PER_BOUNDARY_IF_CAMPAIGN_RUNS_FOR_1_DAY",
+    "message": "Number of teams per boundary if campaign runs for 1 day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_RESULTS_FACILITY_CATCHMENT_MAPPER",
+    "message": "There are no Facility boundary assigners assigned for this microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_RESULTS_FOUND",
+    "message": "No Results Found",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_RESULTS_MICROPLAN_VIEWER",
+    "message": "There are no Microplan estimation viewers assigned for this microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_RESULTS_PLAN_ESTIMATION_APPROVER",
+    "message": "There are no Microplan estimation approvers assigned for this microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_RESULTS_POPULATION_DATA_APPROVER",
+    "message": "There are no Population data approvers assigned for this microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_RESULTS_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "There are no National facility boundary assigners assigned for this microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_RESULTS_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "There are no National microplan estimation approvers assigned for this microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_RESULTS_ROOT_POPULATION_DATA_APPROVER",
+    "message": "There are no National population data Approvers assigned for this microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_ROAD",
+    "message": "No road",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_FACILITY_CATCHMENT_MAPPER",
+    "message": "No result found for given search criteria.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_MICROPLAN_VIEWER",
+    "message": "No result found for given search criteria.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_PLAN_ESTIMATION_APPROVER",
+    "message": "No result found for given search criteria.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_POPULATION_DATA_APPROVER",
+    "message": "No result found for given search criteria.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "No result found for given search criteria.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "No result found for given search criteria.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_ROOT_POPULATION_DATA_APPROVER",
+    "message": "No result found for given search criteria.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BALES_PER_BOUNDARY",
+    "message": "Number of bales per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BEDNETS_PER_BALE",
+    "message": "Number of bednets per bale",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Number of bednets to be distributed per team per day at the fixed post distribution point",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BEDNETS_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Number of bednets to be registered per team per day at the distribution point",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BED_NETS_PER_BOUNDARY",
+    "message": "Number of bednets per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BENEFICIARIES_PER_TEAM",
+    "message": "Number of beneficiaries per team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BENEFICIARIES_PER_TEAM_PER_DAY",
+    "message": "Number of beneficiaries per team per day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Number of beneficiaries or household to be registered per team per day at the fixed post distribution point",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_CAMPAIGN_DAYS",
+    "message": "Number of campaign days",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DAYS_FOR_CAMPAIGN",
+    "message": "Number of days for campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Number of days for fixed post distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Number of days for fixed post registration",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DISTRIBUTORES_PER_SUPERVISOR",
+    "message": "Number of distributors per supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DISTRIBUTORS_IF_CAMPAIGN_RUNS_FOR_1_DAY",
+    "message": "Number of distributors if campaign runs for 1 day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Number of fixed post distribution teams per supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_CAMPAIGN",
+    "message": "Number of registration teams per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_ONE_DAY",
+    "message": "Number of registration teams per boundary for 1 day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Number of fixed post registration teams per supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Number of registration team members per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Number of fixed post team members per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Number of households per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_FIXED_POST_TEAM",
+    "message": "Number of households per fixed post team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Number of households per distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "Number of households per sticker roll",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_CAMPAIGN",
+    "message": "Number of distribution teams per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_ONE_DAY",
+    "message": "Number of distribution teams per boundary for 1 day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Number of distribution team members per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY",
+    "message": "Number of registration teams per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_1_DAY",
+    "message": "Number of registration teams per boundary for 1 day",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Number of registration teams per boundary for the campaign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Number of registration team members per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Number of members per fixed post distribution team ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Number of members per fixed post registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_REGISTRATION_TEAM",
+    "message": "Number of members per registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_TEAM",
+    "message": "Number of members per team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Number of monitors for registration team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_FIXED_POST_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Number of monitors for registration team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_FIXED_POST_TEAM_PER_BOUNDARY",
+    "message": "Number of monitors per fixed post team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Number of monitors for distribution team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_SUPERVISOR_FOR_REGISTRATION",
+    "message": "Number of monitors per supervisor for registration",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_TEAM",
+    "message": "Number of monitors per team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_PERSON_PER_BEDNET",
+    "message": "Number of person per bednet",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Number of registration teams per monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SPRAY_TECHNICIAN_PER_SUPERVISOR",
+    "message": "Number of spray technicians per supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_FOR_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Number of supervisors for registration team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_PER_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Number of supervisors for distribution team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_PER_FIXED_POST_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Number of supervisors for registration team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_PER_FIXED_POST_TEAM_PER_BOUNDARY",
+    "message": "Number of supervisors per fixed post team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "NUMBER_OF_TEAMS_PER_SUPERVISOR",
+    "message": "Number of teams per supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Name",
+    "message": "Name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Number",
+    "message": "Contact Number",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "OFTEN",
+    "message": "Often (Atleast once a year)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "OFTEN1",
+    "message": "Often (Atleast once a week)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "OLD_VALUE",
+    "message": "Old value",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "OPEN_MICROPLANS",
+    "message": "Open Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "OTHER",
+    "message": "Other",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PENDING_FOR_APPROVAL",
+    "message": "Pending for approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PENDING_FOR_VALIDATION",
+    "message": "Pending for validation",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PERMAENENT",
+    "message": "Permanent",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PERMANENT_DELETE",
+    "message": "Deleting a line item will delete the assumption. However, you will be able to retrieve it by clicking on 'Add Assumption' button.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAIN",
+    "message": "Plain",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_APPROVE_CENSUS_DATA",
+    "message": "Finalized Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Sent for approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_EDIT_AND_VALIDATE",
+    "message": "Validated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_FINALIZE_CATCHMENT_MAPPING",
+    "message": "Finalized assigning facilities to villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_INITIATE",
+    "message": "Data submitted",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_SEND_BACK_FOR_CORRECTION",
+    "message": "Sent back for correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_START_DATA_APPROVAL",
+    "message": "Finalizing Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_VALIDATE",
+    "message": "Validated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER",
+    "message": "Microplan estimation approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER_DESCRIPTION",
+    "message": "This user role will have access to edit microplan assumptions and approve the microplan estimation of assigned administrative boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER_POPUP_HEADING",
+    "message": "Select microplan estimation approvers",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_INBOX",
+    "message": "Validate & Approve Microplan Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_HEADING_LABEL",
+    "message": "Send back for correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_SUBMIT_LABEL",
+    "message": "Send for Correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_VALIDATE_HEADING_LABEL",
+    "message": "Validate data for villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_VALIDATE_SUBMIT_LABEL",
+    "message": "Validate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_WORKFLOW_FOR_SEND_BACK_FOR_CORRECTION_UPDATE_SUCCESS",
+    "message": "The estimations for the selected villages are successfully sent back for correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_WORKFLOW_FOR_VALIDATE_UPDATE_SUCCESS",
+    "message": "The estimations for selected villages are successfully validated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_WORKFLOW_UPDATE_SUCCESS",
+    "message": "Action occurred successfully",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLS_ENTER_ASSUMPTION_NAME",
+    "message": "Please enter assumptions name.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PLS_SELECT_ASSUMPTION",
+    "message": "Please select from the dropdown options.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POPULATION",
+    "message": "Population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POPULATION_COUNT_DEMOGRAPHIC_1_PER_BOUNDARY",
+    "message": "Population count for demographic 1 per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POPULATION_COUNT_DEMOGRAPHIC_2_PER_BOUNDARY",
+    "message": "Population count for demographic 2 per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER",
+    "message": "Population data approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER_DESCRIPTION",
+    "message": "This user role will have access to validate & approve the population data for the villages of assigned administrative boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER_POPUP_HEADING",
+    "message": "Select population data approvers",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POPULATION_FINALISED_SUCCESSFUL",
+    "message": "Population data has been finalised successfully!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POPULATION_FINALISE_SUCCESS",
+    "message": "Validate & Approve Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POPULATION_OF_THE_BOUNDARY",
+    "message": "Population of the boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_APPROVE",
+    "message": "Approved",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Sent for approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_EDIT_AND_VALIDATE",
+    "message": "Validated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_INITIATE",
+    "message": "Data submitted",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_ROOT_APPROVE",
+    "message": "Approved",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_SEND_BACK_FOR_CORRECTION",
+    "message": "Sent for correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_VALIDATE",
+    "message": "Validated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX",
+    "message": "Validate & Approve Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_HEADING_LABEL",
+    "message": "Send village data for approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_LABEL",
+    "message": "Submit and validate the Population data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_SUBMIT_LABEL",
+    "message": "Send For Approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_WORKFLOW_UPDATED_SUCCESSFULLY",
+    "message": "The data for selected villages are successfully sent for approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_APPROVE_HEADING_LABEL",
+    "message": "Approve data for villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_APPROVE_SUBMIT_LABEL",
+    "message": "Approve",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_ROOT_APPROVE_HEADING_LABEL",
+    "message": "Approve data for villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_ROOT_APPROVE_SUBMIT_LABEL",
+    "message": "Approve",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_HEADING_LABEL",
+    "message": "Send data for correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_SUBMIT_LABEL",
+    "message": "Send For Correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_VALIDATE_HEADING_LABEL",
+    "message": "Validate data for villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_VALIDATE_SUBMIT_LABEL",
+    "message": "Validate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_APPROVE_UPDATE_SUCCESS",
+    "message": "The data for the selected villages are successfully approved",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_ROOT_APPROVE_UPDATE_SUCCESS",
+    "message": "The data for the selected villages are successfully approved",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_SEND_BACK_FOR_CORRECTION_UPDATE_SUCCESS",
+    "message": "The data for the selected villages are successfully sent back for correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_VALIDATE_UPDATE_SUCCESS",
+    "message": "The data for selected villages are successfully validated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_OR_ROOT_APPROVE_UPDATE_SUCCESS",
+    "message": "Action occurred successfully",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_UPDATE_SUCCESS",
+    "message": "Action occurred successfully",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PREREQUISITES",
+    "message": "Prerequisites",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PREVIOUS",
+    "message": "Previous",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PROCEDURE",
+    "message": "Procedure",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PROVIDE_DETAILS",
+    "message": "Provide the following details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "P_CAMPAIGN_SETUP_DETAILS",
+    "message": "Microplan Name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Please configure the formula with respect to the assumptions considered for resource estimation",
+    "message": "Please configure the formula with respect to the assumptions considered for resource estimation.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Procurar",
+    "message": "Search",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "QUANTITY_OF_INSECTICIDE_REQUIRED",
+    "message": "Quantity of insecticide required",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RAISE_TO",
+    "message": "Raise to (power)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RARELY",
+    "message": "Rarely (Once in 2-3 years)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RARELY1",
+    "message": "Rarely (Once in a month)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "REFER",
+    "message": "Refer data guideline",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "REGISTRATION_AND_DISTRIBUTION",
+    "message": "Is the registration and distribution process happening together or separately?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "REGISTRATION_PROCESS",
+    "message": "How is the campaign registration process happening?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_CALCULATION",
+    "message": "Please enter the values for each assumptions stated below for resource calculation.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_DISTRIBUTION_STRATEGY",
+    "message": "Resource distribution strategy",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_ESTIMATIONS_APPROVED",
+    "message": "Microplan finalised",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_ESTIMATION_IN_PROGRESS",
+    "message": "Validation in progress",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_NO_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Total number of registration team members per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_NO_OF_SUPERVISORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Total number of supervisors for registration team per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Total number of bags required per boundary for registration",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Total number of chalks required per boundary for registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS",
+    "message": "Total SPAQ-1 required with buffer (Age 3-11 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "Total SPAQ-2 required with buffer (Age 12-59 month)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_SPAQ_REQUIRED_WITH_BUFFER",
+    "message": "Total SPAQ required with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_TARGET_POPULATION",
+    "message": "Total target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROLES",
+    "message": "Role",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROLE_ACCESS_CONFIGURATION",
+    "message": "User Access Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_APPROVE",
+    "message": "Approve",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_APPRROVE",
+    "message": "Approve",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "National facility boundary assigner",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER_DESCRIPTION",
+    "message": "This user role will have access to assign & finalize the facility to the catchment area assignment of the assigned administrative boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER_POPUP_HEADING",
+    "message": "Assign national facility boundary assigner",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "National microplan estimation approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER_DESCRIPTION",
+    "message": "This user role will have access to validate, approve and finalize the microplan estimation for the villages of assigned administrative boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER_POPUP_HEADING",
+    "message": "Assign national microplan estimation approvers",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER",
+    "message": "National population data approver",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER_DESCRIPTION",
+    "message": "This user role will have access to validate, approve & finalize the population data for the villages of assigned administrative boundary.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER_POPUP_HEADING",
+    "message": "Assign national population data approvers",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_HEADING_LABEL",
+    "message": "Submit and validate data for villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_SUBMIT_LABEL",
+    "message": "Submit and Validate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROOT_POP_INBOX_HCM_MICROPLAN_EDIT_WORKFLOW_UPDATED_SUCCESSFULLY",
+    "message": "The data for selected villages are successfully validated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "ROWS",
+    "message": "Rows",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RULE_ENGINE",
+    "message": "Rule engine",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INFORMATION_DESCRIPTION",
+    "message": "Dynamic view of how the formulae will help calculate the estimates",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INPUT",
+    "message": "Input",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INPUT_HELP_TEXT",
+    "message": "This can be population or number of households or number of resources based on the campaign type",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INSTRUCTIONS_DELETE_ENTRY_CONFIRMATION",
+    "message": "Deleting a line item will permanently delete the formula configuration. You will not be able to retrieve it.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_KEY_HELP_TEXT",
+    "message": "This is the key that has been configured in the previous step as hypothesis",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_OPERATOR",
+    "message": "Operator",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_OPERATOR_HELP_TEXT",
+    "message": " ",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_VALUE_HELP_TEXT",
+    "message": "This indicates the value to be calculated for estimation",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SAVED_MICROPLANS",
+    "message": "My Saved Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SAVED_MICROPLANS_TEXT",
+    "message": "Saved microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SAVE_CHANGES",
+    "message": "Save changes",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SAVE_PROCEED",
+    "message": "Save and Proceed",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEARCH",
+    "message": "Search",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEARCH_ALL",
+    "message": "Open Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEARCH_All",
+    "message": "Open Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEARCH_MICROPLANS",
+    "message": "Open Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SECURITY_DETAILS_UPDATE_SUCCESS",
+    "message": "Security details are updated successfully",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SECURITY_LEVEL_Q1",
+    "message": "Is your village prone to civil unrest like violent protests, riots, etc.?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SECURITY_LEVEL_Q1_",
+    "message": "Is your village prone to civil unrest like violent protests, riots, etc.?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SECURITY_LEVEL_Q2",
+    "message": "How often the security forces patrol the village?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT",
+    "message": "Select",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECTED",
+    "message": "Selected",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECTED_BOUNDARY",
+    "message": "Administrative Area",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY",
+    "message": "Select Activity",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_ASSIGN_FACILITIES_TO_VILLAGE",
+    "message": "This activity will let you assign and finalize facilities to their catchment villages.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_GEOSPATIAL_MAP_VIEW",
+    "message": "This activity will let you view the microplan estimation on a geospatial map.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_VALIDATE_N_APPROVE_MICROPLAN_ESTIMATIONS",
+    "message": "This activity will let you validate and approve the microplan estimations.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_VALIDATE_N_APPROVE_POPULATION_DATA",
+    "message": "This activity will let you validate and approve the population data to be considered for microplanning.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_ALL",
+    "message": "Select All",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_AN_ACTIVITY_TO_CONTINUE",
+    "message": "Select an activity to continue",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_ASSUMPTION_ALREADY_ADDED",
+    "message": "This assumption name already exists. Please add another assumption name.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_ASSUMPTION_NAME_LONG_THAN_100",
+    "message": "Assumption name should not be more than 100 character.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_A_BOUNDARY",
+    "message": "Select a boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_A_BOUNDARY_TOOLTIP",
+    "message": "Here you can select boundary form your uploaded data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_BOUNDARIES",
+    "message": "Select administrative area",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_CAMPAIGN",
+    "message": "Select a campaign to create microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_FORMULA",
+    "message": "Select formula",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_FORMULA_NAME_LONG_THAN_100",
+    "message": "Formula name should not be more than 100 character.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_HIERARCHY",
+    "message": "Select {{heirarchy}}",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_HIERARCHY_LEVEL",
+    "message": "Select administrative hierarchy",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SELECT_OPTION",
+    "message": "Select an option",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEND_BACK_FOR_CORRECTION",
+    "message": "Send Back For Correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEND_FOR_APPROVAL",
+    "message": "Send For Approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEND_FOR_APPROVE",
+    "message": "Approve data for villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEND_FOR_Approve",
+    "message": "Send For Approve",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEND_FOR_ROOT_APPROVE",
+    "message": "Approve data for villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEND_FOR_SEND_BACK_FOR_CORRECTION",
+    "message": "Send data for correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEND_FOR_Send Back For Correction",
+    "message": "Send data for correction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEND_FOR_VALIDATE",
+    "message": "Validate data for villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEND_FOR_Validate",
+    "message": "Validate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SEPARATELY",
+    "message": "Separately",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SETUP_COMPLETED",
+    "message": "Microplan setup completed!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SETUP_COMPLETED_RESPONSE",
+    "message": "Setup Completed",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SETUP_COMPLETE_FAILED_DUE_TO_API_INTEGRATION",
+    "message": "This action has already been done. Please refresh and try again.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SETUP_MICROPLAN",
+    "message": "Set Up Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SETUP_MICROPLAN_SUCCESS_NAME",
+    "message": "Microplan name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SETUP_MICROPLAN_SUCCESS_RESPONSE_DESC",
+    "message": "Microplan Setup Completed.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SHAPE_FILES",
+    "message": "Shapefile",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SHOW_ON_ESTIMATION_DASHBOARD",
+    "message": "Show on estimation dashboard",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "START",
+    "message": "Start Validation",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "START_DATA_APPROVAL",
+    "message": "Edited and sent data for approval",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "STRAT_FIXED_POST",
+    "message": "Fixed Post",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "STRAT_HOUSE_TO_HOUSE",
+    "message": "House-to-House",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "STRAT_HOUSE_TO_HOUSE_FIXED_POST",
+    "message": "Fixed Post & House-to-House",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUBMIT",
+    "message": "Submit",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUBSTRACTION",
+    "message": "Subtraction",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUB_HEADING_CAMPAIGN_COMMODITIES",
+    "message": "Commodities Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUB_HEADING_CAMPAIGN_VEHICLES",
+    "message": "Vehicles Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUB_HEADING_FIXED_POST_DISTRIBUTION",
+    "message": "Distribution Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUB_HEADING_FIXED_POST_REGISTRATION",
+    "message": "Registration Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUB_HEADING_GENERAL_ESTIMATION",
+    "message": "General Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUB_HEADING_HOUSEHOLD_DISTRIBUTION",
+    "message": "Distribution Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUB_HEADING_HOUSEHOLD_REGISTRATION",
+    "message": "Registration Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUCCESS_DATA_SAVED",
+    "message": "Data saved successfully",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUMMARY",
+    "message": "Microplan Summary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "SUMMARY_SCREEN",
+    "message": "Summary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TEMPORARY",
+    "message": "Temporary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOGETHER",
+    "message": "Together",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_BALES",
+    "message": "Total bales",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_BEDNETS",
+    "message": "Total bednets",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_BUFFER_MULTIPLIER",
+    "message": "Total buffer percentage (%)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_BUFFER_PERCENTAGE",
+    "message": "Total buffer percentage",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_CYCLES_OF_SMC",
+    "message": "Total cycles of SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_FACILITIES_WITH_MAPPED_VILLAGES",
+    "message": "Facilities assigned to villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Total number of bags required per boundary for fixed post distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Total number of bags required per boundary for fixed post registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Total no. of bags required per boundary for distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Total number of bags required per boundary for registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Total number of chalks required per boundary for fixed post distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Total number of chalks required per boundary for fixed post registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Total no. of chalks required per boundary for distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Total number of chalks required per boundary for registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Total number of pens required per boundary for fixed post distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Total number of pens required per boundary fixed post registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Total no. of pens required per boundary for distribution team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Total number of pens required per boundary for registration team",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Total number of bednets per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_DISTRIBUTORS",
+    "message": "Total number of distributors",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_HOUSEHOLDS",
+    "message": "Total number of households",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_TEAMS",
+    "message": "Total number of teams",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_POPULATION_OF_BOUNDARY",
+    "message": "Number of bales per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_PROPORTION_WITH_BUFFER",
+    "message": "Total buffer proportion",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_QUANTITY",
+    "message": "Total quantity",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_FOR_AGE_12_59_MONTHS",
+    "message": "Total SPAQ-1 for age 12-59 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_FOR_AGE_12_59_MONTHS_WITH_BUFFER",
+    "message": "Total SPAQ-1 for age 12-59 months with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_FOR_AGE_3_11_MONTHS",
+    "message": "Total SPAQ-1 for age 3-11 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_WITH_BUFFER",
+    "message": "Total SPAQ-1 for age 3-11 months with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ2_FOR_AGE_12_59_MONTHS",
+    "message": "Total SPAQ-2 for age 12-59 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQA_REQUIRED_PER_CYCLE",
+    "message": "Total SPAQs required per cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQS_REQUIRED_PER_CYCLE",
+    "message": "Total SPAQs required",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_59_MONTHS",
+    "message": "Total SPAQ-1 for age 12-59 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_59_MONTHS_WITH_BUFFER",
+    "message": "Total SPAQ-1 for age 12-59 months with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_TO_59_MONTHS",
+    "message": "Total SPAQ-1 for age 12-59 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "Total SPAQ-1 for age 12-59 months with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_3_11_MONTHS",
+    "message": "Total SPAQ-1 for age 3-11 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS",
+    "message": "Total SPAQ-1 for age 3-11 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS_WITH_BUFFER",
+    "message": "Total SPAQ-1 for age 3-11 months with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_WITH_BUFFER",
+    "message": "Total SPAQ-1 for age 3-11 months with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_2_FOR_AGE_12_59_MONTHS",
+    "message": "Total SPAQ-2 for age 12-59 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS",
+    "message": "Total SPAQ-2 for age 12-59 months",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "Total SPAQ-2 for age 12 to 59 months with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_REQUIRED",
+    "message": "Total SPAQ required",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_REQUIRED_WITH_BUFFER",
+    "message": "Total SPAQ required with buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION",
+    "message": "Total target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_12_TO_59_MONTH_OF_BOUNDARY",
+    "message": "Total target population (Age 12-59 months) of boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_3_11_MONTHS",
+    "message": "Total target population (Age 3-11 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_3_TO_11_MONTHS",
+    "message": "Total target population (Age 3-11 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_3_TO_11_MONTH_OF_BOUNDARY",
+    "message": "Total target population (Age 3-11 months) of boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_OF_BOUNDARY",
+    "message": "Number of bales per boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "TOTAL_VILLAGES_WITH_FACILITY_ASSIGNED",
+    "message": "Villages assigned to facilities",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UNASSIGN",
+    "message": "Unassign",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UNASSIGNED_SUCCESSFULLY",
+    "message": "User has been unassigned from the selected role successfully",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UNASSIGNED_SUCESS",
+    "message": "Villages have been unassigned successfully from Facility",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOAD",
+    "message": "Upload",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Uploaded target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Uploaded Target Population(Age 12 to 59 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Uploaded Target Population(Age 3 to 11 months)",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Uploaded total population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOAD_DATA",
+    "message": "Upload data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOAD_GUIDELINE_INFO_CARD_INSTRUCTION",
+    "message": "Please upload data as per the data guideline",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOAD_USER",
+    "message": "Bulk Upload Users",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "UPLOAD_USER_SUCCESS",
+    "message": "User Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERTAG_CONFIRM_TO_UNASSIGN",
+    "message": "Are you sure you want to unassign the user from the chosen role?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USERTAG_CONFIRM_TO_UNASSIGN_DESC",
+    "message": "Once a user is unassigned from a role, you can reassign the same user to a role from User access management module. Do you want to unassign the user?",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_ACCESS_MANAGEMENT",
+    "message": "User Access Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_ACCESS_MGMT",
+    "message": "User Access Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_DATA_UPLOAD_SUCCESSFUL",
+    "message": "User data uploaded successfully!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_DIRECTIONS_FOR_ERROR_MESSAGE",
+    "message": "Please hover over the highlighted cell to see the errors.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_DOWNLOAD",
+    "message": "Download User Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "USER_MANAGEMENT",
+    "message": "User Management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "User data upload successful",
+    "message": "User data uploaded successfully!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VALIDATE",
+    "message": "Validate",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VALIDATED",
+    "message": "Validated",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VALIDATE_APPROVE_POPULATIONDATA",
+    "message": "Validate & Approve Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VALIDATE_N_APPROVE_MICROPLAN_ESTIMATIONS",
+    "message": "Validate & Approve Microplan Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VALIDATE_N_APPROVE_POPULATION_DATA",
+    "message": "Validate & Approve Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VALUE",
+    "message": "Value",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VIEW_DETAILS",
+    "message": "View Details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VIEW_LESS",
+    "message": "View less",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VIEW_LOGS",
+    "message": "View Logs",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VIEW_MICROPLAN_ESTIMATIONS",
+    "message": "View Microplan Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VIEW_MORE",
+    "message": "View More",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VIEW_SUMMARY",
+    "message": "View Summary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VILLAGE_ASSIGNED_TO_FACILITIES_SUCCESSFUL",
+    "message": "Villages assigned to facilities successfully!",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VILLAGE_FINALISE_SUCCESS",
+    "message": "Assign Facilities to Villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VILLAGE_ROAD_CONDITION",
+    "message": "Village road condition",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VILLAGE_TARNSPORTATION_MODE",
+    "message": "Village transport mode",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VILLAGE_TERRAIN",
+    "message": "Village terrain",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VILLAGE_VIEW",
+    "message": "Village Details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "VISUALIZATIONS",
+    "message": "Visualizations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "Validate and approve population data",
+    "message": "Validate & Approve Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WARE_HOUSES",
+    "message": "Ware houses",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WARNING_INCOMPLETE_MAPPING",
+    "message": "Please complete the mapping before proceeding",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD",
+    "message": "Download",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_MICROPLAN",
+    "message": "Download Estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_EDIT",
+    "message": "Edit",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_FAILED",
+    "message": "Failed",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_INPROGRESS",
+    "message": "In Progress",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_UPLOADED_BY",
+    "message": "Uploaded by",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_FACILITY_MICROPLAN",
+    "message": "Upload Excel for facilities or point of services",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_TARGET_MICROPLAN",
+    "message": "Upload Excel for population data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WORKFLOW_INTEGRATION_ERROR",
+    "message": "This action has already been done. Please refresh and try again.",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "WORKFLOW_UPDATE_SUCCESS",
+    "message": "Action occurred successfully",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "YES",
+    "message": "Yes",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "_CAMPAIGN_SETUP_DETAILS",
+    "message": "Microplan Details",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "_HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_SUFFIX_MESSAGE",
+    "message": "aadministrative areas under the campaign boundary",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "admin",
+    "message": "Admin",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "admin.*",
+    "message": "Admin.*",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "assign-facilities-to-villages",
+    "message": "Assign Facilities To Villages",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "boundaryCode",
+    "message": "Boundarycode",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "boundaryData",
+    "message": "Boundary Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "capacity",
+    "message": "Capacity",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "children",
+    "message": "Children",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "facilityCode",
+    "message": "Facility code",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "facilityData",
+    "message": "Facility data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "facilityName",
+    "message": "Facility name",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "facilityStatus",
+    "message": "Facility status",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "facilityType",
+    "message": "Facility type",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "lat",
+    "message": "Lat",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "long",
+    "message": "Long",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "microplan-search",
+    "message": "Open Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "my-microplans",
+    "message": "My Microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "numberOfMonitors",
+    "message": "No of monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "numberOfMonitors ",
+    "message": "Number of monitors",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "parent",
+    "message": "Parent",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "pop-inbox",
+    "message": "Validate & Approve Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "population-finalise-success",
+    "message": "Validate & Approve Population Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "select-activity",
+    "message": "Choose Activity",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "selectedDistributionProcess",
+    "message": "Distribution process",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "selectedRegistrationDistributionMode",
+    "message": "Registration and distribution mode",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "selectedRegistrationProcess",
+    "message": "Registration process",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "setup-completed-response",
+    "message": "Create Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "setup-microplan",
+    "message": "Create Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "targetHouseholds",
+    "message": "Target households",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "targetPopulation",
+    "message": "Target population",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "targetPopulationAge3To11",
+    "message": "Target population (Age 3 months - 11 months) ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "targetPopulationDemo1",
+    "message": "Target population demo 1",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "targetPopulationToReachPerCycleAgainstTheBoundaryInColumnHTotal",
+    "message": "Target population to reach per cycle against the boundary in column H Total",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "targetpopulationAge12To59",
+    "message": "Target population (Age 12 months - 59 months) ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "targetpopulationDemo2",
+    "message": "Target population demo 2",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "terrain",
+    "message": "Terrain",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "totalTargetPopulation",
+    "message": "Total target population ( Mandatory )",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "upload-user",
+    "message": "Bulk Upload Users",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "upload-user-success",
+    "message": "Users Creation",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "user-download",
+    "message": "Download User Data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "user-management",
+    "message": "User management",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "village-view",
+    "message": "Approve population data",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  },
+  {
+    "code": "MP_USER_DATA_UPLOADED_WILL_BE_AVAILABLE",
+    "message": "The user data uploaded will be available in your microplan user assignment",
+    "module": "rainmaker-microplanning",
+    "locale": "en_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/fr_MZ/hcm-admin-schemas.json
+++ b/localisation/Microplanning/v0.1/fr_MZ/hcm-admin-schemas.json
@@ -1,0 +1,2396 @@
+[
+  {
+    "code": "ADMIN10_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN10_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN10_LOCALIDADE",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN10_POST ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN10_STATE",
+    "message": "État",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN11_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN11_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN11_LOCALIDADE",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN11_POST ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN11_STATE",
+    "message": "État",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_ALDEIA",
+    "message": "Aldéia",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_LOCALIDADE",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_POSTO ADMINISTRATIVO",
+    "message": "Poste Administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_PROVINCIA",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_ALDEIA",
+    "message": "Aldéia",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_LOCALIDADE",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_POSTO ADMINISTRATIVO",
+    "message": "Poste Administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_PROVINCIA",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_ALDEIA",
+    "message": "Aldéia",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_LOCALIDADE",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_POST ADMINISTRATIVO",
+    "message": "Poste Administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_POSTO ADMINISTRATIVO",
+    "message": "Poste Administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_PROVINCIA",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMINE_QA",
+    "message": "Assurance qualité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMINU_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_ALDEIA",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_CONSOLE_TARGET",
+    "message": "Cible du ménage au niveau du village (obligatoire et à saisir par l'utilisateur)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_LOCALIDADE",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_POST ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_POSTO ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_PROVINCIA",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_STATE",
+    "message": "État",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AGE",
+    "message": "Âge",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.Country",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.Distrito",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.Localidade",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.Post Administrativo",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.PostAdministrativo",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.State",
+    "message": "État",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Définition de la population totale et cible une fois le modèle téléchargé :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "Accédez à la feuille du district pour lequel vous souhaitez définir des objectifs et ajoutez les données de population totale et cible pour chaque village.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Entrez la population cible et la population totale de chaque village dans la feuille de chaque district. Si un village n’a pas d’objectifs fixés, la feuille comportera des erreurs.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Enregistrez la feuille avec la cible mise à jour et la population totale pour chaque village sur le modèle Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran de téléchargement de la population et sélectionnez le fichier enregistré avec toute la population cible et totale du système.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2",
+    "message": "Cas d'erreurs courantes :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2_DESC_1",
+    "message": "Si l'utilisateur n'a pas défini d'objectifs ou de population totale pour chaque village, le système générera une erreur avec le numéro de ligne où l'objectif ou la population totale est manquant.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2_DESC_2",
+    "message": "Si l'utilisateur supprime un village de la feuille ou supprime une feuille de district complète et télécharge la feuille, le système générera une erreur. L'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données corrigées.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2_DESC_3",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur. L'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données corrigées.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1",
+    "message": "Téléchargement de modèles Excel pour définir des objectifs :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Téléchargez le modèle Excel en cliquant sur le bouton « Télécharger le modèle ».",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Ouvrez le modèle Excel téléchargé à l'étape précédente et la première feuille que vous verrez est une feuille « Lisez-moi ». Les feuilles restantes seront nommées d'après le nom des districts sélectionnés à l'étape « Sélection des limites »",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2",
+    "message": "Définition des objectifs une fois le modèle téléchargé :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_1",
+    "message": "Accédez à la feuille du district pour lequel vous souhaitez définir des objectifs et ajoutez des chiffres dans la colonne « Cibles » pour chaque village. ",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Entrez les objectifs pour chaque village dans la feuille de chaque district sous la colonne « Cible au niveau de la limite sélectionnée ». Si un village n’a pas d’objectifs fixés, la feuille comportera des erreurs.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger la cible » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3",
+    "message": "Cas d'erreurs courantes :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Si l'utilisateur n'a pas défini d'objectifs pour chaque village, le système générera une erreur avec le numéro de ligne où les cibles sont manquantes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Si l'utilisateur supprime un village de la feuille ou supprime une feuille de district complète et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_3",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_MAINHEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement cible",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": "Nombre de moustiquaires par ménage",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Nombre de personnes par moustiquaire",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_BEFORE_ERROR",
+    "message": "La date de fin de la campagne ne peut pas être antérieure à la date de début de la campagne.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_ERROR",
+    "message": "Champ obligatoire !",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_MANDATORY",
+    "message": "Champ obligatoire !",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE_ERROR",
+    "message": "Champ obligatoire !",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_MZ_capacity",
+    "message": "Capacité (Unités : Balles)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_mz_capacity",
+    "message": "Capacité (Unités : Balles)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIN_mz_capacity",
+    "message": "Capacité (Unités : Balles)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN__capacity",
+    "message": "Capacité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN_capacity",
+    "message": "Capacité ( Unités : SPAQ Blister )",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_boundaryCode",
+    "message": "Code des limites du bassin versant (obligatoire)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityUsage",
+    "message": "Utilisation des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EDIT_MICROPLANS_TEXT",
+    "message": "Modifier le microplan",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EQUAL_TO",
+    "message": "égal à",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_LOADING_BASE_MAP",
+    "message": "Impossible de trouver la carte de base requise, veuillez contacter l'administrateur.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_READ_ME_MISSING",
+    "message": "Veuillez ne pas modifier les noms des feuilles.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_TIMELINE",
+    "message": "Chronologie",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_1",
+    "message": "S'il n'y a aucune installation disponible pour la sélection, l'onglet « Liste des installations disponibles » dans le modèle sera vide. Pour créer de nouvelles données d'installation, ajoutez le nom de l'installation, le type d'installation",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Pour mapper l'installation à la limite correcte, l'utilisateur doit copier le code de limite correct de la limite de la feuille « Liste des limites de campagne » sur laquelle l'installation doit être cartographiée. ",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Création de nouvelles données d'installation/utilisation des données d'installation existantes une fois le modèle téléchargé :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "S'il n'y a aucune installation disponible pour la sélection, l'onglet « Liste des installations disponibles » dans le modèle sera vide. Pour créer de nouvelles données d'installation, ajoutez le nom de l'installation, le type d'installation, l'état de l'installation, la capacité et l'utilisation de l'installation.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Pour mapper l'installation à la limite correcte, l'utilisateur doit copier le code de limite correct de la limite de la feuille « Données de limite » sur laquelle l'installation doit être cartographiée.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Enregistrez la feuille avec les détails de l'établissement saisis dans le modèle Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger les données de l'installation » et sélectionnez le fichier enregistré avec toutes les données de l'installation du système.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_2",
+    "message": "Désactivation des installations existantes pour une campagne",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_2_DESC_1",
+    "message": "Une fois que l'utilisateur a téléchargé le modèle pour les installations, si le système dispose de données d'installation existantes à réutiliser, le modèle sera pré-rempli avec cette liste d'installations.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_2_DESC_2",
+    "message": "Si l'utilisateur choisit ensuite de ne pas utiliser des installations spécifiques, il peut désactiver ces installations en marquant le champ « Utilisation des installations » comme « Inactif ».",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3",
+    "message": "Cas d'erreurs courantes :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3_DESC_1",
+    "message": "Si l'utilisateur a supprimé le code de limite d'installation pour une installation existante dans la liste, le système affichera un message d'erreur.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3_DESC_2",
+    "message": "Si l'utilisateur supprime des colonnes de la « Liste des installations disponibles » de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3_DESC_3",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1",
+    "message": "Téléchargement de modèles Excel pour la configuration des installations :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Téléchargez le modèle Excel en cliquant sur le bouton « Télécharger le modèle ».",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Ouvrez le modèle téléchargé à l'étape précédente et comportera 3 feuilles et la première feuille que vous verrez est une feuille « Lisez-moi ». La deuxième feuille intitulée « Liste des installations disponibles » ",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2",
+    "message": "Création de nouvelles données d'installation/utilisation des données d'installation existantes une fois le modèle téléchargé :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "S'il n'y a aucune installation disponible pour la sélection, l'onglet « Liste des installations disponibles » dans le modèle sera vide. Pour créer de nouvelles données d'installation, ajoutez le nom de l'installation, le type d'installation.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Pour mapper l'installation à la limite correcte, l'utilisateur doit copier le code de limite correct de la limite de la feuille « Liste des limites de campagne » sur laquelle l'installation doit être cartographiée. ",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger les données de l'installation » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_5",
+    "message": "Désactivation des installations existantes pour une campagne.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_6",
+    "message": "Une fois que l'utilisateur a téléchargé le modèle pour les installations, si le système dispose de données d'installation existantes à réutiliser, le modèle sera pré-rempli avec cette liste d'installations.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_7",
+    "message": "Si l'utilisateur choisit ensuite de ne pas utiliser des installations spécifiques, il peut supprimer les lignes de données pour ces installations.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1",
+    "message": "Cas où il n'y a pas de données d'installation dans le système :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_1",
+    "message": "Étape 1 : Lorsqu'il n'y a pas de données d'établissement dans le système, le modèle « Liste des établissements disponibles » sera vide. ",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_2",
+    "message": "Étape 2 : Pour cartographier les installations sur une limite donnée, l'utilisateur doit copier le code de limite correct à partir de la feuille « Données de limite ».",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_3",
+    "message": "Étape 3 : Pour chaque installation, l'utilisateur doit ajouter Actif ou Inactif pour toutes les installations dans la colonne « Utilisation des installations ».",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_4",
+    "message": "Étape 4 : Une fois toutes les fonctionnalités ajoutées, l'utilisateur doit enregistrer le fichier sur son système et télécharger le fichier en appuyant sur l'option « Parcourir dans mes fichiers ».",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2",
+    "message": "Cas où il existe des données d'installation existantes dans le système :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_1",
+    "message": "Étape 1 : Lorsque vous ouvrez le modèle d'installation téléchargé, veuillez vous référer à la feuille Liste des installations disponibles.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_2",
+    "message": "Étape 2 : Dans cette étape, l'utilisateur devra ajouter des entrées dans la colonne Utilisation de l'installation avec des entrées valides étant soit Actives, ",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_3",
+    "message": "Étape 3 : Pour ajouter de nouveaux établissements qui ne sont pas présents dans la liste des établissements existants, l'utilisateur doit saisir le nom de l'établissement (doit être unique).",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_4",
+    "message": "Étape 4 : Une fois toutes les fonctionnalités ajoutées, l'utilisateur doit enregistrer le fichier sur son système et télécharger le fichier en appuyant sur l'option « Parcourir dans mes fichiers ».",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3",
+    "message": "Cas d'erreurs courantes :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Si l'utilisateur a supprimé les codes d'établissement pour un établissement existant dans la liste, le système créera un établissement en double avec ces valeurs de colonne.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Si l'utilisateur supprime des colonnes de la « Liste des installations disponibles » de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_3",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_MAINHEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER",
+    "message": "Approbateur des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FEMALE",
+    "message": "Femelle",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FROM",
+    "message": "depuis",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GENDER",
+    "message": "Genre",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GREATER_THAN",
+    "message": "supérieur à",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GREATER_THAN_EQUAL_TO",
+    "message": "supérieur ou égal à",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_ALDEIA",
+    "message": "Aldéia",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_LOCALIDADE",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POST ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POSTO ADMINISTRATIVO",
+    "message": "Poste Administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_PROVINCIA",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_AVAILABLE_FACILITIES",
+    "message": "Liste des structures disponibles",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Code des limites",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY",
+    "message": "Code de délimitation (obligatoire)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY_ERROR",
+    "message": "est invalide. Il doit être extrait de la feuille « Données de limite »",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_OLD",
+    "message": "Ancien code de délimitation",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Données de limite",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITIES",
+    "message": "Liste des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY",
+    "message": "Capacité (Unités : Balles pour moustiquaires/Blister SPAQ pour SMC)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_ERROR",
+    "message": "ne doit pas être vide et doit être un nombre compris entre 1 et 10 millions",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN",
+    "message": "Capacité (unités : balles pour moustiquaires/",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_LLIN-mz",
+    "message": "Capacité (Unités : balles)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_MR-DN",
+    "message": "Capacité (Unités : Blisters)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CODE",
+    "message": "Code de l'établissement",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_FIXED_POST_MICROPLAN",
+    "message": "Est un poste fixe (Oui/Non)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LATITUDE_OPTIONAL_MICROPLAN",
+    "message": "Latitude (facultatif)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LONGITUDE_OPTIONAL_MICROPLAN",
+    "message": "Longitude (facultatif)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME",
+    "message": "Nom de l'établissement",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME_MICROPLAN",
+    "message": "Nom de l'établissement",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS",
+    "message": "Statut de l'établissement",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS_MICROPLAN",
+    "message": "Statut de l'établissement",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE",
+    "message": "Type d'établissement",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE_MICROPLAN",
+    "message": "Type d'établissement",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE",
+    "message": "Utilisation des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE_MICROPLAN",
+    "message": "Utilisation des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LAT",
+    "message": "Latitude",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LONG",
+    "message": "Longitude",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_RESIDING_BOUNDARY_CODE_MICROPLAN",
+    "message": "Code de limite de résidence",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET",
+    "message": "Cible du ménage au niveau du village (obligatoire et à saisir par l'utilisateur)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_AT_THE_SELECTED_BOUNDARY_LEVEL",
+    "message": "Cible du ménage au niveau du village (obligatoire et à saisir par l'utilisateur)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_1",
+    "message": "Cible des ménages au niveau du village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_2",
+    "message": "Cible de salle au niveau du village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LAT_OPT",
+    "message": "Latitude (facultatif)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LONG_OPT",
+    "message": "Longitude (facultatif)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Population cible",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Population cible (âge 12-59 mois)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Population cible (âge 3-11 mois)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC",
+    "message": "Cible au niveau du village (Obligatoire et à saisir par l'utilisateur)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_12_TO_59",
+    "message": "Cible au niveau du village - Âge 12 à 59 mois (Obligatoire et à saisir par l'utilisateur)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_3_TO_11",
+    "message": "Cible au niveau du village - Âge 3 à 11 mois (Obligatoire et à saisir par l'utilisateur)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Population totale",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMAIL_MICROPLAN",
+    "message": "E-mail",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMPLOYMENT_TYPE",
+    "message": "Type d'emploi (obligatoire)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LIST",
+    "message": "Créer une liste d'utilisateurs",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Nom de la personne (obligatoire)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME_MICROPLAN",
+    "message": "Nom",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER",
+    "message": "Numéro de téléphone (obligatoire)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_ERROR",
+    "message": "doit être fourni et doit être un numéro de téléphone de 10 chiffres",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_MICROPLAN",
+    "message": "Numéro de contact",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_ROLE",
+    "message": "Rôle (obligatoire)",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_USAGE",
+    "message": "Actif / Inactif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_README_SHEETNAME",
+    "message": "Lisez-moi",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_TIMELINE",
+    "message": "Chronologie",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEIGHT",
+    "message": "Hauteur",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_ADMINISTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_CAN_BE_ONLY_APPLIED_ON_ADMIN_LEVEL_ZORO",
+    "message": "Les filtres ne peuvent être appliqués qu'au niveau 0",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "IN_BETWEEN",
+    "message": "entre",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LESS_THAN",
+    "message": "moins que",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LESS_THAN_EQUAL_TO",
+    "message": "inférieur ou égal à",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIM_MZ_capacity",
+    "message": "Capacité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIM_mz_capacity",
+    "message": "Capacité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "S'il n'y a aucune installation disponible pour la sélection, l'onglet « Liste des installations disponibles » dans le modèle sera vide.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Pour mapper l'installation à la limite correcte, l'utilisateur doit copier le code de limite correct de la limite de la feuille « Liste des limites de campagne » sur laquelle l'installation doit être cartographiée.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger les données de l'installation » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Désactivation des installations existantes pour une campagne.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "Une fois que l'utilisateur a téléchargé le modèle pour les installations, si le système dispose de données d'installation existantes à réutiliser, le modèle sera pré-rempli avec la liste des installations.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "Si l'utilisateur choisit ensuite de ne pas utiliser des installations spécifiques, il peut supprimer les lignes de données pour ces installations spécifiques qui doivent être supprimées et télécharger la feuille avec uniquement les installations nécessaires à la campagne avec les codes de limite corrects mappés à ces installations.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "Si l'utilisateur a supprimé les codes d'établissement pour un établissement existant dans la liste, le système créera un établissement en double avec ces valeurs de colonne.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "Si l'utilisateur supprime des colonnes de la « Liste des installations disponibles » de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_1",
+    "message": "Création de nouvelles données d'installation/utilisation des données d'installation existantes une fois le modèle téléchargé",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_2",
+    "message": "Cas d'erreurs courantes :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER",
+    "message": "Création de nouvelles données d'installation/utilisation des données d'installation existantes une fois le modèle téléchargé :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_1",
+    "message": "Définition des objectifs une fois le modèle téléchargé :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_2",
+    "message": "Cas d'erreurs courantes :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement de la population",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Accédez à la feuille du district pour lequel vous souhaitez définir des objectifs et ajoutez des chiffres dans la colonne « Cibles » pour chaque village.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Entrez les objectifs pour chaque village dans la feuille de chaque district sous la colonne « Cible au niveau de la limite sélectionnée ». Si un village n’a pas d’objectifs fixés, la feuille comportera des erreurs.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_3",
+    "message": "Si l'utilisateur n'a pas défini d'objectifs pour chaque village, le système générera une erreur avec le numéro de ligne où les cibles sont manquantes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_4",
+    "message": "Si l'utilisateur supprime un village de la feuille ou supprime une feuille de district complète et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_5",
+    "message": "Si l'utilisateur n'a pas défini d'objectifs pour chaque village, le système générera une erreur avec le numéro de ligne où les cibles sont manquantes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_6",
+    "message": "Si l'utilisateur supprime un village de la feuille ou supprime une feuille de district complète et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_7",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_mz_capacity",
+    "message": "Capacité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MALE",
+    "message": "Mâle",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ACTIVE",
+    "message": "Actif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINSTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_BOUNDARY_DATA_SHEET",
+    "message": "Données de limite",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_COLUMN",
+    "message": "Détails de l'erreur",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_COLUMN",
+    "message": "Statut",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_INVALID",
+    "message": "INVALIDE",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_DATA_SHEET",
+    "message": "Données des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_READ_ME_SHEET",
+    "message": "Lisez-moi",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEMPLATE_README_MAIN_HEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement cible",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "S'il n'y a aucune installation disponible pour la sélection, l'onglet « Liste des installations disponibles » dans le modèle sera vide. Pour créer de nouvelles données d'installation, ajoutez le nom de l'installation, ",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Pour mapper l'installation à la limite correcte, l'utilisateur doit copier le code de limite correct de la limite de la feuille « Liste des limites de campagne » sur laquelle l'installation doit être cartographiée. ",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger les données de l'installation » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Désactivation des installations existantes pour une campagne.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "Une fois que l'utilisateur a téléchargé le modèle pour les installations, si le système dispose de données d'installation existantes à réutiliser, le modèle sera pré-rempli avec la liste des installations.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "Si l'utilisateur choisit ensuite de ne pas utiliser des installations spécifiques, il peut supprimer les lignes de données pour ces installations spécifiques qui doivent être supprimées et télécharger la feuille avec uniquement les installations nécessaires à la campagne avec les codes de limite corrects mappés à ces installations.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "Si l'utilisateur a supprimé les codes d'établissement pour un établissement existant dans la liste, le système créera un établissement en double avec ces valeurs de colonne.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "Si l'utilisateur supprime des colonnes de la « Liste des installations disponibles » de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_1",
+    "message": "Création de nouvelles données d'installation/utilisation des données d'installation existantes une fois le modèle téléchargé",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_2",
+    "message": "Cas d'erreurs courantes :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_1",
+    "message": "Définition des cibles une fois le modèle téléchargé :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_2",
+    "message": "Cas d'erreurs courantes :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement de la population",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Accédez à la feuille du district pour lequel vous souhaitez définir des objectifs et ajoutez des chiffres dans la colonne « Cibles » pour chaque village.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Entrez les objectifs pour chaque village dans la feuille de chaque district sous la colonne « Cibles ». Si un village n’a pas d’objectifs définis, la feuille comportera des erreurs.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger la cible » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_5",
+    "message": "Si l'utilisateur n'a pas défini d'objectifs pour chaque village, le système générera une erreur avec le numéro de ligne où les cibles sont manquantes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_6",
+    "message": "Si l'utilisateur supprime un village de la feuille ou supprime une feuille de district complète et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_7",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_capacity",
+    "message": "Capacité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW BOUNDARY_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEWTEST0005_ADMINISTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEWTEST0005_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEWTEST0005_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEWTEST0005_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEWTEST0005_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEWTEST0005_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_ALDEIA",
+    "message": "Aldéia",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_LOCALIDADE",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_POST ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_STATE",
+    "message": "État",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "OTHER_TARGETS",
+    "message": "Autres cibles",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER",
+    "message": "Approbateur de estimation",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER",
+    "message": "Approbateur des population",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Approbateur installation racine",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Approbateur estimation racine",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER",
+    "message": "Approbateur population racine",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Svefewg4YCb",
+    "message": "Murrupule",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TARGET_HOUSEHOLDS",
+    "message": "Ménages cibles",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_CITY",
+    "message": "Ville",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_REGION",
+    "message": "Région",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_STATE",
+    "message": "État",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_WARD",
+    "message": "Salle",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_ZONE",
+    "message": "Zone",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TESTD_DISTRITO",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TO",
+    "message": "à",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Directives pour remplir la fiche utilisateur",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "Veuillez parcourir la fiche « Rôles utilisateur » pour lire et comprendre l'accessibilité de chaque rôle.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Veuillez remplir les détails de l'utilisateur (nom, numéro de contact et e-mail) dans chacune des feuilles appartenant au rôle en conséquence.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Veuillez ne pas attribuer l'utilisateur en double aux rôles d'approbateur d'estimation Microplan et d'approbateur d'estimation Microplan national.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Veuillez ne pas attribuer d'utilisateurs en double dans les rôles d'attribution de limites d'installation et d'attribution de limites d'installation nationale.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_5",
+    "message": "Veuillez ne pas attribuer d'utilisateurs en double dans les rôles d'approbateur de données démographiques et d'approbateur de données démographiques nationales.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1",
+    "message": "Téléchargement de modèles Excel pour créer des utilisateurs :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Téléchargez le modèle Excel en cliquant sur le bouton « Télécharger le modèle ».",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Ouvrez le modèle Excel téléchargé à l'étape précédente et comportera 3 feuilles et la première feuille que vous verrez est une feuille « Lisez-moi ». ",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2",
+    "message": "Création d'utilisateurs pour la campagne :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "L'administrateur système devra créer une entrée distincte pour chaque utilisateur. L'administrateur système devra ajouter le nom de l'utilisateur (obligatoire), le numéro de téléphone (obligatoire), le rôle (obligatoire), le type d'emploi (obligatoire), le code limite (obligatoire).",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Chaque utilisateur créé doit être attribué à une limite à l'aide du code de limite de la limite requise qui se trouve dans la « Liste des limites de campagne ».",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger la cible » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3",
+    "message": "Cas d'erreurs courantes :",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Si l'utilisateur n'a pas ajouté de codes limites pour toutes les entrées utilisateur, le système générera une erreur avec le numéro de ligne où le code limite est manquant.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_MAINHEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement par l'utilisateur",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN1",
+    "message": "Rôle de l'utilisateur",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN2",
+    "message": "Description",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_ROLES",
+    "message": "Rôles des utilisateurs",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE1",
+    "message": "Approbateur de l’estimation du plan",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE10",
+    "message": "Ce rôle aura accès à l'affectation de l'installation aux zones de chalandise de la limite administrative attribuée.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE11",
+    "message": "Attribuateur de limites d'installation racine",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE12",
+    "message": "Ce rôle aura accès à l'attribution et à la finalisation de l'installation dans les zones de chalandise du pays.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE13",
+    "message": "Visionneuse Microplan",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE14",
+    "message": "Ce rôle aura accès à la visualisation des estimations du microplan de la limite administrative attribuée.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE2",
+    "message": "Ce rôle aura accès à la modification des hypothèses du microplan et à l'approbation de l'estimation du microplan pour tous les villages de la limite administrative attribuée.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE3",
+    "message": "Approbateur de l’estimation du plan racine",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE4",
+    "message": "Ce rôle aura accès à la modification des hypothèses du microplan, à l'approbation et à la finalisation de l'estimation du microplan pour tous les villages du pays.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE5",
+    "message": "Approbateur des données démographiques",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE6",
+    "message": "Ce rôle aura accès à la validation et à l'approbation des données démographiques pour les villages de la limite administrative assignée.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE7",
+    "message": "Approbateur des données de population racine",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE8",
+    "message": "Ce rôle aura accès à valider, approuver et finaliser les données démographiques pour tous les villages du pays.",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE9",
+    "message": "Attribution des limites des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_DISTRICT",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_LOCALITY",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_PROVINCE",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_VILLAGE",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VFTw0jbRf1y",
+    "message": "Cavina1",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WEIGHT",
+    "message": "Poids",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "f5F6xAskA05",
+    "message": "Namula",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "facilityUsage",
+    "message": "Utilisation des installations",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_COUNTRY",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_Country",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_District",
+    "message": "District",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_Locality",
+    "message": "Localité",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_Post administrative",
+    "message": "Poste administratif",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_Province",
+    "message": "Province",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_Village",
+    "message": "Village",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_country",
+    "message": "Pays",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mz",
+    "message": "Mozambique",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "w22L4En0Zgg",
+    "message": "Nihessiué",
+    "module": "hcm-admin-schemas",
+    "locale": "fr_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/fr_MZ/hcm_admin_schemas.json
+++ b/localisation/Microplanning/v0.1/fr_MZ/hcm_admin_schemas.json
@@ -1,0 +1,38 @@
+[
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Directives pour remplir la fiche utilisateur",
+    "module": "hcm_admin_schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "Veuillez parcourir la fiche « Rôles utilisateur » pour lire et comprendre l'accessibilité de chaque rôle.",
+    "module": "hcm_admin_schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Veuillez remplir les détails de l'utilisateur (nom, numéro de contact et e-mail) dans chacune des feuilles appartenant au rôle en conséquence.",
+    "module": "hcm_admin_schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Veuillez ne pas attribuer l'utilisateur en double aux rôles d'approbateur d'estimation Microplan et d'approbateur d'estimation Microplan national.",
+    "module": "hcm_admin_schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Veuillez ne pas attribuer d'utilisateurs en double dans les rôles d'attribution de limites d'installation et d'attribution de limites d'installation nationale.",
+    "module": "hcm_admin_schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_5",
+    "message": "Veuillez ne pas attribuer d'utilisateurs en double dans les rôles d'approbateur de données démographiques et d'approbateur de données démographiques nationales.",
+    "module": "hcm_admin_schemas",
+    "locale": "fr_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/fr_MZ/rainmaker-campaignmanager.json
+++ b/localisation/Microplanning/v0.1/fr_MZ/rainmaker-campaignmanager.json
@@ -1,0 +1,4250 @@
+[
+  {
+    "code": " CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR",
+    "message": "Veuillez remplir tous les champs obligatoires.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR ",
+    "message": "Veuillez remplir tous les champs obligatoires.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " EQUAL_TO",
+    "message": "égal à",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " GREATER_THAN",
+    "message": "supérieur à",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " GREATER_THAN_EQUAL_TO",
+    "message": "supérieur ou égal à",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Code des limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Données de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Nom de la personne (obligatoire)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " HCM_PLEASE_WAIT_LOADING_BOUNDARY",
+    "message": "S'il vous plaît, attendez",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " IN_BETWEEN",
+    "message": "entre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " LESSER_THAN_EQUAL_TO",
+    "message": "inférieur ou égal à",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": " LESS_THAN",
+    "message": "moins que",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_DISTRIBUTOR",
+    "message": "Distributeur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_DISTRICT_SUPERVISOR",
+    "message": "Superviseur de district",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_HEALTH_FACILITY_WORKER",
+    "message": "Agent d'établissement de santé",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_NATIONAL_SUPERVISOR",
+    "message": "Superviseur national",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_PROVINCIAL_SUPERVISOR",
+    "message": "Superviseur provincial",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_TEAM_SUPERVISOR",
+    "message": "Superviseur d'équipe",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_WAREHOUSE_MANAGER",
+    "message": "Responsable d'entrepôt",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION",
+    "message": "Action",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_CREATE_CHECKLIST",
+    "message": "Créer une liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_CONFIGURE_APP",
+    "message": "Configurer l'application",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_RETRY",
+    "message": "Réessayer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_UPDATE_BOUNDARY_DETAILS",
+    "message": "Campagne de mise à jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_UPDATE_DATES",
+    "message": "Dates de mise à jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_VIEW_TIMELINE",
+    "message": "Télécharger les informations d'identification de l'utilisateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_",
+    "message": "Campagne de configuration",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_0HOME",
+    "message": "Maison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_1CAMPAIGN",
+    "message": "Mes campagnes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CAMPAIGN_CYCLE",
+    "message": "Faire du vélo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CAMPAIGN_HOME",
+    "message": "Maison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CAMPAIGN_MANAGER",
+    "message": "Gestionnaire de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CREATECAMPAIGN",
+    "message": "Mes campagnes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CREATE_NEW_HIERARCHY",
+    "message": "Gérer les limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_LOCALISATION",
+    "message": "Localisation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MDMS",
+    "message": "MDMS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MY_CAMPAIGN",
+    "message": "Mes campagnes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_NATIONAL",
+    "message": "National",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_PREVIEW_CAMPAIGN",
+    "message": "Aperçu de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_PROVINCIAL",
+    "message": "Provincial",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_CAMPAIGN",
+    "message": "Créer une nouvelle campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_CAMPAIGN_FROM_MICROPLAN",
+    "message": "Campagne de configuration de Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_CAMPAIGN_FROM_MICROPLAN ",
+    "message": "Campagne de configuration de Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_UPDATE_CHECKLIST",
+    "message": "Liste de contrôle de mise à jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_VIEW_CHECKLIST",
+    "message": "Voir la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_BOUNDARY_HIERARCHY_LEVEL",
+    "message": "Ajouter un niveau de hiérarchie de limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_COMMENT",
+    "message": "Ajouter un commentaire",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_COMMENT_(OR)",
+    "message": "Ajouter un commentaire (ou)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_HIERARCHY_LEVEL",
+    "message": "Ajouter un niveau hiérarchique",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_NEW_CHECKLIST",
+    "message": "Ajouter une nouvelle liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_OPTIONS",
+    "message": "Ajouter des options pour la question",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_QUESTION",
+    "message": "Ajouter une question",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AT_LEAST_ONE_FILE_REQUIRED_ERROR",
+    "message": "Erreur : au moins un fichier requis",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BACK",
+    "message": "Dos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BAD_REQUEST",
+    "message": "Erreur interne. Veuillez réessayer.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BEDNET",
+    "message": "Moustiquaire",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_DATA_FROM_GEOPODE",
+    "message": "Données de limite de GeoPoDe.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_DATA_MANAGEMENT",
+    "message": "Gestion des données limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_DOWNLOADED",
+    "message": "Données de limite téléchargées",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_DOWNLOAD_MESSAGE",
+    "message": "Téléchargez le modèle Excel contenant les données de limites sélectionnées. Une fois téléchargé, veuillez remplir le modèle avec les données cibles correctes et télécharger la feuille.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_HIERARCHY_INFO_MSG",
+    "message": "Ajoutez vos niveaux de hiérarchie de limites en cliquant sur le bouton « Ajouter un nouveau niveau de hiérarchie de limites ». Si vous souhaitez supprimer un niveau, cliquez sur l'icône de suppression à côté du niveau que vous souhaitez supprimer.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_LOCALISATION_ERROR",
+    "message": "La création de frontières a échoué. Erreur de localisation.!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MANAGEMENT",
+    "message": "Gestion des limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Les validations concernent uniquement la colonne Code de limite et la colonne Cible au niveau de limite sélectionnée.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_SHEET_UPLOADED_INVALID_ERROR",
+    "message": "Feuille Invlid",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMAPAIGN_DELIVERY_TAB_TEXT",
+    "message": "Livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ACTIONS",
+    "message": "Actes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_MORE_ATTRIBUTE_TEXT",
+    "message": "Ajouter plus d'attributs",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_MORE_DELIVERY_BUTTON",
+    "message": "Ajouter plus de conditions de livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_MORE_PRODUCT_BUTTON",
+    "message": "Ajouter des ressources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCTS_BUTTON_TEXT",
+    "message": "Ajouter des ressources à livrer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCTS_LABEL",
+    "message": "Ressources à livrer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR",
+    "message": "Veuillez remplir les champs obligatoires.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR ",
+    "message": "Veuillez remplir tous les champs obligatoires.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_START_END_DATE_TEXT",
+    "message": "Ajouter des dates de début et de fin pour les cycles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_AGE",
+    "message": "Âge (en mois)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": " Nombre de moustiquaires par ménage",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Nombre de personnes par moustiquaire",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_GENDER",
+    "message": "Sexe (homme ou femme)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_HEIGHT",
+    "message": "Hauteur (en cm)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_LABEL",
+    "message": "Attribut",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_MEMBERCOUNT",
+    "message": "Nombre de moustiquaires par ménage",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_TYPE_OF_STRUCTURE",
+    "message": "Type de structure",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_WEIGHT",
+    "message": "Poids (en Kgs)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": " Nombre de moustiquaires par ménage",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Nombre de personnes par moustiquaire",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE",
+    "message": "Type de bénéficiaire",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_PLEASE_WAIT",
+    "message": "Veuillez patienter un moment.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CANNOT_REMOVE_PREVIOUS_BOUNDARIES",
+    "message": "Impossible de supprimer les limites précédentes.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_COMPLETED",
+    "message": "Complété",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CONDITION",
+    "message": "Condition",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_COUNT_LABEL",
+    "message": "Compter",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CREATION_TAKES_SOME_TIME_PLEASE_WAIT",
+    "message": "La création d'une campagne prend un certain temps. S'il vous plaît, attendez!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE",
+    "message": "Faire du vélo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING",
+    "message": "Le nombre de cycles et de livraisons dans chaque cycle sont préchargés pour la campagne SMC",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_IRS-MZ",
+    "message": "Configuration pour la campagne IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_LLIN-MOZ",
+    "message": "Configuration spécifique au Mozambique pour les campagnes MILD",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_LLIN-MZ",
+    "message": "Configuration pour la campagne MILDA",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_MR-DN",
+    "message": "Configuration pour une campagne à plusieurs tours",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_IRS-MZ",
+    "message": "Les cycles et les livraisons de chaque cycle sont définis conformément aux directives de l’OMS pour les campagnes de « pulvérisation résiduelle en intérieur ». ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_IRS_MZ",
+    "message": "Les cycles et les livraisons de chaque cycle sont définis conformément aux directives de l’OMS pour les campagnes de « pulvérisation résiduelle en intérieur ». ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_LLIN-MZ",
+    "message": "Selon les directives de l'OMS, les MILDA doivent être distribuées tous les trois ans. Cette recommandation est basée sur la durée de vie moyenne des MILD. Sur la base de cette directive, le nombre de cycles et de livraisons est fixé à 1 chacun.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_MR-DN",
+    "message": "Veuillez noter que le nombre de cycles et d'accouchements dans chaque cycle indiqué ci-dessous sont configurés conformément aux directives fournies par l'OMS pour les campagnes de « chimioprévention du paludisme saisonnier ». Si vous souhaitez modifier le nombre de cycles ou de livraisons dans chaque cycle, vous pouvez le faire en appuyant sur les icônes « + » ou « - » des cycles et livraisons selon vos préférences.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_TAB_TEXT",
+    "message": "Faire du vélo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELETE_CONDITION_LABEL",
+    "message": "Supprimer la condition",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELETE_QUESTION",
+    "message": "Supprimer la question",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELETE_ROW_TEXT",
+    "message": "Supprimer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY",
+    "message": "Livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_DETAILS",
+    "message": "Détails de livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_RULE_LABEL",
+    "message": "État de livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_IRS",
+    "message": "Configurer les conditions de livraison pour la campagne IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_IRS-MZ",
+    "message": "Configurer les conditions de livraison pour la campagne IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_LLIN-MZ",
+    "message": "Configurer les conditions de livraison pour la campagne MILDA",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_MR-DN",
+    "message": "Configurer les conditions de livraison pour la campagne MR-DN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DETAILS",
+    "message": "Détails de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DOWNLOAD_USER_CRED",
+    "message": "Télécharger les informations d'identification de l'utilisateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DRAFTS",
+    "message": "Brouillons",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_EDIT",
+    "message": "Modifier",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE",
+    "message": "Date de fin de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_BEFORE_ERROR",
+    "message": "La date de fin de la campagne ne peut pas être antérieure à la date de début de la campagne.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_ERROR",
+    "message": "Champ obligatoire !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_SAME_ERROR",
+    "message": "La date de début et de fin d'une campagne ne peut pas être la même !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FAILED",
+    "message": "Échoué",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_ERROR_MANDATORY",
+    "message": "Champ obligatoire !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_MANDATORY",
+    "message": "Champ obligatoire !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FROM_LABEL",
+    "message": "Depuis",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_HOME",
+    "message": "Maison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_IN_BETWEEN_ERROR",
+    "message": "Le champ De doit être inférieur au champ À pour la sélection de l’opérateur Entre deux.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME",
+    "message": "Nom de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_ERROR",
+    "message": "Ce nom de campagne existe déjà ! Essayez avec un autre nom valide.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_FIELD_ERROR",
+    "message": "Champ obligatoire !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_FIELD_ERROR ",
+    "message": "Champ obligatoire !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_LONG_ERROR",
+    "message": "Erreur! Nom de campagne long ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_MISSING_TYPE_ERROR",
+    "message": "Veuillez saisir un nom de campagne !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_TOO_LONG_ERROR",
+    "message": "Le nom de la campagne ne peut pas comporter plus de 250 caractères.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NEW_PRODUCT_TEXT",
+    "message": "Vous ne trouvez pas votre ressource dans la liste des ressources ?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_CYCLE",
+    "message": "Nombre de cycles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_CYCLES",
+    "message": "Nombre de cycles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_DELIVERIES",
+    "message": "Nombre de livraisons",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_DELIVERY",
+    "message": "Nombre de livraisons",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ONGOING",
+    "message": "En cours",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_OPERATOR_LABEL",
+    "message": "Opérateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCTS_MODAL_HEADER_TEXT",
+    "message": "Configurer les ressources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCTS_MODAL_SECONDARY_ACTION",
+    "message": "Ajouter des ressources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCTS_MODAL_SUBMIT_TEXT",
+    "message": "Confirmer les ressources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_LABEL",
+    "message": "Ressource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_MISSING_ERROR",
+    "message": "Merci de remplir les ressources à livrer.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_NAME_ERROR",
+    "message": "Les champs obligatoires doivent comporter entre 2 et 100 caractères seulement.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_VARIANT_ERROR",
+    "message": "Les champs obligatoires doivent comporter entre 2 et 100 caractères seulement.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_DEFAULT1",
+    "message": "Configuration pour le type par défaut",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_IRS-MZ",
+    "message": "Campagne IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_IRS_MZ",
+    "message": "Campagne IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-MOZ",
+    "message": "Configuration spécifique au Mozambique pour les campagnes MILD",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-MZ",
+    "message": "Configuration pour la campagne MILDA",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-Moz",
+    "message": "Configuration spécifique au Mozambique pour les campagnes MILD",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-mz",
+    "message": "Configuration spécifique au Mozambique pour les campagnes MILD",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN_MOZ",
+    "message": "Configuration spécifique au Mozambique pour les campagnes MILDA",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN_MZ",
+    "message": "Configuration pour la campagne MILDA",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_MR-DN",
+    "message": "Configuration pour une campagne à plusieurs tours",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_MR_DN",
+    "message": "Configuration pour une campagne à plusieurs tours",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_SMC",
+    "message": "SMC",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_RESOURCE",
+    "message": "Ressource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SEARCH_NAME",
+    "message": "Nom de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SEARCH_TITLE",
+    "message": "Mes campagnes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SEARCH_TYPE",
+    "message": "Type de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Les limites sont les zones administratives définies dans lesquelles vous souhaitez lancer une campagne. Commencez à sélectionner les limites à partir du premier niveau afin que les limites présentes dans le niveau suivant soient disponibles pour la sélection.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARY",
+    "message": "Sélectionnez les limites où vous souhaitez lancer la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARY_BUTTON",
+    "message": "Confirmer la limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_HIERARCHY",
+    "message": "Sélectionnez la hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE",
+    "message": "Date de début de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE_ERROR",
+    "message": "La date de début doit être antérieure à la date de fin uniquement.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_STATUS_CREATING_MESSAGE",
+    "message": "La liste des utilisateurs de la campagne est en cours de création. Veuillez réessayer après un certain temps.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_ATTRIBUTES_ACTION",
+    "message": "Ajouter des attributs",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_DATE_ACTION",
+    "message": "Ajouter une date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_DELIVERY_TYPE_ACTION",
+    "message": "Ajouter un type de livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_PRODUCT_ACTION",
+    "message": "Ajouter un produit",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_VALUES_ACTION",
+    "message": "Ajouter des valeurs",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ATTRIBUTES_MISSING_ERROR",
+    "message": "Des attributs manquent dans le cycle {CYCLE_NO} de livraison {DELIVERY_NO} pour la condition de livraison {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_DATE_MISSING_ERROR",
+    "message": "Il manque des dates dans le cycle {CYCLE_NO}",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_DELIVERY_TYPE_MISSING_ERROR",
+    "message": "Type de livraison manquant dans le cycle {CYCLE_NO} de livraison {DELIVERY_NO} pour la condition de livraison {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_NA",
+    "message": "A mettre à jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_PRODUCT_MISSING_ERROR",
+    "message": "Il manque des produits dans le cycle de livraison {CYCLE_NO} {DELIVERY_NO} pour la condition de livraison {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_VALUES_MISSING_ERROR",
+    "message": "Des valeurs sont manquantes dans le cycle {CYCLE_NO} de livraison {DELIVERY_NO} pour la condition de livraison {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_INFO_TEXT_IRS-MZ",
+    "message": "Les cycles et les livraisons de chaque cycle sont définis conformément aux directives de l’OMS pour les campagnes de « pulvérisation résiduelle en intérieur ». ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_INFO_TEXT_LLIN-MZ",
+    "message": "La valeur de 1,8 pour le paramètre « Nombre de bénéficiaires par moustiquaire » est basée sur les directives de l'OMS. L'utilisateur peut choisir de modifier cette valeur si cela ne fonctionne pas pour le cas d'utilisation de son pays.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_INFO_TEXT_MR-DN",
+    "message": "Veuillez noter que les conditions énumérées ci-dessous sont configurées conformément aux directives fournies par l'OMS pour les campagnes de « chimioprévention du paludisme saisonnier ». Si vous souhaitez modifier des conditions spécifiques ou des ressources à livrer, vous pouvez le faire en modifiant les règles de livraison selon vos préférences.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT",
+    "message": "Les conditions de livraison que vous configurez à cette étape détermineront les critères d'éligibilité de vos bénéficiaires. Vous pouvez configurer plusieurs conditions de livraison en fonction des différents critères d'éligibilité suivis dans la campagne. Chaque critère d'éligibilité doit être créé en tant que condition de livraison distincte. Chaque condition pour un type de bénéficiaire individuel peut être créée en utilisant 4 attributs, à savoir l'âge, le poids, la taille et le sexe.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_IRS-MZ",
+    "message": "Configuration pour la campagne IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-MOZ",
+    "message": "Configuration spécifique au Mozambique pour les campagnes MILD",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-MZ",
+    "message": "Configuration pour la campagne MILDA",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-Moz",
+    "message": "Configuration spécifique au Mozambique pour les campagnes MILD",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-mz",
+    "message": "Configuration spécifique au Mozambique pour les campagnes MILD",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_MR-DN",
+    "message": "Configuration pour une campagne à plusieurs tours",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_TEXT",
+    "message": "Configurer les conditions de livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TO_LABEL",
+    "message": "À",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE",
+    "message": "Type de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_HOUSEHOLD",
+    "message": "Ménage",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_INDIVIDUAL",
+    "message": "Individuel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_UPCOMING",
+    "message": "Prochain",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_UPDATE_DATES",
+    "message": "Mettre à jour les dates de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_UPDATE_DATE_SUBMIT",
+    "message": "Confirmer le changement de date",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_USER_GENERATION_SUCCESS",
+    "message": "Identifiant utilisateur généré avec succès. Veuillez télécharger.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VALIDATION_INPROGRESS",
+    "message": "S'il vous plaît, attendez. La validation est en cours.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VALUE_LABEL",
+    "message": "Valeur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VALUE_ZERO_ERROR",
+    "message": "La valeur ne peut pas être nulle pour les conditions de livraison.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CANCEL",
+    "message": "Annuler",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CEMENT",
+    "message": "Ciment",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHECKLIST_CREATED_FAILED",
+    "message": "Échec de la création de la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHECKLIST_CREATED_LOCALISATION_ERROR",
+    "message": "Échec de la localisation de la liste de contrôle créée",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHECKLIST_NAME",
+    "message": "Nom de la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHECKLIST_PREVIEW",
+    "message": "Aperçu de la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHECKLIST_ROLE",
+    "message": "Rôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHECKLIST_TOBE_CONFIGURED",
+    "message": "A configurer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHECKLIST_TYPE",
+    "message": "Type de liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHECKLIST_UPDATE_FAILED",
+    "message": "Échec de la mise à jour de la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHECKLIST_UPDATE_LOCALISATION_ERROR",
+    "message": "Échec de la localisation mise à jour de la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHOOSE_MEANS_TO_CREATE_BOUNDARY",
+    "message": "Choisir les moyens de créer une limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CLAY",
+    "message": "Argile",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CLEAR",
+    "message": "Clair",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CLOSE",
+    "message": "Fermer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CMN_ALL_DATA_FETCH_DONE",
+    "message": "Toute la cartographie terminée",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CMN_ATLEAST_ONE_HIERARCHY",
+    "message": "Veuillez saisir au moins un niveau hiérarchique",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_CREATE",
+    "message": "Créer un type de hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_DATA_CREAT",
+    "message": "Données sur les limites de la Crète",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_DATA_CREATE",
+    "message": "Créer des données de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_DATA_CREATE_PREVIEW",
+    "message": "Suivant",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CMN_FILLORDELETE_CREATED_HIERARCHY",
+    "message": "Veuillez remplir tous les champs ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CMN_NOOPTION",
+    "message": "Aucune option disponible",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CM_CREATE_REQUEST",
+    "message": "Créer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CM_DRAFT_TYPE",
+    "message": "Type de brouillon",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CM_UPDATE_REQUEST",
+    "message": "Mise à jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COMMON_BACK",
+    "message": "Dos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COMMON_NO_RESULTS_FOUND",
+    "message": "Aucun résultat trouvé pour ce critère de recherche.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIGURE_CHECKLIST",
+    "message": "Configurer la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIRM_BOUNDARY_DATA",
+    "message": "Confirmer les données des limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIRM_BOUNDARY_HIERARCHY_LEVEL",
+    "message": "Confirmer le niveau de hiérarchie des limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE",
+    "message": "Créer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE_BOUNDARY_HIERARCHY",
+    "message": "Créer une hiérarchie de limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE_BOUNDARY_HIERARCHY_TYPE",
+    "message": "Gérer les limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE_CHECKLIST",
+    "message": "Configurer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE_MY_OWN_BOUNDARY_DATA",
+    "message": "Créer mes propres données de limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE_NEW_BOUNDARY_DATA",
+    "message": "Créer de nouvelles données de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE_NEW_CAMPAIGN",
+    "message": "Campagne de configuration",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE_NEW_CHECKLIST",
+    "message": "Créer une nouvelle liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATING_CAMPAIGN_BASED_ON_MICROPLAN",
+    "message": "Création d'une nouvelle campagne basée sur le Microplan sélectionné",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATION_DATE",
+    "message": "Date de création",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_ACTION_CONFIGURE_APP",
+    "message": "Configurer l'application",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_ACTION_HCM_CONFIGURE_APP",
+    "message": "Configurer l'application",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_ACTION_HCM_UPDATE_CAMPAIGN",
+    "message": "Campagne de mise à jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_ACTION_HCM_UPDATE_DATES",
+    "message": "Dates de mise à jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_ACTION_UPDATE_DATES",
+    "message": "Modifier les dates de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_BOUNDARY_dATA_NEW_RESPONSE_ACTION",
+    "message": "Afficher la limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_CHECKLIST_NEW_RESPONSE_ACTION",
+    "message": "Configurer l'application",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_COMMON_ROWS_PER_PAGE",
+    "message": "Lignes par page",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_COMMON_ROWS_PER_PAGE :",
+    "message": "Lignes par page",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_HOME",
+    "message": "Maison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CURRENT_HIERARCHIES",
+    "message": "Hiérarchies actuelles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CYCLE",
+    "message": "Faire du vélo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CYCLE 1",
+    "message": "Faire du vélo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CYCLE_NUMBER",
+    "message": "Nombre de cycles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Campaign_name_missing_type_error",
+    "message": "Veuillez remplir le champ obligatoire pour continuer.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Confirm Addition of Products",
+    "message": "Confirmer l'ajout de ressources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Create_New_Checklist",
+    "message": "Créer une nouvelle liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DATA_CREATION_IN_PROGRESS",
+    "message": "Création de données en cours",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DATA_FECTHING_FROM_SERVER",
+    "message": "Les données Microplan sont récupérées",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DATA_SYNC_WITH_SERVER",
+    "message": "Chargement...",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DELETE",
+    "message": "Supprimer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_DATE_ERROR",
+    "message": "Les dates de début et de fin des cycles de livraison sont vides. Veuillez remplir les valeurs.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_DETAILS",
+    "message": "Détails de livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_EMPTY_ERROR",
+    "message": "Le nombre de cycles et de livraisons est vide. Veuillez remplir les valeurs.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_MISMATCH_LENGTH_ERROR",
+    "message": "Les dates de début et de fin des cycles de livraison sont vides. Veuillez remplir les valeurs.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DELIVERY_NUMBER",
+    "message": "Nombre de livraisons par cycle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DELIVERY_RULES_ERROR",
+    "message": "Veuillez remplir toutes les valeurs dans les conditions de livraison ainsi que les ressources à livrer.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DIGIT_CLOSE",
+    "message": "Fermer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DIGIT_CONFIRM_SELECTION",
+    "message": "Confirmer la sélection",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DIGIT_SELECT",
+    "message": "Choisi",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DIRECT",
+    "message": "Livraison directe",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISTRICT",
+    "message": "District",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD",
+    "message": "Télécharger",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_EXCEL_TEMPLATE",
+    "message": "Télécharger le modèle Excel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_EXCEL_TEMPLATE_FOR_BOUNDARY",
+    "message": "Télécharger le modèle Excel pour la limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_TEMPLATE_BOUNDARY",
+    "message": "Télécharger le modèle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_THE_FACILITY_TEMPLATE",
+    "message": "Téléchargement du modèle d'installation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_THE_TARGET_TEMPLATE",
+    "message": "Téléchargement du modèle cible",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_THE_USER_TEMPLATE",
+    "message": "Téléchargement du modèle utilisateur ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DRUG",
+    "message": "Médicament",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DUPLICATE_RECORD",
+    "message": "La hiérarchie des limites avec le tenantId et le type de hiérarchie fournis existe déjà",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EDIT_BOUNDARY_DATA",
+    "message": "Modifier les données de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EMPTY_TEMPLATE_GENERTAION_NOTCOMPLETED_STILL_PROCEEDING",
+    "message": "Le délai de génération du modèle a expiré. Récupération de Microplan en cours.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "END_DATE",
+    "message": "Date de fin",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EQUAL_TO",
+    "message": "Égal à",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_FETCHING_CAMPAIGN",
+    "message": "Erreur lors de la récupération des données de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_WHILE_DOWNLOADING",
+    "message": "Un problème a été détecté lors du téléchargement du modèle. Veuillez réessayer plus tard.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_HRMS_INVALID_CITY",
+    "message": "Veuillez sélectionner un nom de ville valide.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_ADD_PRODUCT_TITLE",
+    "message": "Ressource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_BOUNDARY_DATA_CREATED_SUCCESS_RESPONSE",
+    "message": "Données de limite créées avec succès !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_BOUNDARY_SUMMARY_HEADING",
+    "message": "Résumé des détails des limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_ADD_PRODUCT_BUTTON",
+    "message": "Confirmer l'ajout de ressources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_ADD_PRODUCT_LINK",
+    "message": "Ajouter une nouvelle ressource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_BOUNDARY_MODAL_BACK",
+    "message": "Oui",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_BOUNDARY_MODAL_SUBMIT",
+    "message": "Non",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_CHANGE_DATE_CONFIRM",
+    "message": "Êtes-vous sûr de vouloir modifier les dates ?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_CREATE_SUCCESS_RESPONSE",
+    "message": "Données de campagne enregistrées avec succès !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_CREATE_SUCCESS_RESPONSE_TEXT",
+    "message": "Les données de la campagne ont été capturées avec succès et la création de la campagne prendra quelques minutes. Une fois la campagne créée, vous pouvez télécharger les informations d'identification de l'utilisateur et d'autres données de campagne à partir de l'écran « Mes campagnes ».",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_DATE_CHANGE_SUCCESS",
+    "message": "La date a été modifiée avec succès",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_DATE_CHANGE_WITH_BOUNDARY_SUCCESS",
+    "message": "La date a été modifiée avec succès pour les limites sélectionnées !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_DOWNLOAD_USER_DETAILS",
+    "message": "Télécharger les informations d'identification de l'utilisateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_NO_DOCUMENTS_AVAILABLE",
+    "message": "Veuillez télécharger une feuille Excel valide.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_RESPONSE_ACTION",
+    "message": "Rentrer à la maison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_SUCCESS_INFO_TEXT",
+    "message": "ID de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_TIMELINE",
+    "message": "Chronologie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_BOUNDARY_MODAL_HEADER",
+    "message": "Êtes-vous sûr de vouloir mettre à jour les limites de votre campagne ?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_BOUNDARY_MODAL_TEXT",
+    "message": "Si vous modifiez les données de limite de campagne à cette étape, le(s) fichier(s) téléchargé(s) pour les étapes suivantes seront supprimés.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_TYPE_MODAL_HEADER",
+    "message": "Êtes-vous sûr de vouloir mettre à jour le type de campagne ?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_TYPE_MODAL_TEXT",
+    "message": "Si vous modifiez le type de campagne à cette étape, toutes les données seront supprimées.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_HEADER",
+    "message": "Télécharger le modèle Excel pour la cible",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_TEXT",
+    "message": "Téléchargez le modèle Excel contenant les données de limites sélectionnées. Une fois téléchargé, veuillez remplir le modèle avec les données cibles correctes et télécharger la feuille.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_HEADER",
+    "message": "Télécharger le modèle Excel pour les données des installations",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_TEXT",
+    "message": "Téléchargez le modèle Excel qui contient la liste des installations permanentes et la liste des données de limites sélectionnées. Une fois téléchargé, veuillez remplir le modèle avec les données correctes de l'établissement et télécharger la feuille.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_FACILITY_DATA_TEXT",
+    "message": "Téléchargez le modèle Excel qui contient la liste des installations permanentes et la liste des données de limites sélectionnées. Une fois téléchargé, veuillez remplir le modèle avec les données correctes de l'établissement et télécharger la feuille.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_USER_DATA_MODAL_HEADER",
+    "message": "Téléchargez le modèle Excel pour les détails de l'utilisateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_USER_DATA_MODAL_TEXT",
+    "message": "Téléchargez le modèle Excel contenant les données de limites sélectionnées. Une fois téléchargé, veuillez remplir le modèle avec les données utilisateur correctes et télécharger la feuille.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_USER_DATA_MODAL_TEXT ",
+    "message": "Téléchargez le modèle Excel contenant les données de limites sélectionnées. Une fois téléchargé, veuillez remplir le modèle avec les données utilisateur correctes et télécharger la feuille.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CHECKLIST_CREATE_SUCCESS_RESPONSE",
+    "message": "Liste de contrôle créée avec succès",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CHECKLIST_RESPONSE_ACTION",
+    "message": "Accéder à mes campagnes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CHECKLIST_UPDATE_SUCCESS_RESPONSE",
+    "message": "Liste de contrôle mise à jour avec succès",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_SEARCH",
+    "message": "Clair",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_PLEASE_ENTER_ALL_MANDATORY_FIELDS",
+    "message": "Veuillez saisir un nom de campagne valide pour passer à l'étape suivante.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_SEARCH",
+    "message": "Recherche",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_TAKE_ACTION",
+    "message": "Passez à l'action",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_FORGOT_PASSWORD_DESC",
+    "message": "Veuillez saisir le numéro de mobile de l'utilisateur.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE",
+    "message": "Ressource créée avec succès !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_BOLD_TEXT",
+    "message": "Ressource à livrer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_POST_TEXT",
+    "message": "liste déroulante dans la fenêtre contextuelle de configuration des ressources.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_PRE_TEXT",
+    "message": "Les ressources nouvellement créées seront renseignées dans le ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_TEXT",
+    "message": "Les ressources nouvellement créées seront renseignées dans la liste déroulante « Ressource à livrer » dans la fenêtre contextuelle de configuration des ressources.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_RESPONSE_ACTION",
+    "message": "Retourner",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_REQUIRED",
+    "message": "Requis",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_TQM_SUMMARY_HEADING",
+    "message": "Résumé",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "End Date",
+    "message": "Date de fin",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1",
+    "message": "Cas où il n'y a pas de données d'installation dans le système :",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_1",
+    "message": "Étape 1 : Lorsqu'il n'y a pas de données d'établissement dans le système, le modèle « Liste des établissements disponibles » sera vide. Pour chaque établissement ajouté, l'utilisateur doit saisir le nom de l'établissement (doit être unique), le type d'établissement (entrepôt/établissement de santé), le statut de l'établissement (temporaire/permanent), la capacité (saisie du numéro)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_2",
+    "message": "Étape 2 : Pour cartographier les installations sur une limite donnée, l'utilisateur doit copier le code de limite correct à partir de la feuille « Données de limite ». S'il existe plusieurs limites auxquelles une installation doit être mappée, l'utilisateur peut ajouter tous les codes de limite séparés par des virgules.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_3",
+    "message": "Étape 3 : Pour chaque installation, l'utilisateur doit ajouter Actif ou Inactif pour toutes les installations dans la colonne « Utilisation des installations ». Toutes les installations marquées comme « Actives » seront utilisées dans la campagne en cours de création, celles marquées « Inactives » ne seront pas utilisées dans la campagne en cours de création.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_4",
+    "message": "Étape 4 : Une fois toutes les fonctionnalités ajoutées, l'utilisateur doit enregistrer le fichier sur son système et télécharger le fichier en appuyant sur l'option « Parcourir dans mes fichiers ».",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2",
+    "message": "Cas où il existe des données d'installation existantes dans le système :",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_1",
+    "message": "Étape 1 : Lorsque vous ouvrez le modèle d'installation téléchargé, veuillez vous référer à la feuille Liste des installations disponibles. Pour les installations existantes, veuillez ajouter des entrées dans la colonne Code limite. Vous pouvez trouver les codes de limites dans la feuille de données des limites. Si une installation correspond à plusieurs limites, veuillez séparer les codes par des virgules.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_2",
+    "message": "Étape 2 : Dans cette étape, l'utilisateur devra ajouter des entrées dans la colonne Utilisation de l'installation avec des entrées valides étant soit Actives, soit Inactives, où l'utilisateur peut définir l'utilisation d'une installation sur Active si l'installation est utilisée pour une campagne ou bien. peut être réglé sur Inactif. Les entrées dans la colonne Utilisation des installations doivent être ajoutées pour toutes les entrées.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_3",
+    "message": "Étape 3 : Pour ajouter de nouveaux établissements qui ne sont pas présents dans la liste des établissements existants, l'utilisateur doit saisir le nom de l'établissement (doit être unique), le type d'établissement (entrepôt/établissement de santé), le statut de l'établissement (temporaire/permanent), la capacité. (Saisie du numéro), code de limite (à partir de la fiche de données de limite) et utilisation des installations (actif/inactif) comme expliqué précédemment",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_4",
+    "message": "Étape 4 : Une fois toutes les fonctionnalités ajoutées, l'utilisateur doit enregistrer le fichier sur son système et télécharger le fichier en appuyant sur l'option « Parcourir dans mes fichiers ».",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITY_DETAILS",
+    "message": "Détails de l'installation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITY_DETAILS_ERROR",
+    "message": "Veuillez ajouter le fichier Excel des détails de l'installation.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITY_FILE_MISSING",
+    "message": "La fiche d'installation est manquante.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FEMALE",
+    "message": "Femelle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FETCHED_ALLMAPPING_DATA_FROM_MICROPLAN",
+    "message": "Récupération de toutes les données cartographiques de Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_BOUNDARIRES_FROM_MICROPLAN",
+    "message": "Récupérer les limites de la campagne depuis Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_DATA_FROM_MICROPLAN",
+    "message": "Récupération des données de campagne depuis Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_FACILITY_FROM_MICROPLAN",
+    "message": "Récupération des données des installations à partir de la cartographie des bassins versants des installations de Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_TARGET_FROM_MICROPLAN",
+    "message": "Récupération des données cibles approuvées à partir des données de recensement de Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_TYPE_FROM_MICROPLAN",
+    "message": "Récupération du type de campagne depuis Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_USER_FROM_MICROPLAN",
+    "message": "Récupération des utilisateurs de campagne requis pour la campagne en fonction de la formule et des hypothèses de Microplan ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FETCHING_MICROPLAN_DATA",
+    "message": "Récupération des données Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FILE_UPLOADED_SUCCESSFULLY",
+    "message": "Fichier téléchargé avec succès !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FILE_UPLOAD_FAILED",
+    "message": "Échec du téléchargement du fichier",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FILLING_CAMPAIGN_FACILITY_DATA_FROM_MICROPLAN",
+    "message": "Données des installations de remplissage de Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FILLING_CAMPAIGN_TARGET_DATA_FROM_MICROPLAN",
+    "message": "Remplissage des données cibles de campagne à partir de Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FILLING_CAMPAIGN_USER_DATA_FROM_MICROPLAN",
+    "message": "Remplissage des données utilisateur de la campagne depuis Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FROM_DATE",
+    "message": "Date de début",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "From_date",
+    "message": "À partir du jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GENERATING_ALL_THE_TEMPLATES",
+    "message": "Générer tous les modèles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GET_BOUNDARY_DATA_FROM_GEOPODE",
+    "message": "Obtenez des données de limites à partir de GeoPoDe",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GLASS",
+    "message": "Verre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GREATER_THAN",
+    "message": "Plus grand que",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GREATER_THAN_EQUAL_TO",
+    "message": "Supérieur ou égal à",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_AVAILABLE_FACILITIES",
+    "message": "Liste des installations disponibles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Code des limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_OLD",
+    "message": "Ancien code de délimitation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Données de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY",
+    "message": "Capacité (Unités : Balles pour moustiquaires/Blister SPAQ pour SMC)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CODE",
+    "message": "Code de l'établissement",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME",
+    "message": "Nom de l'établissement",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS",
+    "message": "Statut de l'établissement",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE",
+    "message": "Type d'établissement",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE",
+    "message": "Utilisation des installations",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LAT",
+    "message": "Latitude",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LONG",
+    "message": "Longitude",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_AT_THE_SELECTED_BOUNDARY_LEVEL",
+    "message": "Cible au niveau de la limite sélectionnée",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LAT_OPT",
+    "message": "Latitude (facultatif)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LONG_OPT",
+    "message": "Longitude (facultatif)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Population cible",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Population cible (âge 12-59 mois)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Population cible (âge 3-11 mois)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC",
+    "message": "Cible au niveau du village (Obligatoire et à saisir par l'utilisateur)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Population totale",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMPLOYMENT_TYPE",
+    "message": "Type d'emploi (obligatoire)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LIST",
+    "message": "Créer une liste d'utilisateurs",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LISTTTTTTTT",
+    "message": "Liste des utilisateurs",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Nom de la personne (obligatoire)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER",
+    "message": "Numéro de téléphone (obligatoire)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBERRR",
+    "message": "Numéro de téléphone (obligatoire)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_ROLE",
+    "message": "Rôle (obligatoire)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BACK",
+    "message": "Dos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BENEFICIARY_TYPE",
+    "message": "Type de bénéficiaire",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_CLOSE",
+    "message": "Fermer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_DETAILS",
+    "message": "Détails des limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_DETAILS_VERTICAL",
+    "message": "Détails des limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INF0",
+    "message": "Si vous ne trouvez pas votre hiérarchie de limites, veuillez contacter l'équipe L1 au ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INF0 ",
+    "message": "Si vous ne trouvez pas votre hiérarchie de limites, veuillez contacter l'équipe L1 au ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INFO",
+    "message": "Si vous ne trouvez pas votre hiérarchie de limites, veuillez contacter l'équipe L1 au ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INFO ",
+    "message": "Si vous ne trouvez pas votre hiérarchie de limites, veuillez contacter l'équipe L1 au ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_MESSAGE",
+    "message": "Veuillez remplir le modèle téléchargé avec les données cibles et télécharger la feuille Excel.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION",
+    "message": "Veuillez ajouter vos nouvelles ressources. Les ressources nouvellement créées seront renseignées dans la liste déroulante « Ressources à livrer » dans la fenêtre contextuelle de configuration des ressources.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION_BOLD_TEXT",
+    "message": "Ressource à livrer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION_POST_TEXT",
+    "message": "liste déroulante dans la fenêtre contextuelle de configuration des ressources.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION_PRE_TEXT",
+    "message": "Veuillez ajouter vos nouvelles ressources. Les ressources nouvellement créées seront renseignées dans le ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_HEADER",
+    "message": "Ajouter une nouvelle ressource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ALL_THE_LEVELS_ARE_MANDATORY",
+    "message": "Veuillez remplir tous les champs obligatoires.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CHILD_NOT_PRESENT",
+    "message": "les limites des niveaux inférieurs sont manquantes. Veuillez sélectionner les limites jusqu'au niveau le plus bas.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CREATION",
+    "message": "Campagne créée avec succès",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CREATION_PROGRESS",
+    "message": "Progression de la création de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATE",
+    "message": "Date de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES",
+    "message": "Dates de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_CHANGE_BOUNDARY_HEADER",
+    "message": "Modifier les dates de campagne pour des limites spécifiques",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_CHANGE_BOUNDARY_SUB_TEXT",
+    "message": "Sélectionnez vos limites pour modifier les dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_DESCRIPTION",
+    "message": "Choisissez votre campagne « Date de début » et « Date de fin ». Les dates une fois sélectionnées refléteront les étapes à venir pour configurer la campagne.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_HEADER",
+    "message": "Quelle est la date de début et de fin de la campagne ?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATE_MISSING",
+    "message": "Veuillez saisir la date de début et de fin de la campagne !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS",
+    "message": "Détails de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS_SUMMARY",
+    "message": "Résumé détaillé de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DOWNLOAD_TEMPLATE",
+    "message": "Télécharger le modèle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_END_DATE_BEFORE_START_DATE",
+    "message": "La date de début de la campagne ne peut pas être postérieure à la date de fin de la campagne.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_END_DATE_EQUAL_START_DATE",
+    "message": "Les dates de début et de fin d'une campagne ne peuvent pas être les mêmes.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_FOR",
+    "message": "Pour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME",
+    "message": "Nom de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME_DESCRIPTION",
+    "message": "Veuillez nommer votre campagne. La meilleure pratique pour nommer votre campagne consiste à utiliser une combinaison du type de campagne configurée, des mois et des années de la campagne et de la limite où la campagne est diffusée.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME_EXAMPLE",
+    "message": "Exemple de nom : CampaignType_Boundary_Dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME_HEADER",
+    "message": "Quel est le nom de votre campagne ?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SELECT_BOUNDARY_DATA_LABEL",
+    "message": "Sélectionner une limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SELECT_BOUNDARY_HIERARCHY_LEVEL",
+    "message": "Sélectionnez un niveau hiérarchique",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SETUP_DETAILS",
+    "message": "Détails de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SUCCESS_RESPONSE_ACTION",
+    "message": "Accéder à mes campagnes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE",
+    "message": "Type de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE_DESCRIPTION",
+    "message": "Le type de campagne déterminera le type de bénéficiaire de votre campagne. Vos règles de livraison seront préchargées en fonction du type de campagne que vous sélectionnez.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE_HEADER",
+    "message": "Quel type de campagne souhaitez-vous lancer ?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_UPLOAD_CANCEL",
+    "message": "Annuler",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_ACTION",
+    "message": "Action",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_CLEAR",
+    "message": "Clair",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_CREATE",
+    "message": "Configurer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_OPTION",
+    "message": "Option",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_QUESTION",
+    "message": "Question",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_ROLE",
+    "message": "Sélectionnez un rôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_STATUS",
+    "message": "Statut",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_ELIGIBILITY",
+    "message": "Admissibilité",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_ASMT",
+    "message": "Évaluation des établissements de santé",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_DRUG_SE_CC",
+    "message": "Orientation vers un établissement de santé : effet secondaire du médicament du cycle en cours",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_DRUG_SE_PC",
+    "message": "Orientation vers un établissement de santé : effet secondaire du médicament du cycle précédent",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_FEVER",
+    "message": "Référence à un établissement de santé : Fièvre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_SICK",
+    "message": "Référence établissement de santé : Malade",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_IEC",
+    "message": "CEI",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_TEAM_FORMATION",
+    "message": "Formation d'équipe",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_TRAINING_SUPERVISION",
+    "message": "Supervision de la formation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_WAREHOUSE",
+    "message": "Entrepôt",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_VIEW",
+    "message": "Voir",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CHECK_FILE_AGAIN",
+    "message": "Il y a quelques erreurs dans la feuille. Veuillez télécharger à nouveau le fichier téléchargé.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CLEAR_ALL",
+    "message": "Tout effacer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CONFIGURE_APP",
+    "message": "Configurer l'application",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CONFIGURE_APP_RESPONSE_ACTION",
+    "message": "Configurer l'application",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CONFIRMING_RESOURCE_CREATION",
+    "message": "Création de ressources",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CREATE_BOUNDARY_HIERARCHY",
+    "message": "Créer une nouvelle hiérarchie de frontières",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CURRENT",
+    "message": "Actuel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CYCLES",
+    "message": "Cycles & Livraisons",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DATA_ALLOWED_VALUES_ARE",
+    "message": ". Les valeurs autorisées sont :",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DATA_AT_ROW",
+    "message": "Données à la ligne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_10_DIGIT",
+    "message": "Le numéro de téléphone (obligatoire) doit être un numéro à 10 chiffres.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_GREATER_THAN_ZERO",
+    "message": "doit être supérieur à 0",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_LESS_THAN_MAXIMUM",
+    "message": "devrait être inférieur à cent millions",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_NUMBER",
+    "message": "devrait être un nombre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_NOT_BE_EMPTY",
+    "message": "ne devrait pas être vide",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DATA_UPLOAD",
+    "message": "Téléchargement de données",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DATA_UPLOAD_SUMMARY",
+    "message": "Résumé du téléchargement des données",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DATE_CHANGE_SUCCESS_RESPONSE_ACTION",
+    "message": "Retour au résumé de la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_DETAILS",
+    "message": "Détails de livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_DETAILS_SUMMARY",
+    "message": "Résumé des détails de la livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_RULES",
+    "message": "Règles de livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_TYPE",
+    "message": "Type de livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_EMPTY_SHEET",
+    "message": "La feuille téléchargée ne doit pas être vide.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_END_DATE",
+    "message": "Date de fin",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ERROR",
+    "message": "Erreur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ERROR_INVALID_FILE_TYPE",
+    "message": "Veuillez télécharger un fichier Excel valide selon le modèle uniquement.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ERROR_MORE_THAN_ONE_FILE",
+    "message": "Un seul fichier valide de feuille Excel peut être téléchargé.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_CREATION",
+    "message": "Création d'installations",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_DETAILS",
+    "message": "Détails de l'installation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_MAPPING",
+    "message": "Installations mappées à la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_MESSAGE",
+    "message": "Veuillez remplir le modèle téléchargé avec les données de l'établissement et télécharger la feuille Excel.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_USAGE_VALIDATION",
+    "message": "Veuillez remplir la colonne requise « Utilisation des installations » avec Actif/Inactif uniquement. Au moins une « utilisation des installations » doit être active.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_FETCH_FROM_PLAN_INFO",
+    "message": "Générer un objet de campagne à partir du Microplan sélectionné, récupérer les données Microplan, créer un modèle de campagne vide, ajouter des dates à la feuille générée, valider les données de terrain et mettre à jour les feuilles avec les détails de la campagne : veuillez patienter pendant que le processus de récupération des données est finalisé.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_FILE_VALIDATION",
+    "message": "La validation du fichier a échoué. Veuillez télécharger le fichier de données correct.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_FILE_VALIDATION_ERROR",
+    "message": "Veuillez télécharger un fichier valide.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_FILE_VALIDATION_PROGRESS",
+    "message": "La validation du dossier est en cours.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_HIERARCHY_TYPE",
+    "message": "Type de hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_INVALID_BOUNDARY_SHEET",
+    "message": "L'une des feuilles du fichier téléchargé semble porter un nom incorrect. Veuillez télécharger à nouveau le modèle et le télécharger avec les données correctes.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_INVALID_FACILITY_SHEET",
+    "message": "L'une des feuilles du fichier téléchargé semble porter un nom incorrect. Veuillez télécharger à nouveau le modèle et le télécharger avec les données correctes.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_INVALID_USER_SHEET",
+    "message": "L'une des feuilles du fichier téléchargé semble porter un nom incorrect. Veuillez télécharger à nouveau le modèle et le télécharger avec les données correctes.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_IN_COLUMN",
+    "message": "en colonne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_IS_INVALID",
+    "message": "est invalide.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_IS_MAXIMUM_VALUE",
+    "message": "devrait être inférieur à 100 millions",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_LEVEL",
+    "message": "Niveau",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_LEVEL_IS_MANDATORY",
+    "message": "Veuillez remplir les champs obligatoires.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MANAGE_CHECKLIST",
+    "message": "Gérer la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MISSING_HEADERS",
+    "message": "Une ou plusieurs colonnes ou en-têtes sont manquants dans le fichier téléchargé et ne correspondent pas au modèle. Veuillez télécharger à nouveau le modèle et télécharger le modèle correct avec les données.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MISSING_TARGET",
+    "message": "Les valeurs de la colonne cible sont manquantes ou incorrectes. Veuillez remplir les valeurs de 1 à 100 000 uniquement.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_NEXT",
+    "message": "Suivant",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_PLEASE_WAIT",
+    "message": "S'il vous plaît, attendez",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_PLEASE_WAIT_LOADING_BOUNDARY",
+    "message": "Veuillez patienter un moment.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_PLEASE_WAIT_TRY_IN_SOME_TIME",
+    "message": "Veuillez patienter. La génération du modèle est en cours.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_PRODUCT_NAME",
+    "message": "Nom de la ressource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_PRODUCT_TYPE",
+    "message": "Type de ressource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_PRODUCT_VARIANT",
+    "message": "Variante de ressource",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_RESOURCE_MAPPING",
+    "message": "Ressources ajoutées à la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_REVIEW_DETAILS",
+    "message": "Résumé",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_SELECTED",
+    "message": "Choisi",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_SELECT_BOUNDARY",
+    "message": "Veuillez sélectionner la hiérarchie des limites pour avancer.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_SHOW_LESS",
+    "message": "Afficher moins d'étapes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_SHOW_LESS_ALL",
+    "message": "Afficher moins",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_SHOW_LESS_SELECTED",
+    "message": "Afficher moins de sélection",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_SHOW_MORE",
+    "message": "Afficher plus d'étapes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_SHOW_MORE_ALL",
+    "message": "Afficher plus",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_STAFF_CREATION",
+    "message": "Création d'utilisateurs d'application",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_STAFF_MAPPING",
+    "message": "Utilisateurs de l'application mappés à la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_START_DATE",
+    "message": "Date de début",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_SUBMIT",
+    "message": "Créer une campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_SUMMARY",
+    "message": "Résumé",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_TARGETS",
+    "message": "Détails de la cible",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_TARGET_AND_DELIVERY_RULES_CREATION",
+    "message": "Création de règles de cibles et de livraison",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_TARGET_VALIDATION_ERROR",
+    "message": "Les valeurs cibles doivent être supérieures à 0 et inférieures à 100 000.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_TIMELINE",
+    "message": "Chronologie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPCOMING",
+    "message": "Prochain",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPDATE",
+    "message": "Mettre à jour la campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPDATE_DATE",
+    "message": "Mettre à jour les dates de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPDATE_DATE_INFO",
+    "message": "La date de début sélectionnée est déjà passée, vous avez donc été redirigé vers l'écran Dates de campagne. Cliquez sur 'Suivant' pour enregistrer les modifications que vous avez apportées",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_BOUNDARY",
+    "message": "Gérer les limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_DATA",
+    "message": "Télécharger des données",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_FACILITY",
+    "message": "Télécharger les données de l'établissement",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_FACILITY_DATA",
+    "message": "Télécharger les données de l'établissement",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_TARGET",
+    "message": "Télécharger les données cibles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_TARGET_DATA",
+    "message": "Télécharger les données cibles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_USER",
+    "message": "Télécharger les données utilisateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_USER_DATA",
+    "message": "Télécharger les données utilisateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_USER_DETAILS",
+    "message": "Détails de l'utilisateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_USER_MESSAGE",
+    "message": "Veuillez remplir le modèle téléchargé avec les données utilisateur et télécharger la feuille Excel.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_COMPLETED",
+    "message": "La validation du fichier est terminée et réussie.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_FAILED",
+    "message": "Le processus de validation du fichier a échoué.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_IN_PROGRESS",
+    "message": "Validation en cours",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_VIEW_PROGRESS",
+    "message": "Afficher la progression",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHY",
+    "message": "Type de hiérarchie de limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_ADMINISTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHY_CREATED_SUCCESSFULLY",
+    "message": "Hiérarchie créée avec succès",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHY_CREATION_FAILED",
+    "message": "La création de la hiérarchie a échoué ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHY_NAME",
+    "message": "Nom de la hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHY_PLEASE_WAIT",
+    "message": "Veuillez patienter quelques minutes pendant la création de la hiérarchie des limites.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHY_PLEASE_WAIT ",
+    "message": "Créer une hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HOUSEHOLD",
+    "message": "Ménage",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INDIRECT",
+    "message": "Livraison indirecte",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INDIVIDUAL",
+    "message": "Individuel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INTERNAL_SERVER_ERROR",
+    "message": "Erreur interne du serveur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INVALID_FILE_FORMAT",
+    "message": "Format de fichier invalide. Veuillez télécharger le fichier .xlsx ou .xls",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "IN_BETWEEN",
+    "message": "Entre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "IRS-mz",
+    "message": "Campagne IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LAST_MODIFIED_TIME",
+    "message": "Heure de la dernière modification",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LESSER_THAN_EQUAL_TO",
+    "message": "Inférieur ou égal à",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LESS_THAN",
+    "message": "Moins que",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LESS_THAN_EQUAL_TO",
+    "message": "Inférieur ou égal à",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LEVEL",
+    "message": "Niveau",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LEVELS",
+    "message": "Niveaux",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LEVELS_CANNOT_BE_EMPTY",
+    "message": "Les niveaux ne peuvent pas être vides.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LINK_NESTED_CHECKLIST",
+    "message": "Liste de contrôle imbriquée de liens",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN-Moz",
+    "message": "Configuration spécifique au Mozambique pour les campagnes MILD",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN-mz",
+    "message": "Configuration pour la campagne MILDA",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MALE",
+    "message": "Mâle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MASTER_LANDING_SCREEN_BOUNDARY_SETTINGS",
+    "message": "Définition des limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MASTER_LANDING_SCREEN_CHECKLIST",
+    "message": "Liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MASTER_LANDING_SCREEN_MASTER_LANDING_SETTING",
+    "message": "Réglage principal",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "METAL",
+    "message": "Métal",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "METAL/GLASS",
+    "message": "Métal / Verre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "METAL_OR_GLASS",
+    "message": "Métal / Verre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_COMPELTED_STEPS",
+    "message": "Complété ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_OUT_OFF",
+    "message": "sortir de ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR-DN",
+    "message": "Configuration pour une campagne à plusieurs tours",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MSG",
+    "message": "Ajoutez vos niveaux de hiérarchie de limites en cliquant sur le bouton « Ajouter un nouveau niveau de hiérarchie de limites ». Si vous souhaitez supprimer un niveau, cliquez sur l'icône de suppression à côté du niveau que vous souhaitez supprimer.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MY_CAMPAIGN",
+    "message": "Mes campagnes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MY_FETCH_FROM_MICROPLAN_HEADING",
+    "message": "Récupérer des données à partir de Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MY_MICROPLANS_HEADING",
+    "message": "Microplans approuvés",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MultiValueList",
+    "message": "Case à cocher",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NAME_OF_CHECKLIST",
+    "message": "Nom de la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NAME_OF_MICROPLAN",
+    "message": "Nom du microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW13_ADMINISTRATIVEPOST",
+    "message": "POAST ADMINISTRATIF",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW13_COUNTRY",
+    "message": "PAYS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW13_DISTRICT",
+    "message": "DISTRICT",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW13_LOCALITY",
+    "message": "LOCALITÉ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW13_PROVINCE",
+    "message": "PROVINCE",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW13_VILLAGE",
+    "message": "VILLAGE",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEWLY_ADDED_BOUNDARY_DATA",
+    "message": "Données de limite nouvellement ajoutées",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEXT",
+    "message": "Suivant",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO",
+    "message": "Non",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_CAMPAIGN_DETAILS_FOUND_FOR_GIVEN_CAMPAIGN_ID",
+    "message": "Veuillez réessayer en cliquant sur le bouton « Enregistrer et continuer ».",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_DOCUMENTS_AVAILABLE",
+    "message": "Aucun document disponible pour les informations d'identification.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Number of Individuals per bed net",
+    "message": "Nombre de personnes par moustiquaire",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "OTHER",
+    "message": "Autre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "OTHERS",
+    "message": "Autres",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "OTHER_TARGETS",
+    "message": "Autres cibles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLEASE_WAIT_AND_RETRY_AFTER_SOME_TIME",
+    "message": "La génération est en cours. Veuillez réessayer après un certain temps",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLS_WAIT_UNTIL_PAGE_REDIRECTS",
+    "message": "L'écran reçoit une redirection automatique vers la campagne de configuration. Veuillez patienter. La récupération des données est en cours.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PREVIEW_CHECKLIST",
+    "message": "Aperçu de la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PREVIEW_ON_MAP",
+    "message": "Aperçu sur la carte",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PROJECT_TYPE_UNDEFINED_ERROR",
+    "message": "Veuillez sélectionner un type de campagne pour passer à l'étape suivante.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "QUESTION",
+    "message": "Question",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "REEDS",
+    "message": "Roseaux",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "REQUIRED",
+    "message": "Requis",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESIDUAL_SPRAY",
+    "message": "Pulvérisation",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROLE",
+    "message": "Rôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_BOUNDARY_LEVEL_ERROR",
+    "message": "Veuillez d'abord sélectionner les limites.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_CHECKLIST_TYPE",
+    "message": "Sélectionnez le type de liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_HIERARCHY_AND_BOUNDARY_ERROR",
+    "message": "Veuillez d'abord sélectionner Hiérarchie et limite.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SHORT_ANSWER",
+    "message": "Réponse courte",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SOME_ERROR_OCCURED_IN_FETCH",
+    "message": "Erreur lors de la récupération",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SOME_ERROR_OCCURED_IN_FETCH_RETRYING",
+    "message": "Erreur lors de la récupération, réessayez !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "START_DATE",
+    "message": "Date de début",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "STATUS",
+    "message": "Statut",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Search",
+    "message": "Recherche",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SingleValueList",
+    "message": "Bouton radio",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Start Date",
+    "message": "Date de début",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TABLET",
+    "message": "Comprimé",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TARGET_DETAILS",
+    "message": "Détails de la cible",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TARGET_DETAILS_ERROR",
+    "message": "Veuillez ajouter le fichier Excel des détails de la cible.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TARGET_FILE_MISSING",
+    "message": "La feuille cible est manquante",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATED_SUCCESSFULLY",
+    "message": "Modèle généré avec succès",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATED_SUCCESSFULLY ",
+    "message": "Modèle généré avec succès",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_FAILED",
+    "message": "Échec de la génération du modèle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_IN_PROGRESS",
+    "message": "Génération de modèle en cours",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_IN_PROGRESS ",
+    "message": "Création d'un modèle de hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_TIMEOUT",
+    "message": "Échec de la génération du modèle. Erreur de délai d'attente !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TONIC",
+    "message": "Tonique",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TO_DATE",
+    "message": "Date de fin",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TRANSGENDER",
+    "message": "Transgenre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TYPE_OF_CHECKLIST",
+    "message": "Type de liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TYPE_OF_STRUCTURE",
+    "message": "Type de structure",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TYPE_YOUR_QUESTION_HERE",
+    "message": "Tapez votre question ici ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "To_date",
+    "message": "À ce jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPDATED_CAMPAIGN_WITH_UPLODAED_DATA",
+    "message": "Campagne mise à jour avec des ressources téléchargées",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPDATE_CAMPAIGN",
+    "message": "Campagne de mise à jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPDATE_CHECKLIST",
+    "message": "Liste de contrôle de mise à jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_AND_CYCLE_HEADER",
+    "message": "Dates et cycle de mise à jour",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE",
+    "message": "Modifier les dates de campagne",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE_INFO_TEXT",
+    "message": "1. La date de début et la date de fin de la campagne ne peuvent pas être mises à jour si elles sont au moins 24 heures à l'avance à partir de l'heure actuelle et si elles commencent après le lendemain.                           2. Les dates de cycle ne peuvent pas être choisies comme dates passées par rapport à la date d'aujourd'hui.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE_INFO_TEXT1",
+    "message": "1. La date de début et la date de fin de la campagne ne peuvent pas être mises à jour si elles sont au moins 24 heures à l'avance à partir de l'heure actuelle et si elles commencent après le lendemain.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE_INFO_TEXT2",
+    "message": "2. Les dates de cycle ne peuvent pas être choisies comme dates passées par rapport à la date d'aujourd'hui.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_MANDATORY_FIELDS_MISSING",
+    "message": "Veuillez remplir tous les champs obligatoires.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOAD_EXCEL",
+    "message": "Télécharger Excel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOAD_EXCEL_FOR_ALL_BOUNDARIES",
+    "message": "Téléchargez Excel pour toutes les limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOAD_GEOJSONS",
+    "message": "Téléchargez géojson",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_DETAILS",
+    "message": "Détails de l'utilisateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_DETAILS_ERROR",
+    "message": "Veuillez ajouter le fichier Excel des détails de l'utilisateur.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_FILE_MISSING",
+    "message": "La fiche utilisateur est manquante",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_GENERATE_DETAILS",
+    "message": "Détails des informations d'identification de l'utilisateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USE_TEMPLATE",
+    "message": "Utiliser le modèle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VALIDATING_THE_USER_TEMPLATE",
+    "message": "Valider toutes les fiches déposées",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VALIDATION_ERROR",
+    "message": "Frontière déjà présente dans le système",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VIEW",
+    "message": "Voir",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VIEW_CHECKLIST",
+    "message": "Voir la liste de contrôle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VIEW_EXISTING_BOUNDARY_DATA",
+    "message": "Afficher les données de limites existantes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WAREHOUSE",
+    "message": "Entrepôt",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_ADD_LEVEL",
+    "message": "Ajouter un niveau",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_FAIL",
+    "message": "Erreur lors de la création de la limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_FAIL: DUPLICATE_RECORD.",
+    "message": "Oups ! On dirait que vous l'avez déjà entré. Veuillez saisir un autre nom de hiérarchie.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_FAIL: INTERNAL_SERVER_ERROR.",
+    "message": "Le fichier téléchargé ne correspond pas au modèle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_TIMEOUT",
+    "message": "La création des données de limite a échoué. Erreur de délai d'attente !",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_BULK_BROWSE_FILES",
+    "message": "Naviguer dans mes fichiers",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_CAMPAIGN_CREATED",
+    "message": "Fichier téléchargé avec succès.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_CREATE_HIERARCHY",
+    "message": "Créer une hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DELETE",
+    "message": "Supprimer",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DOWLOAD_TEMPLATE",
+    "message": "Télécharger le modèle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD",
+    "message": "Télécharger",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_FACILITY",
+    "message": "Télécharger l'installation actuelle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_TARGET",
+    "message": "Télécharger la cible actuelle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_USER",
+    "message": "Télécharger les données utilisateur actuelles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_USERDATA",
+    "message": "Télécharger les données utilisateur actuelles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_TEMPLATE",
+    "message": "Télécharger le modèle",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DRAG_DROP",
+    "message": "Faites glisser et déposez votre feuille Excel remplie ou",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_ERROR_MORE_THAN_ONE_FILE",
+    "message": "Impossible d'ajouter plus d'un fichier",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_CREATED",
+    "message": "Hiérarchie et limite créées avec succès",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_DETAILS",
+    "message": "Détails de la hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_NAME",
+    "message": "Nom de la hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_STATUS_COMPLETED",
+    "message": "Hiérarchie créée avec succès",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_TYPE",
+    "message": "Sélectionnez le type de hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_LOC_BULK_UPLOAD_XLS",
+    "message": "Limites du téléchargement groupé",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_OPERATION_INCOMPLETE",
+    "message": "La création de frontières a échoué.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_UNABLE_TO_FIND_HIERARCHY_TYPE",
+    "message": "Créer un nouveau type de hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_BOUNDARY",
+    "message": "Limite de téléchargement",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_FACILITY",
+    "message": "Télécharger les données de l'établissement",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_Facility",
+    "message": "Télécharger les données de l'établissement",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_TARGET",
+    "message": "Télécharger les données cibles",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_USER",
+    "message": "Télécharger les données utilisateur",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "YES",
+    "message": "Oui",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "YOU_WON'T_BE_ABLE_TO_UNDO_THIS_STEP_OF_CREATING_HIERARCHY",
+    "message": "Vous ne pourrez pas annuler cette étape de création de hiérarchie",
+    "module": "rainmaker-campaignmanager",
+    "locale": "fr_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/fr_MZ/rainmaker-common.json
+++ b/localisation/Microplanning/v0.1/fr_MZ/rainmaker-common.json
@@ -1,0 +1,56 @@
+[
+  {
+  "code": "MICROPLAN_MODULE_SETUP",
+  "message": "Configuration du microplan",
+  "module": "rainmaker-common",
+  "locale": "fr_MZ"
+},
+{
+"code": "SETUP_MICROPLAN",
+"message": "Configurer Microplan",
+"module": "rainmaker-common",
+"locale": "fr_MZ"
+},
+{
+"code": "SEARCH_MICROPLANS",
+"message": "Microplans ouverts",
+"module": "rainmaker-common",
+"locale": "fr_MZ"
+},
+{
+"code": "USER_MANAGEMENT",
+"message": "Gestion des utilisateurs",
+"module": "rainmaker-common",
+"locale": "fr_MZ"
+},
+{
+"code": "ACTION_TEST_OPEN_MICROPLAN",
+"message": "Ouvrir Microplan",
+"module": "rainmaker-common",
+"locale": "fr_MZ"
+},
+{
+"code": "MICROPLAN_MODULE_PROCESS",
+"message": "Processus Microplan",
+"module": "rainmaker-common",
+"locale": "fr_MZ"
+},
+{
+"code": "MY_MICROPLANS",
+"message": "Mes microplans",
+"module": "rainmaker-common",
+"locale": "fr_MZ"
+},
+  {
+    "code": "ACTION_TEST_USER_MANAGEMENT",
+    "message": "Gestion des utilisateurs",
+    "module": "rainmaker-common",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MY_MICROPLAN",
+    "message": "Mes microplans",
+    "module": "rainmaker-common",
+    "locale": "fr_MZ"
+  }
+  ]

--- a/localisation/Microplanning/v0.1/fr_MZ/rainmaker-hcm-admin-schemas.json
+++ b/localisation/Microplanning/v0.1/fr_MZ/rainmaker-hcm-admin-schemas.json
@@ -1,0 +1,2150 @@
+[
+  {
+    "code": "ADMIN10_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN10_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN10_LOCALIDADE",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN10_POST ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN10_STATE",
+    "message": "État",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN11_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN11_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN11_LOCALIDADE",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN11_POST ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN11_STATE",
+    "message": "État",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_ALDEIA",
+    "message": "Aldéia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_LOCALIDADE",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_POSTO ADMINISTRATIVO",
+    "message": "Poste Administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN1_PROVINCIA",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_ALDEIA",
+    "message": "Aldéia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_LOCALIDADE",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_POSTO ADMINISTRATIVO",
+    "message": "Poste Administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN2_PROVINCIA",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_ALDEIA",
+    "message": "Aldéia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_LOCALIDADE",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_POST ADMINISTRATIVO",
+    "message": "Poste Administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_POSTO ADMINISTRATIVO",
+    "message": "Poste Administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN3_PROVINCIA",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMINE_QA",
+    "message": "Assurance qualité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMINU_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_ALDEIA",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_CONSOLE_TARGET",
+    "message": "Cible du ménage au niveau du village (obligatoire et à saisir par l'utilisateur)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_LOCALIDADE",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_POST ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_POSTO ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_PROVINCIA",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_STATE",
+    "message": "État",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AGE",
+    "message": "Âge",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AU_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.Country",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.Distrito",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.Localidade",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.Post Administrativo",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.PostAdministrativo",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Admin9.State",
+    "message": "État",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1",
+    "message": "Téléchargement de modèles Excel pour définir des objectifs :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Téléchargez le modèle Excel en cliquant sur le bouton « Télécharger le modèle ».",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Ouvrez le modèle Excel téléchargé à l'étape précédente et la première feuille que vous verrez est une feuille « Lisez-moi ». Les feuilles restantes seront nommées d'après le nom des districts sélectionnés à l'étape « Sélection des limites », chaque feuille de district comportant une liste de tous les villages cartographiés dans ce district.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2",
+    "message": "Définition des objectifs une fois le modèle téléchargé :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_1",
+    "message": "Accédez à la feuille du district pour lequel vous souhaitez définir des objectifs et ajoutez des chiffres dans la colonne « Cibles » pour chaque village. ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Entrez les objectifs pour chaque village dans la feuille de chaque district sous la colonne « Cible au niveau de la limite sélectionnée ». Si un village n’a pas d’objectifs fixés, la feuille comportera des erreurs.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger la cible » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3",
+    "message": "Cas d'erreurs courantes :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Si l'utilisateur n'a pas défini d'objectifs pour chaque village, le système générera une erreur avec le numéro de ligne où les cibles sont manquantes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Si l'utilisateur supprime un village de la feuille ou supprime une feuille de district complète et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_3",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_MAINHEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement cible",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": "Nombre de moustiquaires par ménage",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Nombre de personnes par moustiquaire",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_BEFORE_ERROR",
+    "message": "La date de fin de la campagne ne peut pas être antérieure à la date de début de la campagne.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_ERROR",
+    "message": "Champ obligatoire !",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_MANDATORY",
+    "message": "Champ obligatoire !",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE_ERROR",
+    "message": "Champ obligatoire !",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CC_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_MZ_capacity",
+    "message": "Capacité (Unités : Balles)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_mz_capacity",
+    "message": "Capacité (Unités : Balles)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIN_mz_capacity",
+    "message": "Capacité (Unités : Balles)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN__capacity",
+    "message": "Capacité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN_capacity",
+    "message": "Capacité ( Unités : SPAQ Blister )",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_boundaryCode",
+    "message": "Code des limites du bassin versant (obligatoire)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityUsage",
+    "message": "Utilisation des installations",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EDIT_MICROPLANS_TEXT",
+    "message": "Modifier le microplan",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EQUAL_TO",
+    "message": "égal à",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_LOADING_BASE_MAP",
+    "message": "Impossible de trouver la carte de base requise, veuillez contacter l'administrateur.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_READ_ME_MISSING",
+    "message": "Veuillez ne pas modifier les noms des feuilles.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_TIMELINE",
+    "message": "Chronologie",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_1",
+    "message": "S'il n'y a aucune installation disponible pour la sélection, l'onglet « Liste des installations disponibles » dans le modèle sera vide. Pour créer de nouvelles données d'installation, ajoutez le nom de l'installation, ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Pour mapper l'installation à la limite correcte, l'utilisateur doit copier le code de limite correct de la limite de la feuille « Liste des limites de campagne » sur laquelle l'installation doit être cartographiée. S'il existe une installation mappée à plusieurs limites, ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1",
+    "message": "Téléchargement de modèles Excel pour la configuration des installations :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Téléchargez le modèle Excel en cliquant sur le bouton « Télécharger le modèle ».",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Ouvrez le modèle téléchargé à l'étape précédente et comportera 3 feuilles et la première feuille que vous verrez est une feuille « Lisez-moi »..",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2",
+    "message": "Création de nouvelles données d'installation/utilisation des données d'installation existantes une fois le modèle téléchargé :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "S'il n'y a aucune installation disponible pour la sélection, l'onglet « Liste des installations disponibles » dans le modèle sera vide. Pour créer de nouvelles données d'installation, ajoutez le nom de l'installation, ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Pour mapper l'installation à la limite correcte, l'utilisateur doit copier le code de limite correct de la limite de la feuille « Liste des limites de campagne »",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger les données de l'installation » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_5",
+    "message": "Désactivation des installations existantes pour une campagne.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_6",
+    "message": "Une fois que l'utilisateur a téléchargé le modèle pour les installations, si le système dispose de données d'installation existantes à réutiliser, le modèle sera pré-rempli avec cette liste d'installations.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_7",
+    "message": "Si l'utilisateur choisit ensuite de ne pas utiliser des installations spécifiques, il peut supprimer les lignes de données pour ces installations spécifiques qui doivent être supprimées et télécharger la feuille avec uniquement les installations nécessaires à la campagne avec les codes de limite corrects mappés à ces installations.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1",
+    "message": "Cas où il n'y a pas de données d'installation dans le système :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_1",
+    "message": "Étape 1 : Lorsqu'il n'y a pas de données d'établissement dans le système, le modèle « Liste des établissements disponibles » sera vide. Pour chaque établissement ajouté, l'utilisateur doit saisir le nom de l'établissement (doit être unique), le type d'établissement (entrepôt/établissement de santé), le statut de l'établissement (temporaire/permanent), la capacité (saisie du numéro)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_2",
+    "message": "Étape 2 : Pour cartographier les installations sur une limite donnée, l'utilisateur doit copier le code de limite correct à partir de la feuille .",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_3",
+    "message": "Étape 3 : Pour chaque installation, l'utilisateur doit ajouter Actif ou Inactif pour toutes les installations dans la colonne 'utilisation des installations' ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_4",
+    "message": "Étape 4 : Une fois toutes les fonctionnalités ajoutées, l'utilisateur doit enregistrer le fichier sur son système et télécharger le fichier en appuyant sur l'option « Parcourir dans mes fichiers ».",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2",
+    "message": "Cas où il existe des données d'installation existantes dans le système :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_1",
+    "message": "Étape 1 : Lorsque vous ouvrez le modèle d'installation téléchargé, veuillez vous référer à la feuille Liste des installations disponibles",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_2",
+    "message": "Étape 2 : Dans cette étape, l'utilisateur devra ajouter des entrées dans la colonne Utilisation de l'installation avec des entrées valides étant soit Actives, soit Inactives, où l'utilisateur peut définir l'utilisation .",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_3",
+    "message": "Étape 3 : Pour ajouter de nouveaux établissements qui ne sont pas présents dans la liste des établissements existants, l'utilisateur doit saisir le nom de l'établissement (doit être unique), ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_4",
+    "message": "Étape 4 : Une fois toutes les fonctionnalités ajoutées, l'utilisateur doit enregistrer le fichier sur son système et télécharger le fichier en appuyant sur l'option « Parcourir dans mes fichiers ».",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3",
+    "message": "Cas d'erreurs courantes :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Si l'utilisateur a supprimé les codes d'établissement pour un établissement existant dans la liste, le système créera un établissement en double avec ces valeurs de colonne.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Si l'utilisateur supprime des colonnes de la « Liste des installations disponibles » de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_3",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_MAINHEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement des installations",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FEMALE",
+    "message": "Femelle",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FROM",
+    "message": "depuis",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GENDER",
+    "message": "Genre",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GREATER_THAN",
+    "message": "supérieur à",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GREATER_THAN_EQUAL_TO",
+    "message": "supérieur ou égal à",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_ALDEIA",
+    "message": "Aldéia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_LOCALIDADE",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POST ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POSTO ADMINISTRATIVO",
+    "message": "Poste Administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_PROVINCIA",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_AVAILABLE_FACILITIES",
+    "message": "Liste des structures disponibles",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Code des limites",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY",
+    "message": "Code de délimitation (obligatoire)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY_ERROR",
+    "message": "est invalide. Il doit être extrait de la feuille « Données de limite »",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_OLD",
+    "message": "Ancien code de délimitation",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Données de limite",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITIES",
+    "message": "Liste des installations",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY",
+    "message": "Capacité (Unités : Balles pour moustiquaires/Blister SPAQ pour SMC)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_ERROR",
+    "message": "ne doit pas être vide et doit être un nombre compris entre 1 et 10 millions",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN",
+    "message": "Capacité (unités : balles pour moustiquaires/",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_LLIN-mz",
+    "message": "Capacité (Unités : balles)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_MR-DN",
+    "message": "Capacité (Unités : Blisters)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CODE",
+    "message": "Code de l'établissement",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_FIXED_POST_MICROPLAN",
+    "message": "Est un poste fixe (Oui/Non)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LATITUDE_OPTIONAL_MICROPLAN",
+    "message": "Latitude (facultatif)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LONGITUDE_OPTIONAL_MICROPLAN",
+    "message": "Longitude (facultatif)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME",
+    "message": "Nom de l'établissement",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME_MICROPLAN",
+    "message": "Nom de l'établissement",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS",
+    "message": "Statut de l'établissement",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS_MICROPLAN",
+    "message": "État de l'installation",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE",
+    "message": "Type d'établissement",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE_MICROPLAN",
+    "message": "Type d'installation",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE",
+    "message": "Utilisation des installations",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE_MICROPLAN",
+    "message": "Utilisation des installations",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_RESIDING_BOUNDARY_CODE_MICROPLAN",
+    "message": "Code de limite de résidence",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET",
+    "message": "Cible du ménage au niveau du village (obligatoire et à saisir par l'utilisateur)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_AT_THE_SELECTED_BOUNDARY_LEVEL",
+    "message": "Cible du ménage au niveau du village (obligatoire et à saisir par l'utilisateur)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_1",
+    "message": "Cible des ménages au niveau du village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_2",
+    "message": "Cible de salle au niveau du village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LAT_OPT",
+    "message": "Latitude (facultatif)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LONG_OPT",
+    "message": "Longitude (facultatif)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Population cible",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Population cible (âge 12-59 mois)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Population cible (âge 3-11 mois)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC",
+    "message": "Cible au niveau du village (Obligatoire et à saisir par l'utilisateur)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_12_TO_59",
+    "message": "Cible au niveau du village - Âge 12 à 59 mois (Obligatoire et à saisir par l'utilisateur)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_3_TO_11",
+    "message": "Cible au niveau du village - Âge 3 à 11 mois (Obligatoire et à saisir par l'utilisateur)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Population totale",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMAIL_MICROPLAN",
+    "message": "E-mail",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMPLOYMENT_TYPE",
+    "message": "Type d'emploi (obligatoire)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LIST",
+    "message": "Créer une liste d'utilisateurs",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Nom de la personne (obligatoire)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME_MICROPLAN",
+    "message": "Nom",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER",
+    "message": "Numéro de téléphone (obligatoire)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_ERROR",
+    "message": "doit être fourni et doit être un numéro de téléphone de 10 chiffres",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_MICROPLAN",
+    "message": "Numéro de contact",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_ROLE",
+    "message": "Rôle (obligatoire)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_USAGE",
+    "message": "Actif / Inactif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_README_SHEETNAME",
+    "message": "Lisez-moi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_TIMELINE",
+    "message": "Chronologie",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEALTH_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEIGHT",
+    "message": "Hauteur",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_ADMINISTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_CAN_BE_ONLY_APPLIED_ON_ADMIN_LEVEL_ZORO",
+    "message": "Les filtres ne peuvent être appliqués qu'au niveau 0",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ID_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "IN_BETWEEN",
+    "message": "entre",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LESS_THAN",
+    "message": "moins que",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LESS_THAN_EQUAL_TO",
+    "message": "inférieur ou égal à",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIM_MZ_capacity",
+    "message": "Capacité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIM_mz_capacity",
+    "message": "Capacité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "S'il n'y a aucune installation disponible pour la sélection, l'onglet « Liste des installations disponibles » dans le modèle sera vide. Pour créer de nouvelles données d'installation, ajoutez le nom de l'installation,",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Pour mapper l'installation à la limite correcte, l'utilisateur doit copier le code de limite correct de la limite de la feuille « Liste des limites de campagne » sur laquelle l'installation doit être cartographiée..",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger les données de l'installation » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Désactivation des installations existantes pour une campagne.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "Une fois que l'utilisateur a téléchargé le modèle pour les installations, si le système dispose de données d'installation existantes à réutiliser, le modèle sera pré-rempli avec la liste des installations.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "Si l'utilisateur choisit ensuite de ne pas utiliser des installations spécifiques, il peut supprimer les lignes de données pour ces installations spécifiques qui doivent être supprimées et télécharger la feuille avec uniquement les installations nécessaires à la campagne avec les codes de limite corrects mappés à ces installations.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "Si l'utilisateur a supprimé les codes d'établissement pour un établissement existant dans la liste, le système créera un établissement en double avec ces valeurs de colonne.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "Si l'utilisateur supprime des colonnes de la « Liste des installations disponibles » de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_1",
+    "message": "Création de nouvelles données d'installation/utilisation des données d'installation existantes une fois le modèle téléchargé",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_2",
+    "message": "Cas d'erreurs courantes :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement des installations",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER",
+    "message": "Création de nouvelles données d'installation/utilisation des données d'installation existantes une fois le modèle téléchargé :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_1",
+    "message": "Définition des objectifs une fois le modèle téléchargé :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_2",
+    "message": "Cas d'erreurs courantes :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement de la population",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Accédez à la feuille du district pour lequel vous souhaitez définir des objectifs et ajoutez des chiffres dans la colonne « Cibles » pour chaque village.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Entrez les objectifs pour chaque village dans la feuille de chaque district sous la colonne « Cible au niveau de la limite sélectionnée ». Si un village n’a pas d’objectifs fixés, la feuille comportera des erreurs.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_3",
+    "message": "Si l'utilisateur n'a pas défini d'objectifs pour chaque village, le système générera une erreur avec le numéro de ligne où les cibles sont manquantes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_4",
+    "message": "Si l'utilisateur supprime un village de la feuille ou supprime une feuille de district complète et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_5",
+    "message": "Si l'utilisateur n'a pas défini d'objectifs pour chaque village, le système générera une erreur avec le numéro de ligne où les cibles sont manquantes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_6",
+    "message": "Si l'utilisateur supprime un village de la feuille ou supprime une feuille de district complète et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_7",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_mz_capacity",
+    "message": "Capacité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MALE",
+    "message": "Mâle",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MH_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ACTIVE",
+    "message": "Actif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINSTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_BOUNDARY_DATA_SHEET",
+    "message": "Données de limite",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_COLUMN",
+    "message": "Détails de l'erreur",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_COLUMN",
+    "message": "Statut",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_INVALID",
+    "message": "INVALIDE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_DATA_SHEET",
+    "message": "Données des installations",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_READ_ME_SHEET",
+    "message": "Lisez-moi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEMPLATE_README_MAIN_HEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement cible",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "S'il n'y a aucune installation disponible pour la sélection, l'onglet « Liste des installations disponibles » dans le modèle sera vide. Pour créer de nouvelles données d'installation, ajoutez le nom de l'installation, le type d'installation, l'état de l'installation et la capacité. La colonne « Code d'établissement ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Pour mapper l'installation à la limite correcte, l'utilisateur doit copier le code de limite correct de la limite de la feuille « Liste des limites de campagne » sur laquelle l'installation doit être cartographiée. S'il existe une installation mappée à plusieurs limites,",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger les données de l'installation » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Désactivation des installations existantes pour une campagne.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "Une fois que l'utilisateur a téléchargé le modèle pour les installations, si le système dispose de données d'installation existantes à réutiliser, le modèle sera pré-rempli avec la liste des installations.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "Si l'utilisateur choisit ensuite de ne pas utiliser des installations spécifiques, il peut supprimer les lignes de données pour ces installations spécifiques qui doivent être supprimées et télécharger la feuille avec uniquement les installations nécessaires à la campagne avec les codes de limite corrects mappés à ces installations.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "Si l'utilisateur a supprimé les codes d'établissement pour un établissement existant dans la liste, le système créera un établissement en double avec ces valeurs de colonne.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "Si l'utilisateur supprime des colonnes de la « Liste des installations disponibles » de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_1",
+    "message": "Création de nouvelles données d'installation/utilisation des données d'installation existantes une fois le modèle téléchargé",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_2",
+    "message": "Cas d'erreurs courantes :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement des installations",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_1",
+    "message": "Définition des cibles une fois le modèle téléchargé :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_2",
+    "message": "Cas d'erreurs courantes :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement de la population",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Accédez à la feuille du district pour lequel vous souhaitez définir des objectifs et ajoutez des chiffres dans la colonne « Cibles » pour chaque village.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Entrez les objectifs pour chaque village dans la feuille de chaque district sous la colonne « Cibles ». Si un village n’a pas d’objectifs définis, la feuille comportera des erreurs.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger la cible » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_5",
+    "message": "Si l'utilisateur n'a pas défini d'objectifs pour chaque village, le système générera une erreur avec le numéro de ligne où les cibles sont manquantes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_6",
+    "message": "Si l'utilisateur supprime un village de la feuille ou supprime une feuille de district complète et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_7",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_capacity",
+    "message": "Capacité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW BOUNDARY_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_ALDEIA",
+    "message": "Aldéia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_LOCALIDADE",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_POST ADMINISTRATIVO",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NITISH_STATE",
+    "message": "État",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "OTHER_TARGETS",
+    "message": "Autres cibles",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SV_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Svefewg4YCb",
+    "message": "Murrupula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TARGET_HOUSEHOLDS",
+    "message": "Ménages cibles",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_CITY",
+    "message": "Ville",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_REGION",
+    "message": "Région",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_STATE",
+    "message": "État",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_WARD",
+    "message": "Salle",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_ZONE",
+    "message": "Zone",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TESTD_DISTRITO",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TO",
+    "message": "à",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1",
+    "message": "Téléchargement de modèles Excel pour créer des utilisateurs :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Téléchargez le modèle Excel en cliquant sur le bouton « Télécharger le modèle ».",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Ouvrez le modèle Excel téléchargé à l'étape précédente et comportera 3 feuilles et la première feuille que vous verrez est une feuille « Lisez-moi ». La deuxième feuille nommée 'Créer une liste d'utilisateurs'qui sera une feuille vide dans laquelle l'utilisateur devra saisir des données pour créer des utilisateurs pour la campagne.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2",
+    "message": "Création d'utilisateurs pour la campagne :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "L'administrateur système devra créer une entrée distincte pour chaque utilisateur. L'administrateur système devra ajouter le nom de l'utilisateur (obligatoire), le numéro de téléphone (obligatoire), le rôle (obligatoire), le type d'emploi (obligatoire), le code limite (obligatoire). ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Chaque utilisateur créé doit être attribué à une limite à l'aide du code de limite de la limite requise qui se trouve dans la « Liste des limites de campagne ». Si un utilisateur est mappé à plusieurs limites, ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Enregistrez la feuille avec les objectifs mis à jour pour chaque village sur le modèle Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Appuyez sur le bouton « Parcourir mes fichiers » sur l'écran « Télécharger la cible » et sélectionnez le fichier enregistré avec toutes les cibles du système.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3",
+    "message": "Cas d'erreurs courantes :",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Si l'utilisateur n'a pas ajouté de codes limites pour toutes les entrées utilisateur, le système générera une erreur avec le numéro de ligne où le code limite est manquant.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Si l'utilisateur supprime l'un des en-têtes de la feuille et télécharge la feuille, le système générera une erreur et l'utilisateur devra télécharger à nouveau le modèle et télécharger à nouveau la bonne feuille avec les données correctes.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_MAINHEADER",
+    "message": "Lisez-moi les instructions pour le téléchargement par l'utilisateur",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN1",
+    "message": "Rôle de l'utilisateur",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN2",
+    "message": "Description",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_ROLES",
+    "message": "Rôles des utilisateurs",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE1",
+    "message": "Approbateur de l’estimation du plan",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE10",
+    "message": "Ce rôle aura accès à l'affectation de l'installation aux zones de chalandise de la limite administrative attribuée.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE11",
+    "message": "Mappeur de bassin versant des installations racine",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE12",
+    "message": "Ce rôle aura accès à l'attribution et à la finalisation de l'installation dans les zones de chalandise du pays.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE13",
+    "message": "Visionneuse Microplan",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE14",
+    "message": "Ce rôle aura accès à la visualisation des estimations du microplan de la limite administrative attribuée.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE2",
+    "message": "Ce rôle aura accès à la modification des hypothèses du microplan et à l'approbation de l'estimation du microplan pour tous les villages de la limite administrative attribuée.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE3",
+    "message": "Approbateur de l’estimation du plan racine",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE4",
+    "message": "Ce rôle aura accès à la modification des hypothèses du microplan, à l'approbation et à la finalisation de l'estimation du microplan pour tous les villages du pays.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE5",
+    "message": "Approbateur des données démographiques",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE6",
+    "message": "Ce rôle aura accès à la validation et à l'approbation des données démographiques pour les villages de la limite administrative assignée.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE7",
+    "message": "Approbateur des données de population racine",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE8",
+    "message": "Ce rôle aura accès à valider, approuver et finaliser les données démographiques pour tous les villages du pays.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE9",
+    "message": "Cartographie des bassins versants des installations",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_POST ADMINISTRATIVE",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UY_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VFTw0jbRf1y",
+    "message": "Cavina1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WEIGHT",
+    "message": "Poids",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "f5F6xAskA05",
+    "message": "Namula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "facilityUsage",
+    "message": "Utilisation des installations",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_Country",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_District",
+    "message": "District",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_Locality",
+    "message": "Localité",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_Post administrative",
+    "message": "Poste administratif",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_Province",
+    "message": "Province",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_Village",
+    "message": "Village",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mobile_country",
+    "message": "Pays",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "mz",
+    "message": "Mozambique",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "w22L4En0Zgg",
+    "message": "Nihessiué",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "fr_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/fr_MZ/rainmaker-hr.json
+++ b/localisation/Microplanning/v0.1/fr_MZ/rainmaker-hr.json
@@ -1,0 +1,8 @@
+[
+  {
+    "code": "HEALTH_HRMS_EMAIL_CODE",
+    "message": "<h2>Identifiants de connexion au tableau de bord</h2><p>Bonjour {User's name},<br>Votre profil a été créé pour accéder au tableau de bord. Veuillez trouver vos identifiants de connexion ci-dessous -<br>URL: {website URL}<br>Username: {Username}<br>Password: {Password}<br>Merci,<br>{Implementation partner}</p>",
+    "module": "rainmaker-hr",
+    "locale": "fr_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/fr_MZ/rainmaker-microplanning.json
+++ b/localisation/Microplanning/v0.1/fr_MZ/rainmaker-microplanning.json
@@ -1,0 +1,9440 @@
+[
+  {
+    "code": " HCM_SELECTED",
+    "message": "Choisi",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "1",
+    "message": "1",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "2",
+    "message": "2",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "3",
+    "message": "3",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "4",
+    "message": "4",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "5",
+    "message": "5",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACCESSIBILITY_DETAILS_UPDATE_SUCCESS",
+    "message": "Les details d'accessibilite ont ete mis a jour avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION",
+    "message": "Action",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTIONS",
+    "message": "Action",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MY_MICROPLAN",
+    "message": "Mes microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_OPEN_MICROPLAN",
+    "message": "Ouvrir Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_MICROPLAN",
+    "message": "Configurer Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTION_TEST_USER_MANAGEMENT",
+    "message": "Gestion des utilisateurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ACTIVA",
+    "message": "Actif",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD",
+    "message": "Ajouter",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADDITION",
+    "message": "Ajout",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_ASSUMPTION",
+    "message": "Ajouter une hypothèse",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_ASSUMPTION_CAMPAIGN_VEHICLES",
+    "message": "Ajouter un vehicule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_FORMULA",
+    "message": "Ajouter une formule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_NEW_FORMULA",
+    "message": "Ajouter une formule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADD_ROW",
+    "message": "Ajouter une ligne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMINISTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMINISTRATIVE_BOUNDARY",
+    "message": "Zone administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMINISTRATIVE_HIERARCHY",
+    "message": "Hierarchie administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ADMIN_PROVINCIA",
+    "message": "Province",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ALERT_HEADER_CAMPAIGN",
+    "message": "Êtes-vous sûr de vouloir continuer ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ALERT_HEADER_MICROPLAN",
+    "message": "Êtes-vous sûr de vouloir continuer ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ALERT_MESSAGE_CAMPAIGN",
+    "message": "Les details de la campagne ne peuvent pas être modifies une fois enregistres. Veuillez vous assurer d'avoir finalise les details de la campagne avant de continuer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ALERT_MESSAGE_MICROPLAN",
+    "message": "Les details de la campagne ne peuvent pas être modifies une fois enregistres. Veuillez vous assurer d'avoir finalise les details de la campagne avant de continuer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ALL",
+    "message": "Toute",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ALL_THE_TIME",
+    "message": "Tout le temps (au moins une fois par mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ALREADY_HAVE_IT",
+    "message": "Je l'ai deja",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ALREDY_HAVE_IT",
+    "message": "Je l'ai deja",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AND",
+    "message": "et",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ANSWER_TO_PROVIDE_ESTIMATE",
+    "message": "Veuillez repondre aux questions suivantes avec des reponses appropriees pour que nous puissions vous fournir un formulaire d'hypothèse d'estimation ideal.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "APPROVE",
+    "message": "Approuver",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGN",
+    "message": "Attribuer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGNED_SUCCESSFULLY",
+    "message": "L'utilisateur a ete affecte au rôle selectionne avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGNED_SUCESS",
+    "message": "Les villages ont ete attribues avec succès a l'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGNED_TO_ALL",
+    "message": "Attribue a tous",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGNED_TO_ME",
+    "message": "M'a ete attribue",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGN_FACILITIES_TO_VILLAGE",
+    "message": "Attribuer des installations au village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGN_FACILITIES_TO_VILLAGES",
+    "message": "Attribuer des installations aux villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGN_FACILITY_CATCHMENT_MAPPER",
+    "message": "Attribuer un assignateur de limites d'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGN_MICROPLAN_VIEWER",
+    "message": "Attribuer le visualiseur Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGN_PLAN_ESTIMATION_APPROVER",
+    "message": "Attribuer un approbateur d’estimation Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGN_POPULATION_DATA_APPROVER",
+    "message": "Attribuer un approbateur de donnees sur la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGN_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Attribuer un assignateur national des limites des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGN_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Designer un approbateur national d’estimation de microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSIGN_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Designer un approbateur des donnees sur la population nationale",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSUMPTION_NAME",
+    "message": "Nom de l'hypothèse",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ASSUMPTION_VEHICLE_DESCRIPTION",
+    "message": "Veuillez saisir la valeur des hypothèses de charge des vehicules en ajoutant des vehicules.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ATLEAST_ONE_FORMULA",
+    "message": "Au moins une formule doit être presente pour avancer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ATLEAST_ONE_MDMS_ASSUMPTION",
+    "message": "Au moins un des champs de saisie d'hypothèses pre-remplis dans cette categorie doit être present.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ATLEAST_ONE_MDMS_FORMULA",
+    "message": "Au moins un des champs de saisie de formule pre-remplis dans cette categorie doit être present.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_CHILDREN_REACHED_BY_ONE_TEAM_PER_DAY",
+    "message": "Nombre moyen d'enfants touches par une equipe par jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_HOUSEHOLDS_COVERED_BY_ONE_DISTRIBUTOR",
+    "message": "Nombre moyen de foyers couverts par un distributeur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_HOUSEHOLDS_COVERED_BY_ONE_SPRAY_TECHNICIAN",
+    "message": "Nombre moyen de menages couverts par un technicien de pulverisation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_HOUSEHOLD_COVERED_BY_ONE_DISTRIBUTORS",
+    "message": "Nombre moyen de foyers couverts par un distributeur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "Personnes moyennes dans un menage",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "AVERAGE_PEOPLE_PER_HH",
+    "message": "Nombre moyen de personnes par foyer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BACK",
+    "message": "Dos",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BACK_TO_HOME",
+    "message": "Retourner a la maison",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BAD_REQUEST",
+    "message": "Il y a eu une erreur. Veuillez reessayer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOLERO",
+    "message": "Bolero",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MP_README_HEADER_1_DESC_1",
+    "message": "Les champs obligatoires tels que les donnees sur la population totale et la population cible doivent contenir un nombre entier (par exemple, la population peut être 1 234 et non 123,5).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_MP_README_HEADER_1_DESC_2",
+    "message": "Les champs Latitude et Longitude doivent contenir des donnees en degres decimaux et en degres minutes secondes (la valeur doit être 12,3455 et non 12° 20' 43,7994').",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BOUNDARY_SELECTION",
+    "message": "Selectionnez la limite de campagne pour le microplaning",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BUFFER",
+    "message": "Tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BULK_UPLOAD_USERS",
+    "message": "Utilisateurs de telechargement groupe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BUTTON",
+    "message": "bouton",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BUTTON_BACK",
+    "message": "Dos",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BUTTON_DOWNLOAD",
+    "message": "Telecharger",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "BUTTON_FILTER_BY_BOUNDARY",
+    "message": "Filtrer par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGNS_ASSIGNED",
+    "message": "Affecte a la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE",
+    "message": "Type de beneficiaire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPEHOUSEHOLD",
+    "message": "Menage",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPEINDIVIDUAL",
+    "message": "Individuel",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE_HOUSEHOLD",
+    "message": "Menage",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE_INDIVIDUAL",
+    "message": "Individuel",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY",
+    "message": "Limite de la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_ADMIN_MO",
+    "message": "Administrateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_CAMP",
+    "message": "Limite de la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_MZ",
+    "message": "Mozambique",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_COMMODITIES",
+    "message": "Hypothèses sur les matières premières",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DATE",
+    "message": "Date de la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DETAILS",
+    "message": "Details de la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DISEASE",
+    "message": "Maladie de campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE",
+    "message": "Date de fin de campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME",
+    "message": "Nom de la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Les limites sont les zones administratives definies dans lesquelles vous souhaitez lancer une campagne. Commencez a selectionner les limites a partir du premier niveau afin que les limites presentes dans le niveau suivant soient disponibles pour la selection.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARY",
+    "message": "Selectionnez les limites où vous souhaitez lancer la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SETUP_DETAILS",
+    "message": "Le nom que vous avez saisi a deja ete utilise. Veuillez essayer un autre nom.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE",
+    "message": "Date de debut de la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE",
+    "message": "Type de campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE-SMC",
+    "message": "SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_IRS_MZ",
+    "message": "Campagne IRS",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN-MZ",
+    "message": "MILDA-MZ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN-mz",
+    "message": "MILDA-MZ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN_DEFAULT_TESTING",
+    "message": "Campagne de tests MILD par defaut",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN_MOZ",
+    "message": "MILD-Moz",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN_MZ",
+    "message": "Campagne Moustiquaire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_MR-DN",
+    "message": "MR-DN",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_MR_DN",
+    "message": "Campagne SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_SMC",
+    "message": "SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_XVZ",
+    "message": "Campagne XVZ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VEHICLES",
+    "message": "Hypothèses relatives aux vehicules",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CANCEL",
+    "message": "Annuler",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CANCLE",
+    "message": "Annuler",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAPACITY_OF_VEHICLE_1_BALES",
+    "message": "Capacite du vehicule 1 (balles)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CAPACITY_OF_VEHICLE_2_BALES",
+    "message": "Capacite du vehicule 2 (balles)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CATEGORY_",
+    "message": "Categorie-",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CATEGORY_1",
+    "message": "Categorie 1",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CATEGORY_2",
+    "message": "Categorie 2",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TARGET_POPULATION",
+    "message": "Population cible confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "Population cible confirmee (12 a 59 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "Population cible confirmee (3 a 11 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TOTAL_POPULATION",
+    "message": "Population totale confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_DATA_APPROVAL_IN_PROGRESS",
+    "message": "Validation en cours",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_DATA_APPROVED",
+    "message": "Validation en cours",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TARGET_POPULATION",
+    "message": "Population cible telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "Population cible telechargee (12 a 59 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "Population cible telechargee (3 a 11 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TOTAL_POPULATION",
+    "message": "Population totale telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CENSUS_VALIDATED_LABEL",
+    "message": "Donnees demographiques finalisees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHOOSE_ASSUMPTION",
+    "message": "Choisir l'hypothèse",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHOOSE_VEHICLE",
+    "message": "Choisir un vehicule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CHOROPLETH_INDEX_COVERAGE",
+    "message": "Couverture",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CLEAR",
+    "message": "Clair",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CLEAR_ALL",
+    "message": "Tout effacer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CLEAR_ALL_CONFIRMATION_MSG",
+    "message": "Etes-vous sûr de vouloir effacer toutes les selections ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CLEAR_ALL_FILTERS",
+    "message": "Effacer tous les filtres",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CLEAR_FILTER",
+    "message": "Effacer le filtre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CLOSE",
+    "message": "Fermer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CMAPAIGN_DISEASE",
+    "message": "Maladie de campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COLUMNS",
+    "message": "Colonnes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COLUMNS_IN_TEMPLATE",
+    "message": "Colonne dans le modèle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COLUMNS_IN_USER_UPLOAD",
+    "message": "Colonne dans votre fichier telecharge",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COMMENT_PREFIX",
+    "message": "Commentaire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COMMON_NO_RESULTS_FOUND",
+    "message": "Aucun resultat trouve",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COMMON_SELECTED",
+    "message": "Choisi",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COMPLETE_MAPPING",
+    "message": "Cartographie complète",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONCRETE",
+    "message": "Beton",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Population cible confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Population cible confirmee (12 a 59 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Population cible confirmee (âge 3 a 11 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Population totale confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIRM_NEW_ASSUMPTION",
+    "message": "Êtes-vous sûr de vouloir ajouter une hypothèse ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIRM_NEW_ASSUMPTION_CAMPAIGN_VEHICLES",
+    "message": "Êtes-vous sûr de vouloir ajouter un vehicule ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIRM_NEW_FORMULA",
+    "message": "Êtes-vous sûr de vouloir ajouter une formule ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONFIRM_TO_DELETE",
+    "message": "Êtes-vous sûr de vouloir supprimer ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CONTACT_NUMBER",
+    "message": "Numero de contact",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CORE_COMMON_EMAIL_ID",
+    "message": "Adresse email",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CORE_COMMON_NAME",
+    "message": "Nom",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CORE_COMMON_STATUS",
+    "message": "Statut de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CORE_COMMON_STATUS_LABEL",
+    "message": "Statut de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CORE_SOMETHING_WENT_WRONG",
+    "message": "Quelque chose s'est mal passe !",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "COVERAGE_PERCENTAGE",
+    "message": "Pourcentage de couverture",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE_MICROPLAN",
+    "message": "Creer un microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE_MICROPLAN_GUIDELINES",
+    "message": "Avis / Instructions avant de commencer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CREATE_NEW_MICROPLAN",
+    "message": "Creer un nouveau microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "CS_INBOX_SEARCH",
+    "message": "Recherche",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Camapaign Type",
+    "message": "Type de campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DATA_MGMT",
+    "message": "Gestion des donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DATA_VALIDATION_RULE",
+    "message": "Règle de validation des donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DELETE",
+    "message": "Supprimer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DESERT",
+    "message": "Desert",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DEVIDED_BY",
+    "message": "Divise par",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DIGIT_CLOSE",
+    "message": "Fermer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DIGIT_CONFIRM_SELECTION",
+    "message": "Confirmer la sélection",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DIGIT_SELECT",
+    "message": "Choisi",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DIRT",
+    "message": "Salete",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAYING_DATA_ONLY_FOR_UPLOADED_BOUNDARIES",
+    "message": "Afficher les donnees uniquement pour les limites pour lesquelles les donnees ont ete telechargees.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_capacity",
+    "message": "Capacite (obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityCode",
+    "message": "Code de l'etablissement (obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityName",
+    "message": "Nom de l'etablissement (obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityStatus",
+    "message": "Statut de l'etablissement (Obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityType",
+    "message": "Type d'installation (obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_lat",
+    "message": "Latitude (facultatif)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_long",
+    "message": "Longue (facultatif)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_targetHouseholds",
+    "message": "Menages cibles (Obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_targetPopulation",
+    "message": "Population cible (obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_targetPopulationAge3To11",
+    "message": "Population cible (Âge 3 mois - 11 mois) (Obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_targetpopulationAge12To59",
+    "message": "Population cible (Âge 12 mois - 59 mois) (Obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISPLAY_totalTargetPopulation",
+    "message": "Population cible totale (obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISTIRBUTION_STRATEGY",
+    "message": "Strategie de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISTRIBUTION_PROCESS",
+    "message": "Comment se deroule le processus de distribution de la campagne ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DISTRICT",
+    "message": "District",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DIVIDED_BY",
+    "message": "Divise par",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOADING",
+    "message": "Telechargement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_DESC",
+    "message": "Telechargez les donnees utilisateur dans la liste ci-dessous",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_IT",
+    "message": "Telechargez-le",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_MICROPLAN",
+    "message": "Telecharger le microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_TEMPLATE",
+    "message": "Telecharger le modèle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DOWNLOAD_USER_DATA",
+    "message": "Telecharger les donnees utilisateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DRAFT",
+    "message": "Configuration redigee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "DRAFTED_SETUP",
+    "message": "Configuration redigee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Data Mgmt",
+    "message": "Gestion des donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Envoye pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EDIT_AND_VALIDATE",
+    "message": "Valider",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EDIT_POPULATION",
+    "message": "Modifier",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EDIT_ROW",
+    "message": "Modifier la ligne {{rowNumber}}",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EMAIL",
+    "message": "Adresse email",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EMPLOYEES_NOT_FOUND",
+    "message": "Veuillez attribuer aux utilisateurs la tâche d'avancer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND",
+    "message": "Veuillez attribuer aux utilisateurs la tâche d'avancer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Veuillez attribuer au moins un utilisateur au rôle d'attribution des limites des installations nationales.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Veuillez attribuer au moins un utilisateur au rôle d'approbateur d'estimation de microplan national.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Veuillez attribuer au moins un utilisateur au rôle d'approbateur de donnees sur la population nationale.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_ADDITIONAL_PROPERTIES",
+    "message": "Les donnees telechargees comportent des champs supplementaires",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_BOUNDARY_DATA_COLUMNS_ABSENT",
+    "message": "Des donnees de limite partielles ou entières sont manquantes. Veuillez ne pas supprimer ou modifier les donnees de limite dans le modèle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_BOUNDARY_SELECTION",
+    "message": "Veuillez selectionner les limites jusqu'au niveau du village.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_CAMPAIGN_DETAILS_MANDATORY",
+    "message": "Veuillez remplir tous les champs obligatoires pour continuer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_CANNOT_DELETE_LAST_HYPOTHESIS",
+    "message": "La suppression de la dernière hypothèse n'est pas interdite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_COLUMNS_DO_NOT_MATCH_TEMPLATE",
+    "message": "Les colonnes {{columns}} ne correspondent pas aux exigences du modèle !",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_CONTENT_NAMING_CONVENSION",
+    "message": "Le système ne pourra pas traiter ce fichier. Veuillez vous referer a la convention de denomination, renommer les sous-fichiers puis telecharger",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_CORRUPTED_FILE",
+    "message": "Le fichier telecharge est corrompu. Veuillez telecharger un fichier valide.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_DATA_EXCEEDS_LIMIT_CONSTRAINTS",
+    "message": "Veuillez saisir les donnees dans les limites indiquees.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_DATA_INCOMPLETE",
+    "message": "Veuillez remplir tous les champs avant de passer a l'etape suivante",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_DATA_NOT_PRESENT",
+    "message": "Donnees incorrectes ou absentes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_DATA_NOT_SAVED",
+    "message": "Donnees non enregistrees. Veuillez vous assurer que toutes les sections requises sont remplies, que le fichier est telecharge, que l'hypothèse est definie et que le moteur de règles est configure.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_DATA_TYPE",
+    "message": "Veuillez entrer un numero",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_DBF_MISSING",
+    "message": "Veuillez consulter les directives de telechargement de donnees. Le sous-fichier DBF est manquant dans le fichier de formes telecharge. Veuillez verifier et telecharger a nouveau.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_DOWNLOADING_TEMPLATE",
+    "message": "Erreur de telechargement du modèle.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_DUPLICATE_MICROPLAN_NAME",
+    "message": "Le nom que vous avez saisi a deja ete utilise. Veuillez essayer un autre nom",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_EXCEL_EXTENSION",
+    "message": "Veuillez telecharger un fichier .xlsx avec la bonne convention de denomination",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_FEATURECOLLECTION",
+    "message": "L'element de niveau superieur doit être de type « FeatureCollection »",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_FIELD_LENGTH",
+    "message": "Veuillez consulter les directives de telechargement de donnees. La longueur minimale de tout champ doit être de 2.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_FIELD_NAME",
+    "message": "Les noms de champs ne doivent pas depasser 10 caractères.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_FILE_SIZE",
+    "message": "Veuillez consulter les directives de telechargement de donnees. La taille du fichier depasse la limite de 2 Go. Veuillez telecharger un fichier plus petit.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_GEOJSON_EXTENSION",
+    "message": "Veuillez telecharger un fichier .geojson avec la bonne convention de denomination",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_HYPOTHESIS_VALUE_SHOULD_NOT_BE_ZERO",
+    "message": "La valeur de l'hypothèse doit être superieure a 0",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_INCORRECT_FORMAT",
+    "message": "Veuillez consulter les directives de telechargement de donnees. Format GeoJSON invalide. Veuillez verifier et corriger le format.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_INCORRECT_LOCATION_COORDINATES",
+    "message": "Les champs Latitude et Longitude doivent contenir des données en degrés décimaux et en degrés minutes secondes (la valeur doit être 12,3455 et non 12° 20' 43,7994\").",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_INVALID_GEOJSON",
+    "message": "Le format GeoJSON fourni n'est pas valide. Veuillez vérifier et réessayer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MANDATORY_FIELDS",
+    "message": "Veuillez remplir tous les champs obligatoires pour continuer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MANDATORY_FIELDS_CANT_BE_EMPTY",
+    "message": "Le champ obligatoire ne peut pas être vide",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MANDATORY_FIELDS_FOR_SUBMIT",
+    "message": "Aucune feuille Excel n’a ete telechargee. Veuillez telecharger, puis cliquez sur le bouton « Soumettre ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MAP_OBJECT_MISSING",
+    "message": "Erreur lors du chargement de la carte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_DETAILS_MANDATORY",
+    "message": "Veuillez remplir le champ obligatoire 'Nom du microplan' pour continuer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_NAME_ALREADY_EXISTS",
+    "message": "Le nom que vous avez saisi a deja ete utilise. Veuillez essayer un autre nom.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_NAME_CRITERIA",
+    "message": "Le nom que vous avez saisi ne correspond pas a la convention de denomination. Veuillez essayer un autre nom.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_NAME_INVALID",
+    "message": "Le nom que vous avez saisi ne correspond pas a la convention de denomination. Veuillez essayer un autre nom.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MISSING_LOCATION_COORDINATES",
+    "message": "Les coordonnees de localisation sont manquantes pour quelques/tous les points de donnees. Vous ne pourrez pas visualiser ces donnees sur la carte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MISSING_PROPERTY",
+    "message": "Les propriétés obligatoires suivantes sont manquantes : {{properties}}",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MULTIPLE_GEOMETRY_TYPES",
+    "message": "Plusieurs types de geometrie detectes. Veuillez vous assurer que le fichier ne contient qu'un seul type de geometrie.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MUST_BE_A_NUMBER",
+    "message": "ça doit être un nombre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MUST_BE_A_NUMBER ",
+    "message": "ça doit être un nombre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_MUST_BE_A_STRING",
+    "message": "doit être une chaîne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_NAMING_CONVENSION",
+    "message": "Le système ne pourra pas traiter ce fichier. Veuillez vous referer a la convention de denomination, renommez le fichier puis telechargez-le.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_PARSING_FILE",
+    "message": "Erreur lors de l'analyse du fichier.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_REFER_UPLOAD_PREVIEW_TO_SEE_THE_ERRORS",
+    "message": "Pour afficher les erreurs detaillees, veuillez",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_REGISTRATION_AND_DISTRIBUTION_ARE_SAME",
+    "message": "Le processus de distribution et d’inscription ne peut pas être le même",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_SHAPE_FILE_EXTENSION",
+    "message": "Veuillez telecharger un fichier .zip avec la bonne convention de denomination",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_SHP_MISSING",
+    "message": "Veuillez consulter les directives de telechargement de donnees. Le sous-fichier SHP est manquant dans le fichier de formes telecharge. Veuillez verifier et telecharger a nouveau.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_SHX_MISSING",
+    "message": "Veuillez consulter les directives de telechargement de donnees. Le sous-fichier SHX est manquant dans le fichier de formes telecharge. Veuillez verifier et telecharger a nouveau.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_UNHANDLED_NEXT_OPERATION",
+    "message": "Erreur non geree, operation suivante",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_UNKNOWN",
+    "message": "Erreur inconnue, contacter l'administrateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_UNKNOWN_FILETYPE",
+    "message": "Erreur de type de fichier inconnu. Veuillez vous assurer d'avoir selectionne un type de fichier pris en charge et reessayer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_UPLOADED_DATA_IS_EMPTY",
+    "message": "Le fichier telecharge ne contient aucune donnee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_UPLOADED_FILE",
+    "message": "Erreur avec le fichier telecharge.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_UPLOADING_FILE",
+    "message": "Le telechargement a echoue. Veuillez telecharger a nouveau",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_UPLOAD_DATA_ENUM",
+    "message": "La valeur doit être l'une des valeurs suivantes : {{allowedValues}}",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_UPLOAD_DATA_LOCATION_AND_MESSAGE",
+    "message": "Donnees sur la ligne {{rowNumber}} : {{columnName}} : {{error}} sur la feuille {{sheetName}}.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_UPLOAD_EXCEL_LOCATION_DATA_MISSING",
+    "message": "les coordonnees de localisation sont manquantes pour quelques/tous les points de donnees. Vous ne pourrez pas visualiser ces donnees sur la carte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_VALIDATION_SCHEMA_ABSENT",
+    "message": "Veuillez consulter les directives de telechargement de donnees. Schema de validation absent. Veuillez contacter l'administrateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_VALID_MANDATORY_FILES",
+    "message": "Veuillez telecharger un fichier Excel valide pour continuer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_VALUE_NOT_ALLOWED",
+    "message": "Veuillez saisir une valeur autorisee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_VIEW_DETAIL_ERRORS",
+    "message": "Afficher l'erreur et les details",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_WHILE_UPDATING_PLANFACILITY",
+    "message": "Une erreur s'est produite lors de l'attribution des installations. Veuillez reessayer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERROR_WRONG_PRJ",
+    "message": "Veuillez consulter les directives de telechargement de donnees. Mauvaise projection. Veuillez utiliser WGS 1984.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_ATLEAST_ONE_MANDATORY_FIELD",
+    "message": "Il devrait y avoir au moins une hypothèse dans la categorie. Il ne devrait pas être vide.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_ATLEAST_ONE_MANDATORY_FORMULA",
+    "message": "Il devrait y avoir au moins une formule pour avancer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_DECIMAL_PLACES_LESS_THAN_TWO",
+    "message": "Veuillez saisir une valeur numerique positive valide avec 2 points decimaux et jusqu'a 1 000 uniquement.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_FORMULA_ENTER_FORMULA_NAME",
+    "message": "Veuillez saisir le nom de la formule.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_FORMULA_SELECT_OPTION",
+    "message": "Veuillez selectionner la formule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_INCORRECT_FIELD",
+    "message": "Veuillez saisir une valeur numerique positive valide avec 2 points decimaux et jusqu'a 1 000 uniquement.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_MANDATORY_FIELD",
+    "message": "Veuillez remplir tous les champs obligatoires pour continuer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_MANDATORY_FIELD_SAME_OPERAND",
+    "message": "Les operateurs ne peuvent pas être des « soustractions » lorsque les entrees sont identiques.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_MIN_LENGTH_CAMPAIGN_NAME",
+    "message": "Au moins 2 caractères sont requis",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_PLS_ENTER_VALID_ASSUMPTION_VALUE",
+    "message": "Veuillez saisir une valeur numerique positive valide avec 2 points decimaux et jusqu'a 1 000 uniquement.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_SHOULD_NOT_EXCEED_999.99",
+    "message": "Veuillez saisir une valeur d'hypothèse valide qui ne doit pas depasser 1 000.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ERR_SKIP_STEP",
+    "message": "Sauter l'etape n'est pas autorise",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ESTIMATION_ASSUMPTIONS",
+    "message": "Hypothèses du Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_APPLY_FILTER",
+    "message": "Appliquer le filtre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_APPLY_FILTERS",
+    "message": "Appliquer le filtre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_ALL",
+    "message": "TOUT EFFACER",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_FILTER",
+    "message": "Clair",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_SEARCH",
+    "message": "Clair",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_FILTER",
+    "message": "Recherche",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_NA",
+    "message": "NA",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_PLEASE_ENTER_ALL_MANDATORY_FIELDS",
+    "message": "Veuillez remplir les champs obligatoires.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_COMMON_SEARCH",
+    "message": "Recherche",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ES_MORE",
+    "message": "Plus",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EVERYDAY",
+    "message": "Tous les jours",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EVERYDAY1",
+    "message": "Tous les jours",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EXAMPLE",
+    "message": "Exemple",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EXCEL",
+    "message": "Exceller",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EXECUTION_IN_PROGRESS",
+    "message": "Validation en cours",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "EXECUTION_TO_BE_DONE",
+    "message": "Configuration terminee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES",
+    "message": "Installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_GUIDELINE_POINTS_1",
+    "message": "Le nom du fichier doit être « Facilities.xlsx ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_GUIDELINE_POINTS_2",
+    "message": "Les champs Latitude et Longitude doivent contenir des données en degrés décimaux et en degrés minutes secondes (la valeur doit être 12,3455 et non 12° 20' 43,7994\").",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_1",
+    "message": "Le fichier GeoJSON doit répondre aux",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_2",
+    "message": "Le nom du fichier doit être « Facilities.geojson ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_3",
+    "message": "Toutes les entites du fichier doivent avoir des geometries du même type (c'est-a-dire qu'elles doivent toutes être des points, ou toutes doivent être des multipolygones, etc.).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_4",
+    "message": "Les coordonnees doivent être dans la plage valide de latitude et de longitude (la plage valide pour la latitude est de -90 a +90 et la plage valide de longitude est de -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_5",
+    "message": "Toutes les fonctionnalites du fichier doivent avoir des proprietes avec le même jeu de cles.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_6",
+    "message": "Les caracteristiques du fichier doivent avoir des cles importantes telles que « Code d'installation », « Nom de l'installation », « Type d'installation », « Statut de l'installation », « Capacite », « Code limite ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_7",
+    "message": "Dans l'objet Proprietes, les valeurs des champs qui representent une valeur numerique ne doivent pas être entre guillemets doubles (c'est-a-dire que le code d'etablissement de 10 000 doit être represente par « code d'etablissement » : 10 000 et non par « code d'etablissement » : « 10 0000). »",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_SPECIFICATION",
+    "message": "RFC 7946 GeoJSON",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_1",
+    "message": "L'utilisateur doit compresser tous les fichiers au format .zip et les telecharger dans le système. Au minimum, le système a besoin de fichiers .shp, .shx et .dbf compresses.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_2",
+    "message": "Le nom du fichier zip doit être « Facilities.zip ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_3",
+    "message": "Le fichier de formes doit être dans le système de coordonnees lat-long WGS 84 pour que le système l'accepte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_4",
+    "message": "Les coordonnees doivent être dans la plage valide de latitude et de longitude (la plage valide pour la latitude est de -90 a +90 et la plage valide de longitude est de -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_5",
+    "message": "Le fichier de formes doit contenir les points de donnees importants tels que « Code d'installation », « Nom de l'installation », « Type d'installation », « Statut de l'installation », « Capacite », « Code de limite ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_6",
+    "message": "La taille totale du fichier compresse ne doit pas depasser 2 Go.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITY",
+    "message": "Facilite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MP_README_HEADER_1_DESC_1",
+    "message": "Tous les champs sont obligatoires et ne peuvent être vides, a l'exception des champs Latitude et Longitude.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MP_README_HEADER_1_DESC_2",
+    "message": "Les champs Latitude et Longitude doivent contenir des donnees en degres decimaux et en degres minutes secondes (la valeur doit être 12,3455 et non 12° 20' 43,7994').",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHEMENT_DONE_LABEL",
+    "message": "Affectation des installations finalisee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER",
+    "message": "Attribution des limites des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER_DESCRIPTION",
+    "message": "Ce rôle d'utilisateur aura le droit d'attribuer l'installation aux zones de chalandise de la limite administrative attribuee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER_POPUP_HEADING",
+    "message": "Selectionner un assignateur de limites d'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FILE_UPLOADED_SUCCESSFULLY",
+    "message": "Fichier telecharge avec succès.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FILE_UPLOADING",
+    "message": "Telechargement de fichiers....",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FILTER",
+    "message": "Filtre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FILTERS",
+    "message": "Filtre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FINALISED_MICROPLAN_SUCCESSFUL",
+    "message": "Microplan finalise avec succès !",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FINALIZED_MIDDLE_MASSAGE",
+    "message": "les installations et les",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FIXED",
+    "message": "Poste Fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FIXED_POST",
+    "message": "Poste Fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FIXED_POST_DISTRIBUTION",
+    "message": "Hypothèses de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FIXED_POST_REGISTRATION",
+    "message": "Hypothèses d'enregistrement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FIXED_POST_REGISTRATIONS",
+    "message": "Hypothèses d'enregistrement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FOREST",
+    "message": "Forêt",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_CAMPAIGN_COMMODITIES",
+    "message": "Estimations des matières premières",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_CAMPAIGN_VEHICLES",
+    "message": "Estimations de vehicules",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_CONFIGURATION",
+    "message": "Configuration de la formule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_CONFIGURATION_DESCRIPTION",
+    "message": "Veuillez configurer la formule en fonction des hypothèses prises en compte pour l'estimation des ressources.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_FIXED_POST_DISTRIBUTION",
+    "message": "Estimations de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_FIXED_POST_REGISTRATION",
+    "message": "Estimations d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_GENERAL_ESTIMATION",
+    "message": "Estimations generales",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_CAMPAIGN_COMMODITIES",
+    "message": "Estimations des matières premières",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_CAMPAIGN_VEHICLES",
+    "message": "Estimations de vehicules",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_FIXED_POST_DISTRIBUTION",
+    "message": "Estimations de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_FIXED_POST_REGISTRATION",
+    "message": "Estimations d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_GENERAL_ESTIMATION",
+    "message": "Estimations generales",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_HOUSEHOLD_DISTRIBUTION",
+    "message": "Estimations de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_HOUSEHOLD_REGISTRATION",
+    "message": "Estimations d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_HOUSEHOLD_DISTRIBUTION",
+    "message": "Estimations de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_HOUSEHOLD_REGISTRATION",
+    "message": "Estimations d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "Cela indique l'estimation du nombre moyen de personnes dans un menage.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BALES_PER_BOUNDARY",
+    "message": "Ceci indique l’estimation du nombre total de balles necessaires.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BEDNETS_PER_BALE",
+    "message": "Ceci indique l’estimation du nombre total de moustiquaires necessaires.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Ceci indique l’estimation du nombre total de moustiquaires necessaires.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "Cela indique l'estimation du nombre total d'equipes d'inscription necessaires pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Ceci indique l'estimation du nombre total d'equipes d'inscription requises si la campagne se deroule pendant une journee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Ceci indique l'estimation du nombre total d'equipes de distribution de courrier fixe requises si la campagne se deroule sur une journee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Cela indique l'estimation du nombre total d'equipes de distribution de courrier fixes necessaires pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Ceci indique l'estimation du nombre total de membres de l'equipe de distribution de postes fixes requis pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "Ceci indique l'estimation du nombre total de superviseurs requis pour les equipes de repartition des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Ceci indique l'estimation du nombre total d'equipes d'enregistrement de poste fixe requises si la campagne se deroule pendant une journee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Cela indique l'estimation du nombre total d'equipes fixes d'enregistrement requises pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Ceci indique l'estimation du nombre total de membres fixes de l'equipe d'enregistrement requis pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "Ceci indique l'estimation du nombre total de superviseurs requis pour les equipes d'enregistrement des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Cela indique l'estimation du nombre total de menages.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Ceci indique l'estimation du nombre total d'equipes de distribution requises si la campagne se deroule pendant une journee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Cela indique l'estimation du nombre total d'equipes de distribution necessaires pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Cela indique l'estimation du nombre total de membres de l'equipe de distribution requis pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Ceci indique l'estimation du nombre total d'equipes d'inscription requises si la campagne se deroule pendant une journee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Cela indique l'estimation du nombre total d'equipes d'inscription necessaires pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Cela indique l'estimation du nombre total de moniteurs requis pour les equipes d'enregistrement.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Ceci indique l'estimation du nombre total de membres de l'equipe d'inscription requis pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Ceci indique l'estimation du nombre total de membres de l'equipe d'inscription requis pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MONITORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Cela indique l'estimation du nombre total de moniteurs requis pour les equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MONITORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Cela indique l'estimation du nombre total de moniteurs requis pour les equipes d'enregistrement.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Cela indique l'estimation du nombre total de superviseurs requis pour les moniteurs de l'equipe d'enregistrement.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_PEOPLE_PER_BEDNET",
+    "message": "Ceci indique l’estimation du nombre total de balles necessaires.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_STICKERS_ROLLS_PER_BOUNDARY",
+    "message": "Cela indique l'estimation du nombre total de rouleaux d'autocollants requis par limite.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_FIXED_POST_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Cela indique l'estimation du nombre total de superviseurs requis pour les equipes de repartition des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_FIXED_POST_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Ceci indique l'estimation du nombre total de superviseurs requis pour les equipes d'enregistrement des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Cela indique l'estimation du nombre total de superviseurs requis pour les equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Ceci indique l'estimation du nombre total de superviseurs requis pour les equipes d'enregistrement.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Cela indique l'estimation du nombre total d'equipes de distribution de courrier fixes necessaires pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Cela indique l'estimation du nombre total d'equipes fixes d'enregistrement requises pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Ceci indique l'estimation du nombre total d'equipes de distribution de courrier fixe requises si la campagne se deroule sur une journee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Ceci indique l'estimation du nombre total d'equipes d'enregistrement de poste fixe requises si la campagne se deroule pendant une journee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Cela indique l'estimation du nombre total de superviseurs requis pour les equipes de repartition des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Cela indique l'estimation du nombre total de superviseurs requis pour les equipes d'enregistrement a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Ceci indique l'estimation du nombre total de membres de l'equipe de distribution de postes fixes requis pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Ceci indique l'estimation du nombre total de membres fixes de l'equipe d'enregistrement requis pour l'ensemble des jours de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Cela indique l'estimation du nombre total de sacs requis par frontière pour les equipes de distribution a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Cela indique l'estimation du nombre total de sacs requis par limite pour les equipes d'enregistrement a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Cela indique l'estimation du nombre total de sacs requis par limite pour les equipes de distribution porte-a-porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Cela indique l'estimation du nombre total de sacs requis par limite pour les equipes d'enregistrement porte-a-porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Ceci indique l'estimation du nombre total de craies necessaires par limite pour les equipes de distribution de postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Ceci indique l'estimation du nombre total de craies requises par limite pour les equipes d'enregistrement a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Cela indique l'estimation du nombre total de craies necessaires par limite pour les equipes de distribution porte-a-porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Cela indique l'estimation du nombre total de craies necessaires par limite pour les equipes d'enregistrement porte-a-porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Cela indique l'estimation du nombre total d'enclos requis par limite pour les equipes de distribution de postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Cela indique l'estimation du nombre total d'enclos requis par limite pour les equipes d'enregistrement a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Cela indique l'estimation du nombre total d'enclos requis par limite pour les equipes de distribution porte-a-porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Cela indique l'estimation du nombre total d'enclos requis par limite pour les equipes d'enregistrement porte-a-porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS",
+    "message": "Cela indique l'estimation du SPAQ requis pour le groupe d'âge cible de 3 a 11 mois.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS_WITH_BUFFER",
+    "message": "Cela indique l'estimation du tampon pour le SPAQ requis pour le groupe d'âge cible de 3 a 11 mois.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS",
+    "message": "Cela indique l'estimation du SPAQ requis pour le groupe d'âge cible de 12 a 59 mois.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "Cela indique l'estimation du tampon pour le SPAQ requis pour le groupe d'âge cible de 12 a 59 mois.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_REQUIRED",
+    "message": "Ceci indique l’estimation du SPAQ total requis.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_REQUIRED_WITH_BUFFER",
+    "message": "Cela indique l’estimation du tampon pour le SPAQ total requis.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_TARGET_POPULATION",
+    "message": "Cela indique une estimation pour la population cible totale.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_NAME",
+    "message": "Nom de la formule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FORMULA_PERMANENT_DELETE_CUSTOM",
+    "message": "La suppression d'un element de campagne supprimera la formule. Êtes-vous sûr de vouloir supprimer la formule ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FOR_CONFIRM_TO_DELETE",
+    "message": "Êtes-vous sûr de vouloir supprimer ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FOR_PERMANENT_DELETE",
+    "message": "La suppression d'un element de campagne supprimera la formule. Vous pourrez cependant le recuperer en cliquant sur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Formula Name",
+    "message": "Nom de la formule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "FormulaConfigScreen",
+    "message": "Configuration de la formule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GENERAL_ESTIMATION",
+    "message": "Hypothèses generales",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GENERAL_INFORMATION",
+    "message": "Informations generales",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GENERATED",
+    "message": "Genere",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GENERATE_MICROPLAN",
+    "message": "Generer un microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GEOJSON",
+    "message": "Geojson",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GEOSPATIAL_MAP_VIEW",
+    "message": "Affichage de la carte geospatiale",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GO_BACK_HOME",
+    "message": "Retourne a la maison",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GO_BACK_TO_HOME",
+    "message": "Retourner a la maison",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GO_BACK_TO_MY_MICROPLAN",
+    "message": "Revenir a mon Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GO_BACK_TO_USER_MANAGEMENT",
+    "message": "Revenir a la gestion des utilisateurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GO_TO_HCM",
+    "message": "Acceder a la campagne HCM",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GRAVEL",
+    "message": "Gravier",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "GUIDELINES_NEXT",
+    "message": "Creer un microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BACK",
+    "message": "Dos",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_MESSAGE",
+    "message": "Veuillez remplir le modèle telecharge avec des informations sur la population et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CHILD_NOT_PRESENT",
+    "message": "sous la juridiction ne sont pas presents.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS_DESC",
+    "message": "Veuillez saisir les informations requises pour proceder a la configuration du microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS_HEADER",
+    "message": "Entrez les details de la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DISEASE",
+    "message": "Maladie de campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_FOR",
+    "message": "Pour Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_RESOURCE_DIST_STRAT",
+    "message": "Strategie de campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE_OF",
+    "message": "Type de campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_CLEAR_ALL",
+    "message": "Tout effacer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_DISEASE_TYPE",
+    "message": "Maladie identifiee pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_ERROR_FILE_UPLOAD_FAILED",
+    "message": "Une erreur interne s'est produite. Veuillez telecharger a nouveau le fichier.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_FILE_UPLOAD_ERROR",
+    "message": "Veuillez telecharger a nouveau un fichier valide.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLANNING_COMMENT_CHAR_LENGTH_ERROR_TOAST_MESSAGE",
+    "message": "Le commentaire ne peut pas contenir plus de 140 caractères.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLANNING_COMMENT_TOAST_MESSAGE",
+    "message": "Liste des cessionnaires",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADD_COMMENT_LABEL",
+    "message": "Ajouter des commentaires",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADD_COMMENT_REQUIRED",
+    "message": "Le commentaire est obligatoire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADMINISTRATIVEPOST_LABEL",
+    "message": "Poste administratif",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADMIN_POST_LABEL",
+    "message": "Poste d'administrateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ASSIGNED_DATA_APPROVER_LABEL",
+    "message": "Approbateur de donnees designe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_COMMENT_LOG_HEADING",
+    "message": "Journaux de commentaires",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_COMMENT_LOG_VIEW_LINK_LABEL",
+    "message": "Afficher les journaux de commentaires",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONCRETE",
+    "message": "Beton",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59_LABEL",
+    "message": "Population cible confirmee (Âge 12 a 59 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11_LABEL",
+    "message": "Population cible confirmee (Âge 3 a 11 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_LABEL",
+    "message": "Population cible confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION_LABEL",
+    "message": "Population totale confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_TARGET_POPULATION",
+    "message": "Confirmer la population cible du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_TARGET_POPULATION_LABEL",
+    "message": "Population cible confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_TOTAL_POPULATION_LABEL",
+    "message": "Population totale confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_VILLAGE_POPULATION",
+    "message": "Confirmer la population totale du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_COUNTRY_LABEL",
+    "message": "Pays",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DATA_UPLOAD_GUIDELINES",
+    "message": "Directives de telechargement de donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DESERT",
+    "message": "Desert",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DIRT",
+    "message": "Salete",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DISCRICT_LABEL",
+    "message": "District",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DISTRICT_LABEL",
+    "message": "District",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_CONFIRM_POPULATION_LABEL",
+    "message": "Modifier la population confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_CLOSE",
+    "message": "Annuler",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_COMMENT_LABEL",
+    "message": "Approuver les donnees pour les villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_COMMENT_SUBMIT_LABEL",
+    "message": "Envoyer pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Envoyer pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_EDIT_AND_VALIDATE",
+    "message": "Soumettre et valider",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_LABEL",
+    "message": "Modifier la population du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_SEND_FOR_APPOVAL",
+    "message": "Envoyer pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_TARGET_POPULATION",
+    "message": "Population cible telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_VILLAGE",
+    "message": "Nom du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_VILLAGE_POPULATION",
+    "message": "Population du village telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_WORKFLOW_UPDATED_SUCCESSFULLY",
+    "message": "Les donnees des villages selectionnes sont envoyees avec succès pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Entrez la population cible confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Entrez la population cible confirmée (de 12 à 59 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Entrez la population cible confirmée (3 à 11 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Entrez la population totale confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_TARGET_POPULATION",
+    "message": "Entrez la population cible",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_VILLAGE_POPULATION",
+    "message": "Entrez la population du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ERRORS_FOUND",
+    "message": "trouve dans le fichier telecharge !",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FACILITY_ACTION_ASSIGNMENT",
+    "message": "Attribuer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FACILITY_VIEW_ASSIGNMENT",
+    "message": "Afficher le devoir",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT",
+    "message": "Proceder a la finalisation de l'attribution des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_HEADING",
+    "message": "Etes-vous sûr de vouloir finaliser l'attribution de l'etablissement ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_MESSAGE",
+    "message": "Veuillez vous assurer que vous avez minutieusement verifie l'affectation des installations pour toutes les installations et les zones administratives situees dans le perimètre de la campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_PREFIX_MESSAGE",
+    "message": "Veuillez vous assurer que vous avez minutieusement verifie l'affectation des installations pour tous les",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_SUFFIX_MESSAGE",
+    "message": " zones administratives situees sous les limites de la campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_CANCEL_ACTION",
+    "message": "Je veux reverifier",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_HEADING_LABEL",
+    "message": "Finaliser l’affectation des installations au village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_SUBMIT_ACTION",
+    "message": "Je veux finaliser",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_SUBMIT_LABEL",
+    "message": "Attribuer des installations aux villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN",
+    "message": "Proceder a la finalisation de l'estimation Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_HEADING",
+    "message": "Etes-vous sûr de vouloir finaliser l'estimation du microplan ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_MESSAGE",
+    "message": "Veuillez vous assurer que vous avez minutieusement verifie l'estimation du microplan pour toutes les zones administratives situees sous les limites de la campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_PREFIX_MESSAGE",
+    "message": "Veuillez vous assurer que vous avez minutieusement verifie l'estimation du microplan pour tous les",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_SUFFIX_MESSAGE",
+    "message": " zones administratives situees sous les limites de la campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_CANCEL_ACTION",
+    "message": "Je veux reverifier",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_HEADING_LABEL",
+    "message": "Finaliser les estimations du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_SUBMIT_LABEL",
+    "message": "Je veux finaliser",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_MESSAGE",
+    "message": "Veuillez vous assurer que vous avez minutieusement verifie les donnees demographiques de toutes les zones administratives situees sous les limites de la campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_PREFIX_MESSAGE",
+    "message": "Veuillez vous assurer que vous avez minutieusement verifie les donnees demographiques pour tous les ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_SUFFIX_MESSAGE",
+    "message": "zones administratives situees sous les limites de la campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_HEADING_MESSAGE",
+    "message": "Etes-vous sûr de vouloir finaliser les donnees demographiques ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_MESSAGE",
+    "message": "Êtes-vous sûr de vouloir finaliser les donnees demographiques des villages ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA",
+    "message": "Continuer a finaliser les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA_CANCEL_ACTION",
+    "message": "Je veux reverifier",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA_LABEL",
+    "message": "Finaliser les donnees demographiques des villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA_SUBMIT_ACTION",
+    "message": "Je veux finaliser",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FOREST",
+    "message": "Forêt",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_GRAVEL",
+    "message": "Gravier",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_HCM_ADMIN_CONSOLE_TARGET_LAT_OPT_LABEL",
+    "message": "Latitude",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_HCM_ADMIN_CONSOLE_TARGET_LONG_OPT_LABEL",
+    "message": "Longitude",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_LOCALITY_LABEL",
+    "message": "Localite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_MICROPLAN_NAME_LABEL",
+    "message": "Nom du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_MOUNTAIN",
+    "message": "Montagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_NOT_ABLE_TO_FETCH_DETAILS",
+    "message": "Il y a un problème. Les details des limites ne sont pas recuperes. ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_NO_ROAD",
+    "message": "Pas de route",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ONLY_POSITIVE_NUMBERS",
+    "message": "Veuillez saisir une valeur numerique positive",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ONLY_POSITIVE_NUMBERS_MAX_LIMIT_VALIDATION_ERROR",
+    "message": "La valeur doit être un nombre entier superieur a 0 et inferieur a 1 00 000.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLAIN",
+    "message": "Plaine",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLAN_INBOX_BACK_BUTTON",
+    "message": "Retourner a la maison",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLAN_INBOX_TOTAL_ASSIGNEES",
+    "message": "Liste des cessionnaires",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLURAL_ERROR",
+    "message": "Erreurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLURAL_ERRORS",
+    "message": "Erreurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_POPULATION_DATA_HEADING",
+    "message": "Donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_POP_INBOX_BACK_BUTTON",
+    "message": "Aller a la page d'accueil",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_POP_INBOX_TOTAL_ASSIGNEES",
+    "message": "Liste des assignes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PROCESSED_FILE",
+    "message": "Feuille telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PROVINCE_LABEL",
+    "message": "Province",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SEARCH_JURISDICTION_INFO_DESCRIPTION",
+    "message": "Veuillez selectionner « Hierarchie administrative », puis les champs deroulants « Zone administrative » pour effectuer la recherche.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SECURITY_AND_ACCESSIBILITY_HEADING",
+    "message": "Securite et accessibilite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SERVING_FACILITY",
+    "message": "Nom de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SINGLE_ERROR",
+    "message": "Erreur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_STATUS_LOG_FOR_LABEL",
+    "message": "Journaux d'etat pour ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_STATUS_LOG_LABEL",
+    "message": "Journaux d'etat",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_TARGET_CANNOT_EXCEED_TOTAL",
+    "message": "La « Population cible confirmee » ne doit pas depasser la valeur de la « Population totale confirmee ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_TOTAL_CANNOT_BE_LESS_THAN_TARGET",
+    "message": "La « Population cible confirmee » ne doit pas depasser la valeur de la « Population totale confirmee ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59_LABEL",
+    "message": "Population cible telechargee (âges de 12 a 59 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11_LABEL",
+    "message": "Population cible telechargee (3 a 11 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_LABEL",
+    "message": "Population cible telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION_LABEL",
+    "message": "Population totale telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_TARGET_POPULATION_LABEL",
+    "message": "Population cible telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_TOTAL_POPULATION_LABEL",
+    "message": "Population totale telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VALIDATE_AND_APPROVE_MICROPLAN_ESTIMATIONS",
+    "message": "Valider et approuver les estimations Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VIEW_VILLAGE_BACK",
+    "message": "Dos",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_CLOSE_LABEL",
+    "message": "Fermer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_DETAIL_EDIT_LINK",
+    "message": "Modifier les details d'accessibilite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_DETAIL_LINK",
+    "message": "Entrez les details d'accessibilite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_DETAIL_VIEW_LINK",
+    "message": "Voir les details d'accessibilite du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_LABEL",
+    "message": "Accessibilite du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_SAVE_LABEL",
+    "message": "Sauvegarder",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_HIERARCHY_LABEL",
+    "message": "Details de la hierarchie des limites",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_LABEL",
+    "message": "Village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ROAD_CONDITION_LABEL",
+    "message": "etat des routes du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_CLOSE_LABEL",
+    "message": "Fermer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_DETAIL_LINK",
+    "message": "Entrez les details de securite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_EDIT_LINK",
+    "message": "Modifier les details de securite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_LABEL",
+    "message": "Securite du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_LEVEL_LABEL",
+    "message": "Niveau de securite du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_SAVE_LABEL",
+    "message": "Sauvegarder",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_VIEW_LINK",
+    "message": "Afficher les details de la securite du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_TERRAIN_LABEL",
+    "message": "Terrain du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_TRANSPORTATION_MODE_LABEL",
+    "message": "Mode de transport",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_NEXT",
+    "message": "Suivant",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_SELECTED",
+    "message": "Choisi",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_BOUNDARY_MICROPLAN",
+    "message": "Population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_DATA",
+    "message": "Gerer les donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_FACILITY_MICROPLAN",
+    "message": "Installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_COMPLETED",
+    "message": "Le fichier a ete valide avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HCM_VIEW_ERROR",
+    "message": "Afficher les erreurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DATA_UPLOAD_GUIDELINES",
+    "message": "Directives de telechargement de donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DATA_WAS_UPDATED_WANT_TO_SAVE",
+    "message": "Les donnees de la section ont ete mises a jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DELETE_FILE_CONFIRMATION",
+    "message": "Etes-vous sûr de vouloir supprimer ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Telecharger le modèle Excel pour l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Telecharger le modèle Geojson pour l'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_SHAPEFILES",
+    "message": "Telecharger le modèle de fichiers Shapefiles pour les installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_EXCEL",
+    "message": "Telecharger le modèle Excel pour l'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_GEOJSON",
+    "message": "Telecharger le modèle Geojson pour l'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_SHAPEFILES",
+    "message": "Telecharger le modèle de fichiers Shapefiles pour les installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATEEXCEL",
+    "message": "Telecharger le modèle Excel pour le taux d'incidents",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_GEOJSON",
+    "message": "Telecharger le modèle Geojson pour le taux d'incidents",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_SHAPEFILES",
+    "message": "Telecharger le modèle de fichiers Shape pour le taux d'incidents",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Telecharger le modèle Excel pour la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Telecharger le modèle Geojson pour la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_SHAPEFILES",
+    "message": "Telecharger le modèle de fichiers Shapefiles pour la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_EXCEL",
+    "message": "Telecharger le modèle Excel pour les entrepôts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_GEOJSON",
+    "message": "Telecharger le modèle Geojson pour les entrepôts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_SHAPEFILES",
+    "message": "Telecharger le modèle de fichiers Shapefiles pour les entrepôts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Telecharger le modèle Excel pour les installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Telecharger le modèle Geojson pour les installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_FACILITIES_SHAPE_FILES",
+    "message": "Telecharger le modèle Shapefile pour les installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Telecharger le modèle Excel pour la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Telecharger le modèle Geojson pour la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_POPULATION_SHAPE_FILES",
+    "message": "Telecharger le modèle Shapefile pour la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITIES_EXCEL",
+    "message": "Telechargez Excel pour les donnees des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITIES_GEOJSON",
+    "message": "Telechargez Geojson pour les donnees sur les installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITIES_SHAPE_FILES",
+    "message": "Telecharger un fichier Shape pour les donnees des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITY_EXCEL",
+    "message": "Telecharger le modèle Excel pour l'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITY_GEOJSON",
+    "message": "Telecharger le modèle GeoJSON pour l'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITY_SHAPE_FILES",
+    "message": "Telecharger le modèle de fichiers Shapefiles pour les installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_INCIDENT_RATE_EXCEL",
+    "message": "Telecharger Excel pour les donnees sur les taux d'incidents",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_INCIDENT_RATE_GEOJSON",
+    "message": "Telecharger Geojson pour les donnees sur le taux d'incidents",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_INCIDENT_RATE_SHAPE_FILES",
+    "message": "Telecharger un fichier Shape pour les donnees sur le taux d'incidents",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POLULATION_EXCEL",
+    "message": "Telecharger Excel pour les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POLULATION_GEOJSON",
+    "message": "Telecharger Geojson pour les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POLULATION_SHAPE_FILES",
+    "message": "Telecharger un fichier Shape pour les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POPULATION_EXCEL",
+    "message": "Telechargez Excel pour les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POPULATION_GEOJSON",
+    "message": "Telechargez Geojson pour les donnees de population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POPULATION_SHAPE_FILES",
+    "message": "Telechargez un fichier Shape pour les donnees sur la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_WARE_HOUSES_EXCEL",
+    "message": "Telecharger Excel pour les donnees des entrepôts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_WARE_HOUSES_GEOJSON",
+    "message": "Telecharger Geojson pour les donnees des entrepôts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_WARE_HOUSES_SHAPE_FILES",
+    "message": "Telecharger un fichier Shape pour les donnees des entrepôts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_HYPOTHESIS",
+    "message": "Proposez vos paramètres d’estimation des cibles et des ressources",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_MICROPLAN_GENERATION_CONFIRMATION",
+    "message": "Generer un microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_PROCEED_WITH_NEW_HYPOTHESIS",
+    "message": "Voulez-vous poursuivre avec la nouvelle hypothèse ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_REUPLOAD_FILE_CONFIRMATION",
+    "message": "Êtes-vous sûr de vouloir reimporter les donnees ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_RULE_ENGINE",
+    "message": "Configurer la règle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_SPATIAL_DATA_PROPERTY_MAPPING",
+    "message": "Mappez vos colonnes de manière appropriee pour qu'elles correspondent au modèle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_FACILITIES",
+    "message": "Selectionnez l'un des formats pour telecharger les donnees des installations.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_FACILITY",
+    "message": "Telecharger les donnees de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_INCIDENT_RATE",
+    "message": "Selectionnez l'un des formats pour telecharger les donnees sur le taux d'incidents",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_POPULATION",
+    "message": "Selectionnez l'un des formats pour telecharger les donnees demographiques.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_WARE_HOUSES",
+    "message": "Selectionnez l'un des formats pour telecharger les donnees des entrepôts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_HYPOTHESIS_ADD_BUTTON",
+    "message": "Cliquez sur « ajouter plus » pour configurer une nouvelle hypothèse. Les valeurs deroulantes sont configurees par type de campagne. Si une nouvelle valeur est requise, veuillez demander a l'equipe d'assistance L1/L2",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_HYPOTHESIS_DELETE_BUTTON",
+    "message": "Cliquez sur « supprimer » pour supprimer une hypothèse configuree qui n'est pas pertinente pour ce microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_HYPOTHESIS_INTERACTABLE_SECTION",
+    "message": "Cette page vous aide a definir les valeurs des hypothèses/hypothèses utilisees dans un microplan. a l'etape suivante, vous pouvez utiliser ces valeurs pour configurer des règles ou des formules. Ces valeurs seront utilisees dans le moteur de calcul pour arriver au nombre de ressources. Peu d'hypothèses sont renseignees par defaut selon le type de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_BASE_MAP",
+    "message": "Cliquez ici pour selectionner une couche - cela vous aidera a visualiser les rues, les routes et les plans d'eau en fonction des donnees disponibles",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_BOUNDARY_SELECTION",
+    "message": "Cliquez ici pour selectionner une limite/geographie pour laquelle vous souhaitez voir les details sur la carte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_FILTER",
+    "message": "Cliquez sur filtre pour voir les points d'interêt et les points de service",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_MAP_GEOMETRIES",
+    "message": "Passez la souris sur ou selectionnez une limite sur la carte pour afficher les cibles, les estimations de ressources et les equipes/personnes affectees.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_VIRTUALIZATION",
+    "message": "Cliquez sur « Visualisations » pour voir une carte choroplèthe pour la propriete selectionnee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_MICROPLAN_DETAILS_CAMPAIGN_DETAILS",
+    "message": "Les details de la campagne sont affiches ici.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_MICROPLAN_DETAILS_EDIT_ROWS",
+    "message": "Pour editer un microplan, double-cliquez sur n'importe quelle ligne et sur la section suivante, configurez les nouvelles valeurs des ressources calculees puis cliquez sur Enregistrer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_MICROPLAN_DETAILS_MICROPLAN_NAME",
+    "message": "Vous pouvez saisir le nom du microplan ici.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_ADD_BUTTON",
+    "message": "Cliquez sur « ajouter plus » pour configurer une nouvelle formule. Les valeurs deroulantes sont configurees par type de campagne. Si vous pensez qu'une nouvelle formule est necessaire, veuillez demander a l'equipe d'assistance L1/L2",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_DELETE_BUTTON",
+    "message": "Cliquez sur « supprimer » pour supprimer une formule configuree qui n'est pas pertinente pour ce microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_INPUT",
+    "message": "Cliquez sur « entree » pour selectionner une option qui a ete recuperee en fonction de vos donnees telechargees et des règles anterieures.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_INTERACTABLE_SECTION",
+    "message": "Cette page vous aide a definir les valeurs des formules utilisees dans un microplan. Ces formules seront utilisees dans le moteur de calcul pour arriver au nombre de ressources. Peu de formules ou de règles sont renseignees automatiquement en fonction du type de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HELP_UPLOAD_FILETYPE_OPTION_CONTAINER",
+    "message": "Selectionnez un format de telechargement. a l'etape suivante, veuillez lire les directives relatives aux donnees liees a chaque format a l'etape suivante. Si vous rencontrez des erreurs lors du telechargement, verifiez le fichier d'entree, sinon contactez l'equipe d'assistance L1/L2. ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HIERARCHY",
+    "message": "Hierarchie administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HOME",
+    "message": "Maison",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HOUSEHOLD_DISTRIBUTION",
+    "message": "Hypothèses de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HOUSEHOLD_REGISTRATION",
+    "message": "Hypothèses d'enregistrement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HOUSEHOLD_REGISTRATION_INFORMATION",
+    "message": "Informations d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HOUSE_TO_HOUSE",
+    "message": "De maison a maison",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "Cela indique le nombre moyen de personnes dans un menage. Ceci sera utilise pour estimer le nombre de menages.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Ceci indique le nombre de sacs necessaires par equipe et par cycle pour les equipes de distribution en poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Celui-ci indique le nombre de sacs necessaires par equipe et par cycle pour les equipes d'inscription a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Cela indique le nombre de sacs requis par equipe et par cycle pour les equipes de distribution domestique.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Cela indique le nombre de sacs requis par equipe et par cycle pour les equipes d'enregistrement des menages.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BEDNETS_PER_BALE",
+    "message": "Cela indique la taille d'une balle. Ceci sera utilise pour estimer le nombre total de balles.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Cela indique le nombre total de beneficiaires devant être pris en charge par une equipe de distribution par jour et par cycle. Ceci sera utilise pour estimer le nombre total d’equipes de distribution requises.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Cela indique le nombre total de beneficiaires devant être pris en charge par une equipe de distribution par jour et par cycle. Ceci sera utilise pour estimer le nombre total d’equipes de distribution requises.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "Ceci indique le nombre de beneficiaires ou de menages qui doivent être enregistres par une equipe d'enregistrement par jour. Cela servira a estimer le nombre d’equipes d’inscription.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Ceci indique le nombre de craies necessaires par equipe et par cycle pour les equipes de distribution a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Ceci indique le nombre de craies necessaires par equipe et par cycle pour les equipes d'inscription a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Ceci indique le nombre de craies necessaires par equipe et par cycle pour les equipes de distribution domestique.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Cela indique le nombre de craies requises par equipe et par cycle pour les equipes d'enregistrement des menages.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Ceci indique le nombre total de jours de distribution. Ceci sera utilise pour estimer le nombre total d’equipes de distribution requises.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Cela indique le nombre total de jours pour la distribution des menages.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Ceci indique le nombre total de jours pour l’inscription. Ceci sera utilise pour estimer le nombre total d’equipes d’inscription requises.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes de distribution de postes fixes gerees par un superviseur. Ce montant sera utilise pour estimer le nombre total de superviseurs pour l'equipe de repartition des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes d'enregistrement a poste fixe gerees par un superviseur. Ceci servira a estimer le nombre de superviseurs pour les equipes d'enregistrement des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "Cela indique le nombre de menages par rouleau d'autocollants.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes de distribution pouvant être gerees par un superviseur. Ceci sera utilise pour estimer le nombre total de superviseurs requis pour les equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Cela indique le nombre d'equipes d'enregistrement sous un moniteur. Cela sera utilise pour estimer le nombre total de moniteurs pour les equipes d'enregistrement.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes d'inscription qui peuvent être gerees par un superviseur. Ceci sera utilise pour estimer le nombre total de superviseurs requis pour les equipes d’inscription.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Cela indique la taille d’une equipe de distribution. Ceci sera utilise pour estimer le nombre total de membres des equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Ceci indique la taille de l'equipe d'une equipe d'inscription a poste fixe. Ceci sera utilise pour estimer le nombre total de membres des equipes d’inscription.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Cela indique la taille de l’equipe de distribution des menages. Ceci sera utilise pour estimer le nombre total de membres des equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Cela indique la taille d’une equipe d’enregistrement. Ceci sera utilise pour estimer le nombre total de membres de l’equipe d’inscription.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Ceci indique le nombre de moniteurs geres par un superviseur. Cela sera utilise pour estimer le nombre total de superviseurs pour les equipes d'inscription.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Ceci indique le nombre de stylos requis par equipe et par cycle pour les equipes de distribution a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Ceci indique le nombre de stylos necessaires par equipe et par cycle pour les equipes d'inscription a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Cela indique le nombre de stylos requis par equipe et par cycle pour les equipes de distribution domestique.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Cela indique le nombre de stylos requis par equipe et par cycle pour les equipes d'enregistrement des menages.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PEOPLE_PER_BEDNET",
+    "message": "Ceci indique le nombre de personnes a accueillir dans une moustiquaire. Ceci sera utilise pour estimer le nombre total de moustiquaires.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Ceci indique le nombre de moustiquaires a distribuer par une equipe de distribution par jour. Ceci sera utilise pour estimer le nombre d’equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Celui-ci indique le nombre de beneficiaires ou de menages a inscrire par jour au point fixe de distribution. Ceci sera utilise pour estimer le nombre d'equipes d'enregistrement de poste fixe necessaires.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Celui-ci indique le nombre de jours d'inscription. Ceci sera utilise pour estimer le nombre total d’equipes d’enregistrement de poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Cela indique le nombre d’equipes de distribution sous un moniteur. Cela sera utilise pour estimer le nombre total de moniteurs pour les equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Cela indique la taille d’une equipe de distribution. Ceci sera utilise pour estimer le nombre total de membres de l’equipe de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_TOTAL_BUFFER_MULTIPLIER",
+    "message": "Ceci indique le pourcentage de tampon qui sera utilise pour calculer les ressources totales requises en excedent.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_TOTAL_CYCLES_OF_SMC",
+    "message": "Ceci indique le nombre total de cycles dans la campagne SMC. Ceci sera utilise pour estimer le nombre total de SPAQ requis.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS",
+    "message": "Hypothèse",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_INSTRUCTIONS_DELETE_ENTRY_CONFIRMATION",
+    "message": "La suppression d'un element de campagne supprimera definitivement l'estimation. Vous ne pourrez pas le recuperer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_KEY_HELP_TEXT",
+    "message": "Il s’agit d’une hypothèse sur le nombre de personnes composant un menage.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "Cela indique le nombre moyen de personnes dans un menage. Ceci sera utilise pour estimer le nombre de menages.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Ceci indique le nombre de sacs necessaires par equipe et par cycle pour la distribution des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Celui-ci indique le nombre de sacs necessaires par equipe et par cycle pour l'inscription en poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Ceci indique le nombre de sacs par equipe et par cycle pour la distribution de porte a porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Celui-ci indique le nombre de sacs par equipe et par cycle pour l'enregistrement en porte-a-porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BEDNETS_PER_BALE",
+    "message": "Cela indique la taille d'une balle. Ceci sera utilise pour estimer le nombre total de balles.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BEDNETS_TO_BE_DISTRIBUTED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY",
+    "message": "Ceci indique le nombre de moustiquaires a distribuer par une equipe de distribution par jour. Ceci sera utilise pour estimer le nombre d’equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Cela indique le nombre total de beneficiaires devant être pris en charge par une equipe de distribution par jour et par cycle. Ceci sera utilise pour estimer le nombre total d’equipes de distribution requises.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Celui-ci indique le nombre de beneficiaires a prendre en charge par jour au point de distribution a poste fixe. Ceci servira a estimer le nombre d'equipes de distribution au point de distribution fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "Ceci indique le nombre de beneficiaires ou de menages a enregistrer par une equipe d'enregistrement par jour. Cela servira a estimer le nombre d’equipes d’inscription.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Celui-ci indique le nombre de beneficiaires a inscrire par jour au point fixe de distribution. Ceci servira a estimer le nombre d'equipes d'enregistrement au point de distribution a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Ceci indique le nombre de craies necessaires par equipe et par cycle pour la distribution des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Celui-ci indique le nombre de craies necessaires par equipe et par cycle pour l'inscription au poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Cela indique le nombre de craies necessaires par equipe et par cycle pour la distribution de porte a porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Ceci indique le nombre de craies necessaires par equipe et par cycle pour l'enregistrement porte a porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Ceci indique le nombre de jours de distribution. Cela servira a estimer le nombre total d’equipes de distribution de postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Celui-ci indique le nombre de jours d'inscription. Ceci sera utilise pour estimer le nombre total d’equipes d’enregistrement de poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Ceci indique le nombre de jours de distribution. Ceci sera utilise pour estimer le nombre total d’equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Celui-ci indique le nombre de jours d'inscription. Ceci sera utilise pour estimer le nombre total d’equipes d’inscription.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes d'enregistrement a poste fixe gerees par un superviseur. Ce montant sera utilise pour estimer le nombre total de superviseurs pour l'equipe d'enregistrement des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes d'enregistrement a poste fixe gerees par un superviseur. Ce montant sera utilise pour estimer le nombre total de superviseurs pour l'equipe d'enregistrement des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "Cela indique le nombre de menages par rouleau d'autocollants. Cela sera utilise pour estimer les besoins en rouleaux d’autocollants.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_MONITOR",
+    "message": "Cela indique le nombre d’equipes de distribution sous un moniteur. Cela sera utilise pour estimer le nombre total de moniteurs pour les equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes de distribution pouvant être gerees par un superviseur. Ceci sera utilise pour estimer le nombre total de superviseurs requis pour les equipes de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Cela indique le nombre d'equipes d'enregistrement sous un moniteur. Cela sera utilise pour estimer le nombre total de moniteurs pour les equipes d'enregistrement.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes d'inscription qui peuvent être gerees par un superviseur. Ceci sera utilise pour estimer le nombre total de superviseurs requis pour les equipes d’inscription.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Cela indique la taille d’une equipe de distribution de courrier fixe. Ceci sera utilise pour estimer le nombre total de membres de l’equipe de distribution des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Cela indique la taille d’une equipe d’enregistrement de poste fixe. Ceci sera utilise pour estimer le nombre total de membres de l’equipe d’enregistrement des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": " Cela indique la taille d’une equipe de distribution. Ceci sera utilise pour estimer le nombre total de membres de l’equipe de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Cela indique la taille d’une equipe d’enregistrement. Ceci sera utilise pour estimer le nombre total de membres de l’equipe d’inscription.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_FIXED_POST_REGISTRATION",
+    "message": "Ceci indique le nombre de moniteurs geres par un superviseur. Ce montant sera utilise pour estimer le nombre total de superviseurs pour l'equipe d'enregistrement des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Ceci indique le nombre de moniteurs geres par un superviseur. Ceci sera utilise pour estimer le nombre total de superviseurs pour l’equipe de distribution.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Ceci indique le nombre de moniteurs geres par un superviseur. Cela sera utilise pour estimer le nombre total de superviseurs pour l’equipe d’inscription.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Ceci indique le nombre de stylos necessaires par equipe et par cycle pour la distribution des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Celui-ci indique le nombre de stylos necessaires par equipe et par cycle pour l'inscription en poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Cela indique le nombre de stylos necessaires par equipe et par cycle pour la distribution porte-a-porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Cela indique le nombre de stylos necessaires par equipe et par cycle pour l'enregistrement porte-a-porte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PEOPLE_PER_BEDNET",
+    "message": "Ceci indique le nombre de personnes a accueillir dans une moustiquaire. Ceci sera utilise pour estimer le nombre total de moustiquaires.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_AT_THE_FIXES_POST_DISTRIBUTION_POINT_PER_DAY",
+    "message": "Ceci indique le nombre de moustiquaires a distribuer au point de distribution fixe par jour. Ceci servira a estimer le nombre d'equipes de distribution au point de distribution fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Ceci indique le nombre de moustiquaires a distribuer au point de distribution fixe par jour. Ceci servira a estimer le nombre d'equipes de distribution au point de distribution fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Celui-ci indique le nombre de beneficiaires ou de menages a inscrire par jour au point fixe de distribution. Ceci servira a estimer le nombre d'equipes d'enregistrement au point de distribution a poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Ceci indique le nombre de jours de distribution. Cela servira a estimer le nombre total d’equipes de distribution de postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Celui-ci indique le nombre de jours d'inscription. Ceci sera utilise pour estimer le nombre total d’equipes d’enregistrement de poste fixe.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_MANAGED_BY_A_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes de distribution de postes fixes gerees par un superviseur. Ce montant sera utilise pour estimer le nombre total de superviseurs pour l'equipe de repartition des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes de distribution de postes fixes gerees par un superviseur. Ce montant sera utilise pour estimer le nombre total de superviseurs pour l'equipe de repartition des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Ceci indique le nombre d'equipes d'enregistrement a poste fixe gerees par un superviseur. Ce montant sera utilise pour estimer le nombre total de superviseurs pour l'equipe d'enregistrement des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Cela indique la taille d’une equipe de distribution de courrier fixe. Ceci sera utilise pour estimer le nombre total de membres de l’equipe de distribution des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Cela indique la taille d’une equipe d’enregistrement de poste fixe. Ceci sera utilise pour estimer le nombre total de membres de l’equipe d’enregistrement des postes fixes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_TOTAL_BEDNET_WASTAGE",
+    "message": "Cela indique le facteur de gaspillage total des moustiquaires.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_TOTAL_BUFFER_MULTIPLIER",
+    "message": "Ceci indique le pourcentage de tampon qui sera utilise pour calculer les ressources totales requises en excedent.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_TOTAL_CYCLES_OF_SMC",
+    "message": "Ceci indique le nombre total de cycles dans la campagne SMC. Ceci sera utilise pour estimer le nombre total de SPAQ requis.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_VALUE_HELP_TEXT",
+    "message": "Veuillez definir une valeur pour calculer les ressources",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYP_CONFIRM_TO_DELETE",
+    "message": "Êtes-vous sûr de vouloir supprimer ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYP_PERMANENT_DELETE",
+    "message": "La suppression d'un element de campagne supprimera l'hypothèse. Vous pourrez cependant le recuperer en cliquant sur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "HYP_PERMANENT_DELETE_CUSTOM",
+    "message": "La suppression d'un element de campagne supprimera l'hypothèse. Etes-vous sûr de vouloir supprimer l'hypothèse ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Home",
+    "message": "Maison",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_ASSIGNEE",
+    "message": "Cessionnaire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Population cible confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Population cible confirmee (12 a 59 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "Population cible confirmee (12 a 59 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Population cible confirmee (3 a 11 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "Population cible confirmee (3 a 11 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Population totale confirmee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_EDITPOPULATION",
+    "message": "Modifier la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_STATUSLOGS",
+    "message": "Journaux d'etat",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_TOTAL_POPULATION",
+    "message": "Population totale",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Population cible telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Population cible telechargee (12 a 59 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "Population cible telechargee (12 a 59 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Population cible telechargee (3 a 11 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "Population cible telechargee (3 a 11 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Population totale telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INBOX_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INCIDENT_RATE",
+    "message": "Taux d'incidents",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INCORRECT_FIELDS",
+    "message": "Veuillez saisir une valeur numerique positive valide avec 2 points decimaux et jusqu'a 1 000 uniquement.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INFO",
+    "message": "Informations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INFORMATION_DESCRIPTION",
+    "message": "Conformement aux lignes directrices standard de telechargement de donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INFORMATION_DESCRIPTION_LINK",
+    "message": "ici",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INITIATE",
+    "message": "Donnees soumises",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_FACILITIES",
+    "message": "Veuillez selectionner l'un des formats suivants pour telecharger les donnees sur les installations requises pour votre microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_FACILITY",
+    "message": "Veuillez selectionner l'un des formats suivants pour telecharger les donnees d'etablissement requises pour votre microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_INCIDENT_RATE",
+    "message": "Veuillez selectionner l'un des formats suivants pour telecharger les donnees de taux d'incidents requises pour votre microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_POPULATION",
+    "message": "Veuillez selectionner l'un des formats suivants pour telecharger les donnees demographiques requises pour votre microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_WARE_HOUSES",
+    "message": "Veuillez selectionner l'un des formats suivants pour telecharger les donnees d'entrepôt requises pour votre microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DELETE_FILE_CONFIRMATION",
+    "message": "La suppression du fichier telecharge l'effacera definitivement. Vous ne pourrez pas le recuperer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Telechargez le modèle Excel pour les installations. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Telechargez le modèle Geojson pour les installations. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_SHAPEFILES",
+    "message": "Telechargez le modèle Shapefiles pour les installations. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_EXCEL",
+    "message": "Telechargez le modèle Excel pour l'installation. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_GEOJSON",
+    "message": "Telechargez le modèle Geojson pour Facility. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_SHAPEFILES",
+    "message": "Telechargez le modèle Shapefiles pour l'installation. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATEEXCEL",
+    "message": "Telechargez le modèle Excel pour le taux d'incidents. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_GEOJSON",
+    "message": "Telechargez le modèle Geojson pour le taux d'incidents. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_SHAPEFILES",
+    "message": "Telechargez le modèle Shapefiles pour le taux d'incidents. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Telechargez le modèle Excel contenant la hierarchie des limites. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Telechargez le modèle Geojson pour la population. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_SHAPEFILES",
+    "message": "Telechargez le modèle Shapefiles pour la population. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_EXCEL",
+    "message": "Telechargez le modèle Excel pour les entrepôts. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_GEOJSON",
+    "message": "Telechargez le modèle Geojson pour les entrepôts. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_SHAPEFILES",
+    "message": "Telechargez le modèle Shapefiles pour les entrepôts. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Telechargez le modèle Excel contenant la hierarchie des limites. Une fois telecharge, veuillez remplir le modèle avec les donnees des installations et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Telechargez le modèle Geojson qui contient la hierarchie des limites. Une fois telecharge, veuillez remplir le modèle avec les donnees des installations et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_FACILITIES_SHAPE_FILES",
+    "message": "Telechargez le modèle Shapefile qui contient la hierarchie des limites. Une fois telecharge, veuillez remplir le modèle avec les donnees des installations et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Telechargez le modèle Excel contenant la hierarchie des limites. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Telechargez le modèle Geojson qui contient la hierarchie des limites. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_POPULATION_SHAPE_FILES",
+    "message": "Telechargez le modèle Shapefile qui contient la hierarchie des limites. Une fois telecharge, veuillez remplir le modèle avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_FACILITIES",
+    "message": "Veuillez remplir le modèle telecharge avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_FACILITY",
+    "message": "Veuillez remplir le modèle telecharge avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_INCIDENT_RATE",
+    "message": "Veuillez remplir le modèle telecharge avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_POPULATION",
+    "message": "Veuillez remplir le modèle telecharge avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_WARE_HOUSES",
+    "message": "Veuillez remplir le modèle telecharge avec les donnees demographiques et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_MICROPLAN_GENERATION_CONFIRMATION",
+    "message": "Êtes-vous sûr de vouloir executer le microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_REUPLOAD_FILE_CONFIRMATION",
+    "message": "Le nouveau telechargement du fichier effacera le fichier precedemment telecharge et vous ne pourrez pas le recuperer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UNLOAD_EXCEL",
+    "message": "Faites glisser et deposez votre feuille Excel remplie ou parcourez mes fichiers.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UNLOAD_GEOJSON",
+    "message": "Faites glisser et deposez votre fichier GeoJSON rempli ou parcourez mes fichiers.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UNLOAD_SHAPE_FILES",
+    "message": "Faites glisser et deposez vos Shapefiles remplis ou parcourez mes fichiers.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_BROWSE_FILES",
+    "message": "Naviguer dans mes fichiers",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_EXCEL",
+    "message": "Faites glisser et deposez votre feuille Excel remplie ou",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_FACILITIES",
+    "message": "Faites glisser et deposez votre fichier geojson rempli ou",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_GEOJSON",
+    "message": "Faites glisser et deposez votre fichier geojson rempli ou",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_SHAPE_FILES",
+    "message": "Faites glisser et deposez votre fichier geojson rempli ou",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_DATA_WAS_UPDATED_WANT_TO_SAVE",
+    "message": "Vous voulez le sauvegarder ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_HYPOTHESIS",
+    "message": "Les cles suggerees sont pre-remplies. Entrez les valeurs des cles pour formuler votre hypothèse. Ceci sera utilise pour l’estimation des ressources. ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_1",
+    "message": "Vous êtes sur l'onglet Clients BI dans l'ecran d'edition des caracteristiques dans les outils de modelisation BW. Vous avez choisi Formes ou Formes et donnees de points comme type geographique.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_2",
+    "message": "Choisissez Telecharger des fichiers de formes sous Actions. Choisissez Aller. Le backend BW/4 s'ouvre.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_3",
+    "message": "Selectionnez vos fichiers de formes. Vous avez besoin des trois fichiers de formes suivants : .dbf, .shp, .shx. Les fichiers de formes doivent figurer dans l'ID de reference spatiale 4326 et doivent tous avoir le même nom avant la fin.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_4",
+    "message": "Choisissez Mettre a jour la geotable sous Actions. Choisissez Aller. Vous pouvez choisir entre la mise a jour Delta ou la mise a jour complète.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_5",
+    "message": "Les formes telechargees sont transformees et stockees dans le SRID (Spatial Reference ID) 3857. Il n'est donc pas possible d'utiliser des formes dans SAC si elles depassent les limites de ce système de reference spatiale. Cela signifie qu'ils ne doivent pas avoir de degres de latitude superieurs a 85,06° et -85,06°.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PREREQUISITES_1",
+    "message": "Vous avez ajoute une colonne ou un champ portant le nom de la caracteristique aux fichiers de formes pour lesquels vous souhaitez charger des formes. Si vous utilisez des caracteristiques composees, vous avez ajoute plusieurs colonnes. Plus d'informations :",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PREREQUISITES_2",
+    "message": "Pour mettre a jour la geotable avec les formes telechargees sur Business Document Server, vous avez besoin de SAP HANA 2.0 Rev 45.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PREREQUISITES_LINK",
+    "message": "Preparation des fichiers de formes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PROCEED_WITH_NEW_HYPOTHESIS",
+    "message": "Votre hypothèse a ete modifiee par rapport a celle proposee precedemment. Vous ne pourrez pas editer ou changer votre hypothèse une fois le microplan genere.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_RULE_ENGINE",
+    "message": "Configurez votre formule pour le microplan en definissant votre entree, vos operateurs, votre valeur et vos cles.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INSTRUCTION_SPATIAL_DATA_PROPERTY_MAPPING",
+    "message": "Le fichier Geojson ou shape que vous avez telecharge a des noms de balises differents, comme prevu. Veuillez effectuer un petit exercice de cartographie afin que nous sachions sur quelles colonnes le mapper.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INTERNAL_SERVER_ERROR",
+    "message": "Erreur interne du serveur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INVALID_MOBILE_NUMBER",
+    "message": "Veuillez saisir un numero de mobile valide.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "INVALID_MOBILE_NUMBER_LENGTH",
+    "message": "Veuillez entrer un numero de contact valide pour effectuer la recherche.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "KEY",
+    "message": "Cles",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LAYERS",
+    "message": "Calques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_GUIDELINE_POINTS_1",
+    "message": "Le nom du fichier doit être « Population.xlsx ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_GUIDELINE_POINTS_2",
+    "message": "Les champs Latitude et Longitude doivent contenir des données en degrés décimaux et en degrés minutes secondes (la valeur doit être 12,3455 et non 12° 20' 43,7994\").",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_1",
+    "message": "Le fichier GeoJSON doit répondre aux",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_2",
+    "message": "Le nom du fichier doit être « Population.geojson ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_3",
+    "message": "Toutes les entites du fichier doivent avoir des geometries du même type (c'est-a-dire qu'elles doivent toutes être des points, ou toutes doivent être des multipolygones, etc.).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_4",
+    "message": "Les coordonnees doivent être dans la plage valide de latitude et de longitude (la plage valide pour la latitude est de -90 a +90 et la plage valide de longitude est de -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_5",
+    "message": "Toutes les fonctionnalites du fichier doivent avoir des proprietes avec le même jeu de cles.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_6",
+    "message": "Les caracteristiques du fichier doivent avoir des cles importantes telles que « Pays », « Province », « District », « Poste administratif », « Localite », « Village », « Code de frontière », « Population cible ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_7",
+    "message": "Dans l'objet Proprietes, les valeurs des champs qui representent une valeur numerique ne doivent pas être entre guillemets doubles (c'est-a-dire qu'une population de 10 000 habitants doit être representee par « population » : 10 000 et non « population » : « 10 000 »).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_SPECIFICATION",
+    "message": "RFC 7946 GeoJSON",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_1",
+    "message": "L'utilisateur doit compresser tous les fichiers au format .zip et les telecharger dans le système. Au minimum, le système a besoin de fichiers .shp, .shx et .dbf compresses.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_2",
+    "message": "Le nom du fichier zip doit être « Population.zip ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_3",
+    "message": "Le fichier de formes doit être dans le système de coordonnees lat-long WGS 84 pour que le système l'accepte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_4",
+    "message": "Les coordonnees doivent être dans la plage valide de latitude et de longitude (la plage valide pour la latitude est de -90 a +90 et la plage valide de longitude est de -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_5",
+    "message": "Le fichier de formes doit contenir les points de donnees importants tels que « Pays », « Province », « District », « Poste administratif », « Localite », « Village », « Limite », « Code », « Population cible ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_6",
+    "message": "La taille totale du fichier compresse ne doit pas depasser 2 Go.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LOADING",
+    "message": "Chargement...",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LOADING_MAP",
+    "message": "Chargement de la carte...",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LOCALITY",
+    "message": "Localité",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "LOGGED_IN_AS",
+    "message": "Connecte en tant que",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MALARIA",
+    "message": "Paludisme",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MAPPING",
+    "message": "Cartographie",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_BOUNDARIES",
+    "message": "Frontières",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_HEADING",
+    "message": "Filtre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_INSTRUCTIONS",
+    "message": "Les cles suggerees sont pre-remplies. Entrez les valeurs des cles pour formuler votre hypothèse. ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_LAYERS",
+    "message": "Calques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_VIRTUALISATIONS",
+    "message": "Virtualisation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MAPPING_NO_DATA_TO_SHOW",
+    "message": "Aucune donnee de localisation n'a ete telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MAPPING_PARTIAL_DATA_TO_SHOW",
+    "message": "Il manque des coordonnees de localisation pour quelques points de donnees. Veuillez telecharger les coordonnees de localisation de tous les points de donnees pour les afficher sur la carte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLANS",
+    "message": "Mes microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVE_AREA",
+    "message": "Zone administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVE_BOUNDARY",
+    "message": "Zone administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVE_HIERARCHY",
+    "message": "Hierarchie administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINSTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGN",
+    "message": "Attribuer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGNED_FACILITIES",
+    "message": "Villages assignes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGNMENT_FACILITY",
+    "message": "Affectation du village de captage a",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGN_CATCHMENT_VILLAGES",
+    "message": "Attribuer des villages de desserte aux installations ou aux points de services",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGN_FACILITY",
+    "message": "Ajouter a l'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSUMPTIONS",
+    "message": "Hypothèses du Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_BOUNDARY_IS_EMPTY_WARNING",
+    "message": "Veuillez selectionner « Hierarchie administrative », puis les champs deroulants « Zone administrative » pour effectuer la recherche.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_CAPACITY",
+    "message": "Capacite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_CLOSE_BUTTON",
+    "message": "Fermer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_COUNTRY",
+    "message": "Pays",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_DATA_CONFIGURATION_HEADING",
+    "message": "Gestion des donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_DETAILS",
+    "message": "Details de la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISEASE_MALARIA",
+    "message": "Paludisme",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRIBUTION_FIXED_POST",
+    "message": "Poste Fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRIBUTION_HOUSE_TO_HOUSE",
+    "message": "De maison a maison",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRIBUTION_MIXED",
+    "message": "Poste fixe et porte-a-porte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_ESTIMATION_ASSUMPTIONS_HEADING",
+    "message": "Hypothèses du Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_EXECUTED",
+    "message": "Microplan finalise",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITYNAME",
+    "message": "Nom de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITYSTATUS",
+    "message": "Statut de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITYTYPE",
+    "message": "Type d'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_ACTION",
+    "message": "Action",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_ASSIGNED_VILLAGES",
+    "message": "Villages assignes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_CAPACITY",
+    "message": "Capacite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_FIXEDPOST",
+    "message": "Poste Fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_LLIN-mz_CAPACITY",
+    "message": "Capacite (balles)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_MR-DN_CAPACITY",
+    "message": "Capacite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_NAME",
+    "message": "Nom de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_NAME_LABEL",
+    "message": "Nom de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_RESIDINGVILLAGE",
+    "message": "Zone administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_SERVINGPOPULATION",
+    "message": "Servir la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_STATUS",
+    "message": "Statut de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_TYPE",
+    "message": "Type d'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_TYPE_LABEL",
+    "message": "Type d'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FIXEDPOST",
+    "message": "Poste Fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_FORMULA_CONFIGURATION_HEADING",
+    "message": "Configuration de la formule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY",
+    "message": "Microplan genere avec succès !",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY_DESCRIPTIION",
+    "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY_ID_LABEL",
+    "message": "Identifiant Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY_NAME_LABEL",
+    "message": "Nom du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATION",
+    "message": "Generation de microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_LOCALITY",
+    "message": "Localite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_MODULE_PROCESS",
+    "message": "Processus Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_MODULE_SETUP",
+    "message": "Configuration du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAME",
+    "message": "Nom du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAME_INPUT_PLACEHOLDER",
+    "message": "Exemple : Microplan-Pays-CampaignType-Date",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINTS",
+    "message": "Contraintes de denomination Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINT_1",
+    "message": "Le nom doit comporter au minimum deux lettres.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINT_2",
+    "message": "Seules les valeurs numeriques ne sont pas autorisees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINT_3",
+    "message": "Les caractères speciaux -, _, (, ) ne sont autorises que",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION",
+    "message": "Format de denomination Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_1",
+    "message": "Le nom doit comporter au minimum 3 caractères et au maximum 64 caractères.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_2",
+    "message": "Seules les valeurs numeriques ne sont pas autorisees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_3",
+    "message": "Les caractères speciaux -, _, (, ),& ne sont autorises que",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_4",
+    "message": "Seuls les caractères speciaux comme (-, _-) ne sont pas autorises",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NO_OF_BALES_PER_BOUNDARY",
+    "message": "Total des balles",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NO_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Moustiquaires totales",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_NO_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Total des menages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_PLEASE_FILL_ALL_THE_FIELDS_AND_RESOLVE_ALL_THE_ERRORS",
+    "message": "Veuillez remplir tous les champs obligatoires et resoudre toutes les erreurs avant de passer a l'etape suivante",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_APPLY",
+    "message": "Appliquer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_CREATE_BY",
+    "message": "Cree par dev-super1",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_HYPOTHESIS",
+    "message": "Hypothèse",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_HYPOTHESIS_HEADING",
+    "message": "Configurer l'hypothèse ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_HYPOTHESIS_INSTRUCTIONS",
+    "message": "Mettez a jour l'hypothèse pour recalculer l'estimation des ressources pour la campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_RESIDINGVILLAGE",
+    "message": "Village residant",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_RESIDING_VILLAGE",
+    "message": "Zone administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_RESIDING_VILLAGE_LABEL",
+    "message": "Zones administratives",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_SEARCH",
+    "message": "Microplans ouverts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECTED",
+    "message": "choisi",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECTED_PLURAL",
+    "message": "Choisi",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Les limites sont les zones administratives definies dans lesquelles vous souhaitez lancer une campagne. Commencez a selectionner les limites a partir du premier niveau afin que les limites presentes dans le niveau suivant soient disponibles pour la selection.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECT_BOUNDARY",
+    "message": "Selectionnez les limites où vous souhaitez lancer la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_SERVINGPOPULATION",
+    "message": "Servir la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS",
+    "message": "Statut",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_CENSUS_DATA_APPROVAL_IN_PROGRESS",
+    "message": "Validation en cours",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_CENSUS_DATA_APPROVED",
+    "message": "Validation en cours",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_COLUMN_DRAFT",
+    "message": "Brouillon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_COLUMN_GENERATED",
+    "message": "Genere",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_DRAFT",
+    "message": "Configuration redigee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_EXECUTION_TO_BE_DONE",
+    "message": "Configuration terminee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_RESOURCE_ESTIMATIONS_APPROVE",
+    "message": "Microplan finalise",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_RESOURCE_ESTIMATIONS_APPROVED",
+    "message": "Microplan finalise",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_RESOURCE_ESTIMATION_IN_PROGRESS",
+    "message": "Validation en cours",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_SUCCESS",
+    "message": "Valider et approuver l'estimation Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_SUM_TOTAL_TARGET_POPULATION",
+    "message": "Population cible totale",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEST",
+    "message": "Message de test",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEST2",
+    "message": "Message de test",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_TYPE_LLIN_MZ",
+    "message": "Campagne Moustiquaire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_TYPE_MR_DN",
+    "message": "Campagne SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_UNASSIGNED_FACILITIES",
+    "message": "Villages non attribues",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_UNASSIGN_FACILITY",
+    "message": "Supprimer de",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_UNASSIGN_FACILITY IRS",
+    "message": "Supprimer de",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_VIEWER",
+    "message": "Visualiseur d'estimation Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_VIEWER_DESCRIPTION",
+    "message": "Ce rôle aura accès a l'affichage des estimations du microplan des limites administratives attribuees.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_VIEWER_POPUP_HEADING",
+    "message": "Selectionnez les visualiseurs d'estimation de microplan ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGES_SELECTED",
+    "message": "choisi",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_in",
+    "message": "onglets presents dans",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MICROPLAN_tabs",
+    "message": "Onglets de feuille",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MIXED",
+    "message": "Poste fixe et porte-a-porte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MONITORS",
+    "message": "Moniteurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MOUNTAIN",
+    "message": "Montagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MPAIGN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Les limites sont les zones administratives dans lesquelles vous souhaitez executer un microplan. Commencez a selectionner les limites a partir du premier niveau afin que les limites disponibles au niveau suivant pour la selection",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ACK",
+    "message": "D'ACCORD",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ACTIONS_EDIT_SETUP",
+    "message": "Modifier la configuration",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ACTIONS_FOR_MICROPLAN_SEARCH",
+    "message": "Actes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ACTIONS_VIEW_SUMMARY",
+    "message": "Afficher le resume",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ADMINISTRATIVEPOST",
+    "message": "Poste administratif",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ASSUMPTIONS_INVALIDATION_MESSAGE",
+    "message": "Une fois que vous l'aurez modifie, vous devrez a nouveau remplir les details des hypothèses.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ASSUMPTION_NAME_INVALID",
+    "message": "Le nom de l’hypothèse n’est pas valide. Veuillez saisir un nom alphanumerique valide.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_BACK",
+    "message": "Dos",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_BOUNDARY_SELECTION",
+    "message": "Selection des limites",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_SETUP_DETAILS",
+    "message": "Details du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_HEADER",
+    "message": "Telecharger le modèle Excel pour la population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_TEXT",
+    "message": "Telechargez le modèle Excel contenant les donnees de limites selectionnees. Une fois telecharge, veuillez remplir le modèle avec les donnees cibles correctes et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_HEADER",
+    "message": "Telecharger le modèle Excel pour l'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_TEXT",
+    "message": "Telechargez le modèle Excel qui contient la liste des installations permanentes et la liste des donnees de limites selectionnees. Une fois telecharge, veuillez remplir le modèle avec les donnees correctes de l'etablissement et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_SKIP",
+    "message": "Sauter",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_COMPLETE_SETUP",
+    "message": "Configuration complète",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_DISTRICT",
+    "message": "District",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION",
+    "message": "Entrez la valeur d'hypothèse",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION_CAMPAIGN_VEHICLES",
+    "message": "Entrez la capacite du vehicule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION_CAMPAIGN_VEHICLES_LLIN-mz",
+    "message": "Veuillez saisir la capacite du vehicule (en balles) pour la campagne de moustiquaire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION_CAMPAIGN_VEHICLES_MR-DN",
+    "message": "Saisir la capacité du véhicule (En blisters) pour la campagne SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_FACILITY_TOTALPOPULATION",
+    "message": "Population cible approuvee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_FACILITY_VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_FAILED_USER_CREATION",
+    "message": "La creation de l'utilisateur a echoue. Veuillez essayer de telecharger a nouveau le fichier.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_FILES_INVALIDATION_MESSAGE",
+    "message": "La mise a jour des limites affectera les donnees telechargees sur la population et les installations (si elles sont telechargees). Veuillez mettre a jour avec prudence.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_FOOTER",
+    "message": "Merci de donner un nom au microplan. Ce nom sera utilise a des fins de reference et d’identification dans les prochaines etapes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_FORMULA_NAME_INVALID",
+    "message": "Le nom de la formule n'est pas valide. Veuillez saisir un nom alphanumerique valide.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_INPROGRESS_USER_CREATION",
+    "message": "La creation d'utilisateurs est en cours. Veuillez patienter un moment.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_MANAGING_DATA",
+    "message": "Gestion des donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_NAME_OF_MICROPLAN_MY_MICROPLANS",
+    "message": "Nom du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_NAME_OF_MICROPLAN_OPEN_MICROPLANS",
+    "message": "Nom du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_NEXT",
+    "message": "Suivant",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_PLAN_ASSIGNED_TO_ALL",
+    "message": "Attribue a tous",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_PLAN_MICROPLAN_NAME",
+    "message": "Nom du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_POP_ASSIGNED_TO_ALL",
+    "message": "Attribue a tous",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_BOUNDARY_MANAGER",
+    "message": "Administrateur du système",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_CAMPAIGN_MANAGER",
+    "message": "Gestionnaire de campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_FACILITY_CATCHMENT_ASSIGNER",
+    "message": "Attribution des limites des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_FACILITY_CATCHMENT_MAPPER",
+    "message": "Attribution des limites des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_MICROPLAN_ADMIN",
+    "message": "Administrateur Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_MICROPLAN_APPROVER",
+    "message": "Approbateur d’estimation Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_MICROPLAN_VIEWER",
+    "message": "Visualiseur d'estimation Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_PLAN_ESTIMATION_APPROVER",
+    "message": "Approbateur d’estimation Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_POPULATION_DATA_APPROVER",
+    "message": "Approbateur des donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Attribution des limites nationales des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Approbateur national des estimations de microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Approbateur des donnees demographiques nationales",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_ROLE_SYSTEM_ADMINISTRATOR",
+    "message": "Administrateur du système",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_SAVE_PROCEED",
+    "message": "Enregistrer et continuer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_UM_FILTER",
+    "message": "Filtre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_UPLOAD_USER",
+    "message": "Telechargement groupe d'utilisateurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_USER_CREATION",
+    "message": "Creation d'utilisateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_USER_DATA_UPLOADED_WILL_BE_AVAILABLE",
+    "message": "Les données utilisateur téléchargées seront disponibles dans votre attribution d'utilisateur microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_EMAIL",
+    "message": "E-mail",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_FILTER",
+    "message": "Filtre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_MOBILE_NO",
+    "message": "Numero de contact",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_NAME",
+    "message": "Nom",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_ROLE",
+    "message": "Rôle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_USER_MESSAGE",
+    "message": "Veuillez remplir le modèle telecharge avec les donnees utilisateur et telecharger la feuille.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_USER_TAG_CLEAR",
+    "message": "Clair",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_USER_TAG_SEARCH",
+    "message": "Recherche",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_VILLAGE_ACCESSIBILITY_LEVEL",
+    "message": "Niveau d'accessibilite du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_VILLAGE_SECURITY_LEVEL",
+    "message": "Niveau de securite du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_WARNING_ASSUMPTIONS_FORM",
+    "message": "Etes-vous sûr de vouloir modifier les reponses au questionnaire sur les hypothèses du microplan ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MP_WARNING_BOUNDARIES_FORM",
+    "message": "Avertissement!",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR-DN",
+    "message": "Campagne SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_GUIDELINE_POINTS_1",
+    "message": "Le nom du fichier doit être « Population.xlsx ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_GUIDELINE_POINTS_2",
+    "message": "Les champs Latitude et Longitude doivent contenir des données en degrés décimaux et en degrés minutes secondes (la valeur doit être 12,3455 et non 12° 20' 43,7994\").",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_1",
+    "message": "Le fichier GeoJSON doit répondre aux",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_2",
+    "message": "Le nom du fichier doit être « Population.geojson ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_3",
+    "message": "Toutes les entites du fichier doivent avoir des geometries du même type (c'est-a-dire qu'elles doivent toutes être des points, ou toutes doivent être des multipolygones, etc.).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_4",
+    "message": "Les coordonnees doivent être dans la plage valide de latitude et de longitude (la plage valide pour la latitude est de -90 a +90 et la plage valide de longitude est de -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_5",
+    "message": "Toutes les fonctionnalites du fichier doivent avoir des proprietes avec le même jeu de cles.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_6",
+    "message": "Les caracteristiques du fichier doivent comporter des cles importantes telles que « Pays », « Province », « District », « Poste administratif », « Localite », « Village », « Code de frontière », « Population cible (Âge 3 mois - 11 mois). ', 'Population cible (Âge 12 mois - 59 mois)', 'Population cible totale'.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_7",
+    "message": "Dans l'objet Proprietes, les valeurs des champs qui representent une valeur numerique ne doivent pas être entre guillemets doubles (c'est-a-dire qu'une population de 10 000 habitants doit être representee par « population » : 10 000 et non « population » : « 10 000 »).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_SPECIFICATION",
+    "message": "RFC 7946 GeoJSON",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_1",
+    "message": "L'utilisateur doit compresser tous les fichiers au format .zip et les telecharger dans le système. Au minimum, le système a besoin de fichiers .shp, .shx et .dbf compresses.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_2",
+    "message": "Le nom du fichier zip doit être « Population.zip ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_3",
+    "message": "Le fichier de formes doit être dans le système de coordonnees lat-long WGS 84 pour que le système l'accepte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_4",
+    "message": "Les coordonnees doivent être dans la plage valide de latitude et de longitude (la plage valide pour la latitude est de -90 a +90 et la plage valide de longitude est de -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_5",
+    "message": "Le fichier de formes doit contenir les points de donnees importants tels que « Pays », « Province », « District », « Poste administratif », « Localite », « Village », « Code de limite », « Population cible (Âge 3 mois - 11 ans). mois)', 'Population cible (Âge 12 mois - 59 mois)', 'Population cible totale'.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_6",
+    "message": "La taille totale du fichier compresse ne doit pas depasser 2 Go.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MULTIPLIED_BY",
+    "message": "Multiplie par",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MY_MICROPLAN",
+    "message": "Tous",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MY_MICROPLANS",
+    "message": "Mes microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "MY_MICROPLANS_HEADING",
+    "message": "Mes microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Microplan Country",
+    "message": "Pays",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NAME",
+    "message": "Nom",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NAME_OF_MICROPLAN",
+    "message": "Nom de Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NAME_OF_MP",
+    "message": "Nom du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NAME_YOUR_MP",
+    "message": "Entrez le nom du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEVER",
+    "message": "Jamais",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEVER1",
+    "message": "Jamais",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW_ASSUMPTION",
+    "message": "Ajouter une nouvelle hypothèse",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW_FORMULA",
+    "message": "Ajouter une nouvelle formule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEW_VALUE",
+    "message": "Nouvelle valeur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NEXT",
+    "message": "Suivant",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO",
+    "message": "Non",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_CAMPAIGN_DETAILS_FOUND_FOR_GIVEN_CAMPAIGN_ID",
+    "message": "Il y a eu un problème. Veuillez reessayer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_DATA",
+    "message": "NA",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_DATA_AVAILABLE",
+    "message": "Aucune donnee disponible. Veuillez telecharger des donnees valides. Si vous en avez deja et qu'elles n'apparaissent toujours pas ici, veuillez contacter l'administrateur.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_NAME_AVAILABLE",
+    "message": "Aucun nom disponible",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Nombre de sacs par equipe par cycle pour l'equipe de distribution en poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Nombre de sacs par equipe par cycle pour l'equipe d'inscription en poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Nombre de sacs par equipe et par cycle pour l'equipe de distribution porte-a-porte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Nombre de sacs par equipe et par cycle pour l'equipe d'enregistrement porte-a-porte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BALES_PER_BOUNDARY",
+    "message": "Nombre total de balles par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_PER_BALE",
+    "message": "Nombre de moustiquaires par balle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Nombre total de moustiquaires par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_PER_HOUSEHOLD",
+    "message": "Nombre de moustiquaires par foyer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_REQUIRED",
+    "message": "Nombre de moustiquaires requis",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_TO_BE_DISTRIBUTED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY",
+    "message": "Nombre de moustiquaires a distribuer par une equipe de distribution par jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNET_PER_HOUSEHOLD",
+    "message": "Nombre de moustiquaires par foyer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNET_REQUIRED",
+    "message": "Nombre de moustiquaires requis",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Nombre de beneficiaires a prendre en charge par une equipe de distribution par jour et par cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Nombre de beneficiaires a prendre en charge par l'equipe de distribution par jour et par cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_CATERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Nombre de beneficiaires a prendre en charge par equipe et par jour au point de distribution a poste fixe par cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "Nombre de beneficiaires ou de menages a enregistrer par une equipe d'enregistrement par jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Nombre de beneficiaires a enregistrer par une equipe d'enregistrement par jour et par cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Nombre de beneficiaires a inscrire par equipe et par jour au point fixe de distribution par cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Nombre de craies par equipe par cycle pour equipe de distribution poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Nombre de craies par equipe par cycle pour l'equipe d'inscription a poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Nombre de craies par equipe et par cycle pour l'equipe de distribution porte-a-porte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Nombre de craies par equipe et par cycle pour l'equipe d'enregistrement porte-a-porte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_CYCLES",
+    "message": "Nombre de cycles",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Nombre de jours pour la distribution du poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Nombre de jours pour l'inscription au poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Nombre de jours pour la distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Nombre de jours pour l'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_OF_THE_CAMPAIGN_AT_THAT_BOUNDRY_LEVEL",
+    "message": "Nombre de jours de campagne a ce niveau de frontière",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_DISTRIBUTORS",
+    "message": "Nombre de distributeurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_DISTRIBUTORS_PER_BOUNDARY",
+    "message": "Nombre de distributeurs par frontière",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_DISTRIBUTORS_PER_MONITOR",
+    "message": "Nombre de distributeurs par moniteur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Nombre total d'equipes de distribution de courrier fixe par limite pendant 1 jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Nombre total d'equipes de distribution de courrier fixe par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Nombre d'equipes de repartition des postes fixes par superviseur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Nombre total de membres de l'equipe de distribution de courrier fixe par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "Nombre total de superviseurs d'equipes de distribution de postes fixes par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Nombre total d'equipes d'enregistrement a poste fixe par limite pendant 1 jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Nombre total d'equipes d'enregistrement de poste fixe par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Nombre d'equipes d'enregistrement a poste fixe par superviseur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Nombre total de membres fixes de l'equipe d'enregistrement par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "Nombre total de superviseurs d'equipes d'enregistrement a poste fixe par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD",
+    "message": "Nombre de menages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Nombre total de menages par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "Nombre de foyers par rouleau d'autocollants",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Nombre total d'equipes de distribution par limite pendant 1 jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Nombre total d'equipes de distribution par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_MONITOR",
+    "message": "Nombre d'equipes de distribution par moniteur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Nombre d'equipes de distribution par superviseur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Nombre total de membres de l'equipe de distribution par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Nombre total d'equipes d'inscription par limite pour 1 jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Nombre total d'equipes d'inscription par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Nombre d'equipes d'enregistrement par moniteur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Nombre d'equipes d'inscription par superviseur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Nombre total de membres de l'equipe d'inscription par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_TO_BE_COVERED",
+    "message": "Nombre de menages a couvrir",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Nombre de membres par equipe de repartition des postes fixes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Nombre de membres par equipe d'enregistrement a poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Nombre de membres par equipe de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Nombre de membres par equipe d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Nombre total de moniteurs pour l'equipe de distribution par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Nombre total de moniteurs pour l'equipe d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Nombre de moniteurs par superviseur pour la distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Nombre de moniteurs par superviseur pour l'enregistrement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Nombre de stylos par equipe par cycle pour l'equipe de distribution de poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Nombre de stylos par equipe par cycle pour l'equipe d'inscription a poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Nombre de stylos par equipe et par cycle pour l'equipe de distribution porte-a-porte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Nombre de stylos par equipe et par cycle pour l'equipe d'enregistrement porte-a-porte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_PEOPLE_PER_BEDNET",
+    "message": "Nombre de personnes par moustiquaire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_PEOPLE_PER_HOUSEHOLD",
+    "message": "Nombre de personnes par foyer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_POPULATION_TARGETTED_FOR_COVERAGE",
+    "message": "Nombre de personnes ciblees pour la couverture",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_POPULATION_TO_BE_COVERED",
+    "message": "Nombre de population a couvrir",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SOAK_PITS",
+    "message": "Nombre de puisards",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_1_REQUIRED_FOR_AGE_3_TO_11_MONTHS",
+    "message": "Total SPAQ-1 requis pour l'âge de 3 mois a 11 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_1_REQUIRED_FOR_AGE_3_TO_11_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-1 total requis pour l'âge de 3 mois a 11 mois avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_2_REQUIRED_FOR_AGE_12_TO_59_MONTHS",
+    "message": "Total SPAQ-2 requis pour l'âge de 12 mois a 59 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_2_REQUIRED_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "Total SPAQ-2 requis pour l'âge de 12 mois a 59 mois avec tampon ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_1",
+    "message": "Nombre de SPAQ requis par cycle pour le groupe demographique 1",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_1_WITH_BUFFER",
+    "message": "Nombre de SPAQ requis par cycle pour le groupe demographique 1 avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_2",
+    "message": "Nombre de SPAQ requis par cycle pour le groupe demographique 1",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_2_WITH_BUFFER",
+    "message": "Nombre de SPAQ requis par cycle pour le groupe demographique 2 avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQ_PER_CYCLE",
+    "message": "Nombre de SPAQ par cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_STICKERS_ROLLS_PER_BOUNDARY",
+    "message": "Nombre total de rouleaux d'autocollants par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES",
+    "message": "Nombre de structures",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES_PER_UNIT_OF_INSECTICIDE",
+    "message": "Nombre de structures pulverisees par jour et par operateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES_SPRAYED_PER_DAY_PER_OPERATOR",
+    "message": "Nombre d'operateurs de pulverisation par moniteur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES_THAT_ARE_SPRAYABLE",
+    "message": "Nombre de structures pulverisables",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERIORS",
+    "message": "Nombre de superieurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS",
+    "message": "Nombre de superviseurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Nombre total de superviseurs pour l'equipe de distribution par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Nombre total de superviseurs pour l'equipe d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS_PER_BOUNDARY",
+    "message": "Nombre de superviseurs par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_TEAMS_PER_BOUNDARY",
+    "message": "Nombre d'equipes par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_OF_TEAMS_PER_BOUNDARY_IF_CAMPAIGN_RUNS_FOR_1_DAY",
+    "message": "Nombre d'equipes par limite si la campagne dure 1 jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_RESULTS_FACILITY_CATCHMENT_MAPPER",
+    "message": "Aucun assignateur de limites d'installation n'est attribue pour ce microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_RESULTS_FOUND",
+    "message": "Aucun resultat trouve",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_RESULTS_MICROPLAN_VIEWER",
+    "message": "Aucun visualiseur d'estimation Microplan n'est attribue a ce microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_RESULTS_PLAN_ESTIMATION_APPROVER",
+    "message": "Aucun approbateur d’estimation Microplan n’est affecte a ce microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_RESULTS_POPULATION_DATA_APPROVER",
+    "message": "Aucun approbateur de donnees demographiques n'est affecte a ce microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_RESULTS_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Aucun assignateur national de limites d’installation n’est attribue pour ce microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_RESULTS_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Aucun approbateur national d’estimation de microplan n’est affecte a ce microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_RESULTS_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Aucun approbateur de donnees demographiques nationales n’est affecte a ce microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_ROAD",
+    "message": "Pas de route",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_FACILITY_CATCHMENT_MAPPER",
+    "message": "Aucun resultat trouve pour les critères de recherche donnes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_MICROPLAN_VIEWER",
+    "message": "Aucun resultat trouve pour les critères de recherche donnes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_PLAN_ESTIMATION_APPROVER",
+    "message": "Aucun resultat trouve pour les critères de recherche donnes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_POPULATION_DATA_APPROVER",
+    "message": "Aucun resultat trouve pour les critères de recherche donnes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Aucun resultat trouve pour les critères de recherche donnes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Aucun resultat trouve pour les critères de recherche donnes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Aucun resultat trouve pour les critères de recherche donnes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BALES_PER_BOUNDARY",
+    "message": "Nombre de balles par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BEDNETS_PER_BALE",
+    "message": "Nombre de moustiquaires par balle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Nombre de moustiquaires a distribuer par equipe et par jour au point de distribution du poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BEDNETS_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Nombre de moustiquaires a enregistrer par equipe et par jour au point de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BED_NETS_PER_BOUNDARY",
+    "message": "Nombre de moustiquaires par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BENEFICIARIES_PER_TEAM",
+    "message": "Nombre de beneficiaires par equipe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BENEFICIARIES_PER_TEAM_PER_DAY",
+    "message": "Nombre de beneficiaires par equipe et par jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Nombre de beneficiaires ou de foyers a inscrire par equipe et par jour au point fixe de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_CAMPAIGN_DAYS",
+    "message": "Nombre de jours de campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DAYS_FOR_CAMPAIGN",
+    "message": "Nombre de jours pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Nombre de jours pour la distribution du poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Nombre de jours pour l'inscription au poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DISTRIBUTORES_PER_SUPERVISOR",
+    "message": "Nombre de distributeurs par superviseur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DISTRIBUTORS_IF_CAMPAIGN_RUNS_FOR_1_DAY",
+    "message": "Nombre de distributeurs si la campagne dure 1 jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Nombre d'equipes de repartition des postes fixes par superviseur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_CAMPAIGN",
+    "message": "Nombre d'equipes d'inscription par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_ONE_DAY",
+    "message": "Nombre d'equipes d'inscription par limite pour 1 jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Nombre d'equipes d'enregistrement a poste fixe par superviseur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Nombre de membres de l'equipe d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Nombre de membres de l'equipe de poste fixe par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Nombre de menages par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_FIXED_POST_TEAM",
+    "message": "Nombre de foyers par equipe de poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Nombre de menages par equipe de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "Nombre de foyers par rouleau d'autocollants",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_CAMPAIGN",
+    "message": "Nombre d'equipes de distribution par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_ONE_DAY",
+    "message": "Nombre d'equipes de distribution par limite pendant 1 jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Nombre de membres de l'equipe de distribution par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY",
+    "message": "Nombre d'equipes d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_1_DAY",
+    "message": "Nombre d'equipes d'inscription par limite pour 1 jour",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Nombre d'equipes d'inscription par limite pour la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Nombre de membres de l'equipe d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Nombre de membres par equipe de repartition des postes fixes ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Nombre de membres par equipe d'enregistrement a poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_REGISTRATION_TEAM",
+    "message": "Nombre de membres par equipe d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_TEAM",
+    "message": "Nombre de membres par equipe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Nombre de moniteurs pour l'equipe d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_FIXED_POST_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Nombre de moniteurs pour l'equipe d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_FIXED_POST_TEAM_PER_BOUNDARY",
+    "message": "Nombre de moniteurs par equipe de poste fixe et par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Nombre de moniteurs pour l'equipe de distribution par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_SUPERVISOR_FOR_REGISTRATION",
+    "message": "Nombre de moniteurs par superviseur pour l'enregistrement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_TEAM",
+    "message": "Nombre de moniteurs par equipe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_PERSON_PER_BEDNET",
+    "message": "Nombre de personnes par moustiquaire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Nombre d'equipes d'enregistrement par moniteur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SPRAY_TECHNICIAN_PER_SUPERVISOR",
+    "message": "Nombre de techniciens de pulverisation par superviseur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_FOR_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Nombre de superviseurs pour l'equipe d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_PER_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Nombre de superviseurs pour l'equipe de distribution par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_PER_FIXED_POST_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Nombre de superviseurs pour l'equipe d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_PER_FIXED_POST_TEAM_PER_BOUNDARY",
+    "message": "Nombre d'encadrants par equipe de poste fixe et par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "NUMBER_OF_TEAMS_PER_SUPERVISOR",
+    "message": "Nombre d'equipes par superviseur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Name",
+    "message": "Nom",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Number",
+    "message": "Numero de contact",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "OFTEN",
+    "message": "Souvent (au moins une fois par an)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "OFTEN1",
+    "message": "Souvent (au moins une fois par semaine)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "OLD_VALUE",
+    "message": "Ancienne valeur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "OPEN_MICROPLANS",
+    "message": "Microplans ouverts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "OTHER",
+    "message": "Autre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PENDING_FOR_APPROVAL",
+    "message": "En attente d'approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PENDING_FOR_VALIDATION",
+    "message": "En attente de validation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PERMAENENT",
+    "message": "Permanent",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PERMANENT_DELETE",
+    "message": "La suppression d'un element de campagne supprimera l'hypothèse. Cependant, vous pourrez le recuperer en cliquant sur le bouton « Ajouter une hypothèse ».",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAIN",
+    "message": "Plaine",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_APPROVE_CENSUS_DATA",
+    "message": "Donnees demographiques finalisees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Envoye pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_EDIT_AND_VALIDATE",
+    "message": "Valide",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_FINALIZE_CATCHMENT_MAPPING",
+    "message": "Finalisation de l'attribution des installations aux villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_INITIATE",
+    "message": "Donnees soumises",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_SEND_BACK_FOR_CORRECTION",
+    "message": "Renvoye pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_START_DATA_APPROVAL",
+    "message": "Finalisation des données démographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_VALIDATE",
+    "message": "Valide",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER",
+    "message": "Approbateur d’estimation Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER_DESCRIPTION",
+    "message": "Ce rôle d'utilisateur aura accès a la modification des hypothèses du microplan et a l'approbation de l'estimation du microplan de la limite administrative attribuee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER_POPUP_HEADING",
+    "message": "Selectionner les approbateurs d'estimation de microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_INBOX",
+    "message": "Valider et approuver les estimations Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_HEADING_LABEL",
+    "message": "Renvoyer pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_SUBMIT_LABEL",
+    "message": "Envoyer pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_VALIDATE_HEADING_LABEL",
+    "message": "Valider les donnees pour les villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_VALIDATE_SUBMIT_LABEL",
+    "message": "Valider",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_WORKFLOW_FOR_SEND_BACK_FOR_CORRECTION_UPDATE_SUCCESS",
+    "message": "Les estimations pour les villages selectionnes sont renvoyees avec succès pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_WORKFLOW_FOR_VALIDATE_UPDATE_SUCCESS",
+    "message": "Les estimations pour les villages selectionnes sont validees avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_WORKFLOW_UPDATE_SUCCESS",
+    "message": "L'action s'est deroulee avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLS_ENTER_ASSUMPTION_NAME",
+    "message": "Veuillez saisir le nom des hypothèses.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PLS_SELECT_ASSUMPTION",
+    "message": "Veuillez selectionner parmi les options deroulantes.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POPULATION",
+    "message": "Population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POPULATION_COUNT_DEMOGRAPHIC_1_PER_BOUNDARY",
+    "message": "Chiffre de population pour le groupe demographique 1 par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POPULATION_COUNT_DEMOGRAPHIC_2_PER_BOUNDARY",
+    "message": "Chiffre de population pour la demographie 2 par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER",
+    "message": "Approbateur des donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER_DESCRIPTION",
+    "message": "Ce rôle d'utilisateur aura accès a la validation et a l'approbation des donnees demographiques pour les villages de la limite administrative attribuee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER_POPUP_HEADING",
+    "message": "Selectionner les approbateurs de donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POPULATION_FINALISED_SUCCESSFUL",
+    "message": "Les donnees demographiques ont ete finalisees avec succès !",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POPULATION_FINALISE_SUCCESS",
+    "message": "Valider et approuver les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POPULATION_OF_THE_BOUNDARY",
+    "message": "Population de la limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_APPROVE",
+    "message": "Approuve",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Envoye pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_EDIT_AND_VALIDATE",
+    "message": "Valide",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_INITIATE",
+    "message": "Donnees soumises",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_ROOT_APPROVE",
+    "message": "Approuve",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_SEND_BACK_FOR_CORRECTION",
+    "message": "Envoye pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_VALIDATE",
+    "message": "Valide",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX",
+    "message": "Valider et approuver les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_HEADING_LABEL",
+    "message": "Envoyer les donnees du village pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_LABEL",
+    "message": "Soumettre et valider les donnees de population",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_SUBMIT_LABEL",
+    "message": "Envoyer pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_WORKFLOW_UPDATED_SUCCESSFULLY",
+    "message": "Les donnees des villages selectionnes sont envoyees avec succès pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_APPROVE_HEADING_LABEL",
+    "message": "Approuver les donnees pour les villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_APPROVE_SUBMIT_LABEL",
+    "message": "Approuver",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_ROOT_APPROVE_HEADING_LABEL",
+    "message": "Approuver les donnees pour les villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_ROOT_APPROVE_SUBMIT_LABEL",
+    "message": "Approuver",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_HEADING_LABEL",
+    "message": "Envoyer les donnees pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_SUBMIT_LABEL",
+    "message": "Envoyer pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_VALIDATE_HEADING_LABEL",
+    "message": "Valider les donnees pour les villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_VALIDATE_SUBMIT_LABEL",
+    "message": "Valider",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_APPROVE_UPDATE_SUCCESS",
+    "message": "Les donnees des villages selectionnes sont approuvees avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_ROOT_APPROVE_UPDATE_SUCCESS",
+    "message": "Les donnees des villages selectionnes sont approuvees avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_SEND_BACK_FOR_CORRECTION_UPDATE_SUCCESS",
+    "message": "Les donnees des villages selectionnes sont renvoyees avec succès pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_VALIDATE_UPDATE_SUCCESS",
+    "message": "Les donnees des villages selectionnes sont validees avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_OR_ROOT_APPROVE_UPDATE_SUCCESS",
+    "message": "L'action s'est deroulee avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_UPDATE_SUCCESS",
+    "message": "L'action s'est deroulee avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PREREQUISITES",
+    "message": "Conditions prealables",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PREVIOUS",
+    "message": "Precedent",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PROCEDURE",
+    "message": "Procedure",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PROVIDE_DETAILS",
+    "message": "Fournissez les details suivants",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "PROVINCE",
+    "message": "Province",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "P_CAMPAIGN_SETUP_DETAILS",
+    "message": "Nom du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Please configure the formula with respect to the assumptions considered for resource estimation",
+    "message": "Veuillez configurer la formule en fonction des hypothèses prises en compte pour l'estimation des ressources.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Procurar",
+    "message": "Recherche",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "QUANTITY_OF_INSECTICIDE_REQUIRED",
+    "message": "Quantite d'insecticide necessaire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RAISE_TO",
+    "message": "Augmenter a (puissance)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RARELY",
+    "message": "Rarement (une fois tous les 2-3 ans)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RARELY1",
+    "message": "Rarement (une fois par mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "REFER",
+    "message": "Referez-vous aux lignes directrices sur les donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "REGISTRATION_AND_DISTRIBUTION",
+    "message": "Les processus d’enregistrement et de distribution se deroulent-ils ensemble ou separement ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "REGISTRATION_PROCESS",
+    "message": "Comment se deroule le processus d’inscription a la campagne ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_CALCULATION",
+    "message": "Veuillez saisir les valeurs de chaque hypothèse indiquee ci-dessous pour le calcul des ressources.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_DISTRIBUTION_STRATEGY",
+    "message": "Strategie de repartition des ressources",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_ESTIMATIONS_APPROVED",
+    "message": "Microplan finalise",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_ESTIMATION_IN_PROGRESS",
+    "message": "Validation en cours",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_NO_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Nombre total de membres de l'equipe d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_NO_OF_SUPERVISORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Nombre total de superviseurs pour l'equipe d'enregistrement par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Nombre total de sacs requis par limite pour l'enregistrement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Nombre total de craies requises par limite pour l'equipe d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS",
+    "message": "SPAQ-1 total requis avec tampon (âge 3-11 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "Total SPAQ-2 requis avec tampon (âge 12-59 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_SPAQ_REQUIRED_WITH_BUFFER",
+    "message": "SPAQ total requis avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_TARGET_POPULATION",
+    "message": "Population cible totale",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROLES",
+    "message": "Rôle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROLE_ACCESS_CONFIGURATION",
+    "message": "Gestion des accès utilisateurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_APPROVE",
+    "message": "Approuver",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_APPRROVE",
+    "message": "Approuver",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Attribution des limites nationales des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER_DESCRIPTION",
+    "message": "Ce rôle d'utilisateur aura accès pour attribuer et finaliser l'installation a l'attribution de la zone de chalandise de la limite administrative attribuee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER_POPUP_HEADING",
+    "message": "Attribuer un responsable national des limites des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Approbateur national des estimations de microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER_DESCRIPTION",
+    "message": "Ce rôle d'utilisateur aura accès pour valider, approuver et finaliser l'estimation du microplan pour les villages de la limite administrative assignee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER_POPUP_HEADING",
+    "message": "Designer des approbateurs nationaux d’estimation de microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER",
+    "message": "Approbateur des donnees demographiques nationales",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER_DESCRIPTION",
+    "message": "Ce rôle d'utilisateur aura accès a la validation, a l'approbation et a la finalisation des donnees demographiques pour les villages de la limite administrative attribuee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER_POPUP_HEADING",
+    "message": "Designer des approbateurs de donnees demographiques nationales",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_HEADING_LABEL",
+    "message": "Soumettre et valider les donnees des villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_SUBMIT_LABEL",
+    "message": "Soumettre et valider",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROOT_POP_INBOX_HCM_MICROPLAN_EDIT_WORKFLOW_UPDATED_SUCCESSFULLY",
+    "message": "Les donnees des villages selectionnes sont validees avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "ROWS",
+    "message": "Lignes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RULE_ENGINE",
+    "message": "Moteur de règles",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INFORMATION_DESCRIPTION",
+    "message": "Vue dynamique de la façon dont les formules aideront a calculer les estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INPUT",
+    "message": "Saisir",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INPUT_HELP_TEXT",
+    "message": "Il peut s'agir de la population, du nombre de menages ou du nombre de ressources en fonction du type de campagne.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INSTRUCTIONS_DELETE_ENTRY_CONFIRMATION",
+    "message": "La suppression d'un element de campagne supprimera definitivement la configuration de la formule. Vous ne pourrez pas le recuperer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_KEY_HELP_TEXT",
+    "message": "C'est la cle qui a ete configuree a l'etape precedente comme hypothèse",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_OPERATOR",
+    "message": "Operateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_OPERATOR_HELP_TEXT",
+    "message": " ",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_VALUE_HELP_TEXT",
+    "message": "Ceci indique la valeur a calculer pour l'estimation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SAVED_MICROPLANS",
+    "message": "Mes microplans enregistres",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SAVED_MICROPLANS_TEXT",
+    "message": "Microplans enregistres",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SAVE_CHANGES",
+    "message": "Enregistrer les modifications",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SAVE_PROCEED",
+    "message": "Enregistrer et continuer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEARCH",
+    "message": "Recherche",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEARCH_ALL",
+    "message": "Microplans ouverts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEARCH_All",
+    "message": "Microplans ouverts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEARCH_MICROPLANS",
+    "message": "Microplans ouverts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SECURITY_DETAILS_UPDATE_SUCCESS",
+    "message": "Les details de securite ont ete mis a jour avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SECURITY_LEVEL_Q1",
+    "message": "Votre village est-il sujet a des troubles civils comme des manifestations violentes, des emeutes, etc. ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SECURITY_LEVEL_Q1_",
+    "message": "Votre village est-il sujet a des troubles civils comme des manifestations violentes, des emeutes, etc. ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SECURITY_LEVEL_Q2",
+    "message": "a quelle frequence les forces de securite patrouillent-elles dans le village ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT",
+    "message": "Selectionner",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECTED",
+    "message": "Choisi",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECTED_BOUNDARY",
+    "message": "Zone administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY",
+    "message": "Selectionnez une activite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_ASSIGN_FACILITIES_TO_VILLAGE",
+    "message": "Cette activite vous permettra d'attribuer et de finaliser les installations dans leurs villages de desserte.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_GEOSPATIAL_MAP_VIEW",
+    "message": "Cette activite vous permettra de visualiser l'estimation du microplan sur une carte geospatiale.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_VALIDATE_N_APPROVE_MICROPLAN_ESTIMATIONS",
+    "message": "Cette activite vous permettra de valider et d'approuver les estimations du microplan.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_VALIDATE_N_APPROVE_POPULATION_DATA",
+    "message": "Cette activite vous permettra de valider et d'approuver les donnees demographiques a prendre en compte pour la microplanification.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_ALL",
+    "message": "Selectionner tout",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_AN_ACTIVITY_TO_CONTINUE",
+    "message": "Selectionnez une activite pour continuer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_ASSUMPTION_ALREADY_ADDED",
+    "message": "Ce nom d'hypothèse existe deja. Veuillez ajouter un autre nom d'hypothèse.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_ASSUMPTION_NAME_LONG_THAN_100",
+    "message": "Le nom de l’hypothèse ne doit pas comporter plus de 100 caractères.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_A_BOUNDARY",
+    "message": "Selectionnez une limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_A_BOUNDARY_TOOLTIP",
+    "message": "Ici, vous pouvez selectionner la limite de vos donnees telechargees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_BOUNDARIES",
+    "message": "Selectionnez la zone administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_CAMPAIGN",
+    "message": "Selectionnez une campagne pour creer un microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_FORMULA",
+    "message": "Selectionnez la formule",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_FORMULA_NAME_LONG_THAN_100",
+    "message": "Le nom de la formule ne doit pas comporter plus de 100 caractères.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_HIERARCHY",
+    "message": "Selectionnez {{hierarchie}}",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_HIERARCHY_LEVEL",
+    "message": "Selectionnez la hierarchie administrative",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SELECT_OPTION",
+    "message": "Selectionnez une option",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEND_BACK_FOR_CORRECTION",
+    "message": "Renvoyer pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEND_FOR_APPROVAL",
+    "message": "Envoyer pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEND_FOR_APPROVE",
+    "message": "Approuver les donnees pour les villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEND_FOR_Approve",
+    "message": "Envoyer pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEND_FOR_ROOT_APPROVE",
+    "message": "Approuver les donnees pour les villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEND_FOR_SEND_BACK_FOR_CORRECTION",
+    "message": "Envoyer les donnees pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEND_FOR_Send Back For Correction",
+    "message": "Envoyer les donnees pour correction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEND_FOR_VALIDATE",
+    "message": "Valider les donnees pour les villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEND_FOR_Validate",
+    "message": "Valider",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SEPARATELY",
+    "message": "Separement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SETUP_COMPLETED",
+    "message": "Configuration de Microplan terminee !",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SETUP_COMPLETED_RESPONSE",
+    "message": "Configuration terminee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SETUP_COMPLETE_FAILED_DUE_TO_API_INTEGRATION",
+    "message": "Cette action a déjà été réalisée. Veuillez actualiser et réessayer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SETUP_MICROPLAN",
+    "message": "Configurer Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SETUP_MICROPLAN_SUCCESS_NAME",
+    "message": "Nom du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SETUP_MICROPLAN_SUCCESS_RESPONSE_DESC",
+    "message": "Configuration du Microplan terminee.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SHAPE_FILES",
+    "message": "Fichier de formes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SHOW_ON_ESTIMATION_DASHBOARD",
+    "message": "Afficher sur le tableau de bord d'estimation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "START",
+    "message": "Demarrer la validation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "START_DATA_APPROVAL",
+    "message": "Donnees editees et envoyees pour approbation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "STRAT_FIXED_POST",
+    "message": "Poste Fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "STRAT_HOUSE_TO_HOUSE",
+    "message": "Maison a Maison",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "STRAT_HOUSE_TO_HOUSE_FIXED_POST",
+    "message": "Poste fixe et porte-a-porte",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUBMIT",
+    "message": "Soumettre",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUBSTRACTION",
+    "message": "Soustraction",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUB_HEADING_CAMPAIGN_COMMODITIES",
+    "message": "Estimations des matières premières",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUB_HEADING_CAMPAIGN_VEHICLES",
+    "message": "Estimations de vehicules",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUB_HEADING_FIXED_POST_DISTRIBUTION",
+    "message": "Estimations de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUB_HEADING_FIXED_POST_REGISTRATION",
+    "message": "Estimations d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUB_HEADING_GENERAL_ESTIMATION",
+    "message": "Estimations generales",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUB_HEADING_HOUSEHOLD_DISTRIBUTION",
+    "message": "Estimations de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUB_HEADING_HOUSEHOLD_REGISTRATION",
+    "message": "Estimations d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUCCESS_DATA_SAVED",
+    "message": "Donnees enregistrees avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUMMARY",
+    "message": "Resume du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "SUMMARY_SCREEN",
+    "message": "Resume",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TEMPORARY",
+    "message": "Temporaire",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOGETHER",
+    "message": "Ensemble",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_BALES",
+    "message": "Total des balles",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_BEDNETS",
+    "message": "Moustiquaires totales",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_BUFFER_MULTIPLIER",
+    "message": "Pourcentage total de tampon (%)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_BUFFER_PERCENTAGE",
+    "message": "Pourcentage total de tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_CYCLES_OF_SMC",
+    "message": "Cycles totaux de SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_FACILITIES_WITH_MAPPED_VILLAGES",
+    "message": "equipements attribues aux villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Nombre total de sacs requis par limite pour l'equipe de distribution du poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Nombre total de sacs requis par limite pour l'equipe d'enregistrement du poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Nombre total. de sacs requis par limite pour l'equipe de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Nombre total de sacs requis par limite pour l'equipe d'enregistrement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Nombre total de craies requises par limite pour l'equipe de distribution de postes fixes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Nombre total de craies requises par limite pour l'equipe d'enregistrement a poste fixe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Nombre total. de craies necessaires par limite pour l'equipe de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Nombre total de craies requises par limite pour l'equipe d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Nombre total d'enclos requis par limite pour l'equipe de distribution de postes fixes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Nombre total d'enclos requis par equipe d'enregistrement des postes fixes aux limites",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Nombre total. de stylos requis par limite pour l'equipe de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Nombre total d'enclos requis par limite pour l'equipe d'enregistrement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Nombre total de moustiquaires par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_DISTRIBUTORS",
+    "message": "Nombre total de distributeurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_HOUSEHOLDS",
+    "message": "Nombre total de menages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_TEAMS",
+    "message": "Nombre total d'equipes",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_POPULATION_OF_BOUNDARY",
+    "message": "Nombre de balles par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_PROPORTION_WITH_BUFFER",
+    "message": "Proportion totale du tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_QUANTITY",
+    "message": "Quantite totale",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_FOR_AGE_12_59_MONTHS",
+    "message": "SPAQ-1 total pour les 12-59 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_FOR_AGE_12_59_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-1 total pour les 12-59 mois avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_FOR_AGE_3_11_MONTHS",
+    "message": "SPAQ-1 total pour les 3 a 11 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_WITH_BUFFER",
+    "message": "SPAQ-1 total pour les enfants de 3 a 11 mois avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ2_FOR_AGE_12_59_MONTHS",
+    "message": "Total SPAQ-2 pour les 12-59 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQA_REQUIRED_PER_CYCLE",
+    "message": "Nombre total de SPAQ requis par cycle",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQS_REQUIRED_PER_CYCLE",
+    "message": "Nombre total de SPAQ requis",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_59_MONTHS",
+    "message": "SPAQ-1 total pour les 12-59 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_59_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-1 total pour les 12-59 mois avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_TO_59_MONTHS",
+    "message": "SPAQ-1 total pour les 12-59 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-1 total pour les 12-59 mois avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_3_11_MONTHS",
+    "message": "SPAQ-1 total pour les 3 a 11 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS",
+    "message": "SPAQ-1 total pour les 3 a 11 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-1 total pour les enfants de 3 a 11 mois avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_WITH_BUFFER",
+    "message": "SPAQ-1 total pour les enfants de 3 a 11 mois avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_2_FOR_AGE_12_59_MONTHS",
+    "message": "Total SPAQ-2 pour les 12-59 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS",
+    "message": "Total SPAQ-2 pour les 12-59 mois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-2 total pour les 12 a 59 mois avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_REQUIRED",
+    "message": "SPAQ total requis",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_REQUIRED_WITH_BUFFER",
+    "message": "SPAQ total requis avec tampon",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION",
+    "message": "Population cible totale",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_12_TO_59_MONTH_OF_BOUNDARY",
+    "message": "Population cible totale (âge 12-59 mois) de la limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_3_11_MONTHS",
+    "message": "Population cible totale (âge 3-11 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_3_TO_11_MONTHS",
+    "message": "Population cible totale (âge 3-11 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_3_TO_11_MONTH_OF_BOUNDARY",
+    "message": "Population cible totale (âge 3-11 mois) de la limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_OF_BOUNDARY",
+    "message": "Nombre de balles par limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "TOTAL_VILLAGES_WITH_FACILITY_ASSIGNED",
+    "message": "Villages affectes a des installations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UNASSIGN",
+    "message": "Annuler l'attribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UNASSIGNED_SUCCESSFULLY",
+    "message": "L'utilisateur a ete desattribue au rôle selectionne avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UNASSIGNED_SUCESS",
+    "message": "Les villages ont ete desattribues avec succès a partir de l'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOAD",
+    "message": "Telecharger",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Population cible telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Population cible telechargee (âges de 12 a 59 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Population cible telechargee (âge 3 a 11 mois)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Population totale telechargee",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOAD_DATA",
+    "message": "Telecharger des donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOAD_GUIDELINE_INFO_CARD_INSTRUCTION",
+    "message": "Veuillez telecharger les donnees conformement aux directives relatives aux donnees",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOAD_USER",
+    "message": "Utilisateurs de telechargement groupe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "UPLOAD_USER_SUCCESS",
+    "message": "Gestion des utilisateurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERTAG_CONFIRM_TO_UNASSIGN",
+    "message": "Êtes-vous sûr de vouloir annuler l'attribution a l'utilisateur du rôle choisi ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USERTAG_CONFIRM_TO_UNASSIGN_DESC",
+    "message": "Une fois qu'un utilisateur n'est plus affecte a un rôle, vous pouvez reaffecter le même utilisateur a un rôle a partir du module de gestion des accès des utilisateurs. Voulez-vous annuler l'attribution de l'utilisateur ?",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_ACCESS_MANAGEMENT",
+    "message": "Gestion des accès utilisateurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_ACCESS_MGMT",
+    "message": "Gestion des accès utilisateurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_DATA_UPLOAD_SUCCESSFUL",
+    "message": "Donnees utilisateur telechargees avec succès !",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_DIRECTIONS_FOR_ERROR_MESSAGE",
+    "message": "Veuillez survoler la cellule en surbrillance pour voir les erreurs.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_DOWNLOAD",
+    "message": "Telecharger les donnees utilisateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "USER_MANAGEMENT",
+    "message": "Gestion des utilisateurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "User data upload successful",
+    "message": "Donnees utilisateur telechargees avec succès !",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VALIDATE",
+    "message": "Valider",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VALIDATED",
+    "message": "Valide",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VALIDATE_APPROVE_POPULATIONDATA",
+    "message": "Valider et approuver les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VALIDATE_N_APPROVE_MICROPLAN_ESTIMATIONS",
+    "message": "Valider et approuver les estimations Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VALIDATE_N_APPROVE_POPULATION_DATA",
+    "message": "Valider et approuver les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VALUE",
+    "message": "Valeur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VIEW_DETAILS",
+    "message": "Afficher les details",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VIEW_LESS",
+    "message": "Voir moins",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VIEW_LOGS",
+    "message": "Afficher les journaux",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VIEW_MICROPLAN_ESTIMATIONS",
+    "message": "Voir les estimations Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VIEW_MORE",
+    "message": "Voir plus",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VIEW_SUMMARY",
+    "message": "Afficher le resume",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VILLAGE",
+    "message": "Village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VILLAGE_ASSIGNED_TO_FACILITIES_SUCCESSFUL",
+    "message": "Villages affectes aux installations avec succès !",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VILLAGE_FINALISE_SUCCESS",
+    "message": "Attribuer des installations aux villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VILLAGE_ROAD_CONDITION",
+    "message": "etat des routes du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VILLAGE_TARNSPORTATION_MODE",
+    "message": "Mode de transport villageois",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VILLAGE_TERRAIN",
+    "message": "Terrain du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VILLAGE_VIEW",
+    "message": "Details du village",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "VISUALIZATIONS",
+    "message": "Visualisations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "Validate and approve population data",
+    "message": "Valider et approuver les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WARE_HOUSES",
+    "message": "Entrepôts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WARNING_INCOMPLETE_MAPPING",
+    "message": "Veuillez completer le mappage avant de continuer",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD",
+    "message": "Telecharger",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_MICROPLAN",
+    "message": "Telecharger les estimations",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_EDIT",
+    "message": "Modifier",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_FAILED",
+    "message": "echoue",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_INPROGRESS",
+    "message": "En cours",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_UPLOADED_BY",
+    "message": "Telecharge par",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_FACILITY_MICROPLAN",
+    "message": "Telechargez Excel pour les installations ou les points de services",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_TARGET_MICROPLAN",
+    "message": "Telechargez Excel pour les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WORKFLOW_INTEGRATION_ERROR",
+    "message": "Cette action a deja ete realisee. Veuillez actualiser et reessayer.",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "WORKFLOW_UPDATE_SUCCESS",
+    "message": "L'action s'est deroulee avec succès",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "YES",
+    "message": "Oui",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "_CAMPAIGN_SETUP_DETAILS",
+    "message": "Details du microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "_HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_SUFFIX_MESSAGE",
+    "message": "azones administratives situees sous les limites de la campagne",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "admin",
+    "message": "Administrateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "admin.*",
+    "message": "Administrateur.*",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "assign-facilities-to-villages",
+    "message": "Attribuer des installations aux villages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "boundaryCode",
+    "message": "Code limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "boundaryData",
+    "message": "Donnees de limite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "capacity",
+    "message": "Capacite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "children",
+    "message": "Enfants",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "facilityCode",
+    "message": "Code de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "facilityData",
+    "message": "Donnees de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "facilityName",
+    "message": "Nom de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "facilityStatus",
+    "message": "Statut de l'etablissement",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "facilityType",
+    "message": "Type d'installation",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "lat",
+    "message": "latitude",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "long",
+    "message": "Long",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "microplan-search",
+    "message": "Microplans ouverts",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "my-microplans",
+    "message": "Mes microplans",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "numberOfMonitors",
+    "message": "Nombre de moniteur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "numberOfMonitors ",
+    "message": "Nombre de moniteurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "parent",
+    "message": "Mère",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "pop-inbox",
+    "message": "Valider et approuver les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "population-finalise-success",
+    "message": "Valider et approuver les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "select-activity",
+    "message": "Choisir une activite",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "selectedDistributionProcess",
+    "message": "Processus de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "selectedRegistrationDistributionMode",
+    "message": "Mode d'inscription et de distribution",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "selectedRegistrationProcess",
+    "message": "Processus d'inscription",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "setup-completed-response",
+    "message": "Creer un microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "setup-microplan",
+    "message": "Creer un microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "targetHouseholds",
+    "message": "Cibler les menages",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "targetPopulation",
+    "message": "Population cible",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "targetPopulationAge3To11",
+    "message": "Population cible (Âge 3 mois - 11 mois) (Obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "targetPopulationDemo1",
+    "message": "Demo de population cible 1",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "targetPopulationToReachPerCycleAgainstTheBoundaryInColumnHTotal",
+    "message": "Population cible a atteindre par cycle par rapport a la limite de la colonne H Total",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "targetpopulationAge12To59",
+    "message": "Population cible (Âge 12 mois - 59 mois) (Obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "targetpopulationDemo2",
+    "message": "Demo de population cible 2",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "terrain",
+    "message": "Terrain",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "totalTargetPopulation",
+    "message": "Population cible totale (obligatoire)",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "upload-user",
+    "message": "Utilisateurs de telechargement groupe",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "upload-user-success",
+    "message": "Creation d'utilisateurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "user-download",
+    "message": "Telecharger les donnees utilisateur",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "user-management",
+    "message": "Gestion des utilisateurs",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  },
+  {
+    "code": "village-view",
+    "message": "Approuver les donnees demographiques",
+    "module": "rainmaker-microplanning",
+    "locale": "fr_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/pt_MZ/hcm-admin-schemas.json
+++ b/localisation/Microplanning/v0.1/pt_MZ/hcm-admin-schemas.json
@@ -1,0 +1,7886 @@
+[
+  {
+    "code": "ADMIN10_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN10_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN10_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN10_POST ADMINISTRATIVO",
+    "message": "Pós Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN10_STATE",
+    "message": "Estado",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN11_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN11_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN11_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN11_POST ADMINISTRATIVO",
+    "message": "Pós Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN11_STATE",
+    "message": "Estado",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_PROVINCIA",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_PROVINCIA",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_POST ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_PROVINCIA",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMINE_QA",
+    "message": "Controle de qualidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMINU_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_CONSOLE_TARGET",
+    "message": "Alvo do agregado familiar ao nível da aldeia (obrigatório e a ser introduzido pelo utilizador)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO",
+    "message": "Moçambique",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_01_CANGUD ZI",
+    "message": "CANGUD ZI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_01_CAVINA1",
+    "message": "Cavina1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_02_CANDOD O",
+    "message": "CANDODO O",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_02_CAVINA2",
+    "message": "Cavina2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_03_CARANG ACHE",
+    "message": "DOR DE CARANG",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_03_CAVINA3",
+    "message": "Cavina3",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_04_CAVINA4",
+    "message": "Cavina4",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_04_NHANTS UNGUI",
+    "message": "NHANTS UNGUI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_05_CAVINA5",
+    "message": "Cavina5",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_05_CHITHA NDO",
+    "message": "CHITHA NDO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_06_CAVINA6",
+    "message": "Cavina6",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_06_GUEBUZ A",
+    "message": "GUEBUZ A",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_07_CADONG OLO",
+    "message": "CADONG OLO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_07_CAVINA7",
+    "message": "Cavina7",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_08_BOROMA",
+    "message": "BOROMA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_08_CAVINA8",
+    "message": "Cavina8",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_09_CAHO",
+    "message": "CAHO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_09_CAVINA9",
+    "message": "Cavina9",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_10_1 DE M AIO",
+    "message": "1 DE M AIO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_10_CAVINA10",
+    "message": "Cavina10",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_11_CATOND O",
+    "message": "CATOND O",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_11_CAVINA11",
+    "message": "Cavina11",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_12_CAVINA12",
+    "message": "Cavina12",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_12_JOSINA MACHEL",
+    "message": "JOSINA MACHEL",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_13_25 DE JUNHO",
+    "message": "25 DE JUNHO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_13_CAVINA13",
+    "message": "Cavina13",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_14_CAVINA14",
+    "message": "Cavina14",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_14_VALE",
+    "message": "VALE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_15_CAVINA15",
+    "message": "Cavina15",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_15_CAWIRA B",
+    "message": "CAWIRA B",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_16_CAVINA16",
+    "message": "Cavina16",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_16_CAWIRA A",
+    "message": "CAWIRA A",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_17_CAVINA17",
+    "message": "Cavina17",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_18_CAVINA18",
+    "message": "Cavina18",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_19_CAVINA19",
+    "message": "Cavina19",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_20_CAVINA20",
+    "message": "Cavina20",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_21_CAVINA21",
+    "message": "Cavina21",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_22_CAVINA22",
+    "message": "Cavina22",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_23_CAVINA23",
+    "message": "Cavina23",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_24_CAVINA24",
+    "message": "Cavina24",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_25_CAVINA25",
+    "message": "Cavina25",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_26_CAVINA26",
+    "message": "Cavina26",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_27_CAVINA27",
+    "message": "Cavina27",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_28_CAVINA28",
+    "message": "Cavina28",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_29_CAVINA29",
+    "message": "Cavina29",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_CHITIMA SEDE",
+    "message": "Chitima Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_NIHESSIUEA",
+    "message": "Nihessiuea",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_01_NACULUER1",
+    "message": "Naculuer1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_02_NACULUER2",
+    "message": "Naculuer2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_03_NACULUER3",
+    "message": "Naculuer3",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_04_NACULUER4",
+    "message": "Naculuer4",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_05_NACULUER5",
+    "message": "Naculuer5",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_06_NACULUER6",
+    "message": "Naculuer6",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_07_NACULUER7",
+    "message": "Naculuer7",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_08_NACULUER8",
+    "message": "Naculuer8",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_09_NACULUER9",
+    "message": "Naculuer9",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_10_NACULUER10",
+    "message": "Naculuer10",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_MULHANIUA",
+    "message": "Mulhaniua",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_01_NACOCOLOA1",
+    "message": "Nacocoloa1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_02_NACOCOLOA2",
+    "message": "Nacocoloa2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_03_NACOCOLOA3",
+    "message": "Nacocoloa3",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_04_NACOCOLOA4",
+    "message": "Nacocoloa4",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_05_NACOCOLOA5",
+    "message": "Nacocoloa5",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_06_NACOCOLOA6",
+    "message": "Nacocoloa6",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_07_NACOCOLOA7",
+    "message": "Nacocoloa7",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_08_NACOCOLOA8",
+    "message": "Nacocoloa8",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_09_NACOCOLOA9",
+    "message": "Nacocoloa9",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_NACOCOLO",
+    "message": "Nacocolo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_CHITIMA",
+    "message": "Chitima",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_NIHESSIUE",
+    "message": "Nihessiue",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_01_CAWIRA A",
+    "message": "Cawira A",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_01_THEQUESSE",
+    "message": "Thequesse",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_02_CAWIRA B",
+    "message": "Cawira B",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_02_ZANICHI",
+    "message": "Zanichi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_03_MACATA",
+    "message": "Macatá",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_03_VALE",
+    "message": "Vale",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_04_25 DE JUNHO",
+    "message": "25 de junho",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_04_JULIO CHAMALULO",
+    "message": "Júlio Chamalulo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_05_COFATI 1",
+    "message": "Cofati 1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_05_JOSINA MACHEL",
+    "message": "Josina Machel",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_06_AFULEDI",
+    "message": "Afuledi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_06_CATOND O",
+    "message": "Catond O",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_07_1 DE M AIO",
+    "message": "1 De M Aio",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_07_ADAMO",
+    "message": "Adão",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_08_ACUSE",
+    "message": "Acusar",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_08_CAHO",
+    "message": "Caho",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_09_BOROMA",
+    "message": "Boroma",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_09_NTUITI",
+    "message": "Ntuiti",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_10_CADONG OLO",
+    "message": "Cadong Olo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_10_NCUMBZI 1",
+    "message": "Ncumbzi 1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_11_GUEBUZ A",
+    "message": "Guebuz A",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_11_NCUMBUZI 2",
+    "message": "Ncumbuzi 2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_12_ACHINTSUE",
+    "message": "Achintsue",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_12_CHITHA NDO",
+    "message": "Chitha Ndo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_13_AMBULEZI",
+    "message": "Ambulézi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_13_NHANTS UNGUI",
+    "message": "Nhants Ungui",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_14_CARANG ACHE",
+    "message": "Dor de Carang",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_14_KAPHIRI KA MPANDA",
+    "message": "Kaphiri ka mpanda",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_15_CANDOD O",
+    "message": "Candod O",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_15_COFATI 2",
+    "message": "Café 2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_16_CANGUD ZI",
+    "message": "Cangud Zi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_16_TSHIRIZA",
+    "message": "Tshiriza",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_17_ANANIAS",
+    "message": "Ananias",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_18_MAXENECA",
+    "message": "Maxeneca",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_19_CAPOCHI",
+    "message": "Capochi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_20_CHANGUI",
+    "message": "Changui",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_21_LIPIRANI",
+    "message": "Lipirani",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_22_MPHEMBERE",
+    "message": "Mphembere",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_23_MOAMBEDZI",
+    "message": "Moambedzi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_ANG'OMBE",
+    "message": "Ang'ombe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_CHITIMA SEDE",
+    "message": "Chitima Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_CHITIMA ",
+    "message": "Chitima",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_NSADZO",
+    "message": "Nsadzo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_MOSSURILEE",
+    "message": "Mossurilê",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_MOSSURILEE ",
+    "message": "Mossurilê",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_MURRUPULA",
+    "message": "Múrrupula",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_01_NACOCOLOA9",
+    "message": "NACOCOLOA9",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_02_NACOCOLOA8",
+    "message": "NACOCOLOA8",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_03_NACOCOLOA7",
+    "message": "NACOCOLOA7",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_04_NACOCOLOA6",
+    "message": "NACOCOLOA6",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_05_NACOCOLOA5",
+    "message": "NACOCOLOA5",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_06_NACOCOLOA4",
+    "message": "NACOCOLOA4",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_07_NACOCOLOA3",
+    "message": "NACOCOLOA3",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_08_NACOCOLOA2",
+    "message": "NACOCOLOA2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_09_NACOCOLOA1",
+    "message": "NACOCOLOA1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_NACOCOLO",
+    "message": "Nacocolo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_01_NACULUER10",
+    "message": "NACULUER10",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_02_NACULUER9",
+    "message": "NACULUER9",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_03_NACULUER8",
+    "message": "NACULUER8",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_04_NACULUER7",
+    "message": "NACULUER7",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_05_NACULUER6",
+    "message": "NACULUER6",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_06_NACULUER5",
+    "message": "NACULUER5",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_07_NACULUER4",
+    "message": "NACULUER4",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_08_NACULUER3",
+    "message": "NACULUER3",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_09_NACULUER2",
+    "message": "NACULUER2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_10_NACULUER1",
+    "message": "NACULUER1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_MULHANIUA",
+    "message": "Mulhaniua",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_01_CAVINA29",
+    "message": "CAVINA29",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_02_CAVINA28",
+    "message": "CAVINA28",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_03_CAVINA27",
+    "message": "CAVINA27",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_04_CAVINA26",
+    "message": "CAVINA26",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_05_CAVINA25",
+    "message": "CAVINA25",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_06_CAVINA24",
+    "message": "CAVINA24",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_07_CAVINA23",
+    "message": "CAVINA23",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_08_CAVINA22",
+    "message": "CAVINA22",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_09_CAVINA21",
+    "message": "CAVINA21",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_10_CAVINA20",
+    "message": "CAVINA20",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_11_CAVINA19",
+    "message": "CAVINA19",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_12_CAVINA18",
+    "message": "CAVINA18",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_13_CAVINA17",
+    "message": "CAVINA17",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_14_CAVINA16",
+    "message": "CAVINA16",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_15_CAVINA15",
+    "message": "CAVINA15",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_16_CAVINA14",
+    "message": "CAVINA14",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_17_CAVINA13",
+    "message": "CAVINA13",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_18_CAVINA12",
+    "message": "CAVINA12",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_19_CAVINA11",
+    "message": "CAVINA11",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_20_CAVINA10",
+    "message": "CAVINA10",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_21_CAVINA9",
+    "message": "CAVINA9",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_22_CAVINA8",
+    "message": "CAVINA8",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_23_CAVINA7",
+    "message": "CAVINA7",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_24_CAVINA6",
+    "message": "CAVINA6",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_25_CAVINA5",
+    "message": "CAVINA5",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_26_CAVINA4",
+    "message": "CAVINA4",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_27_CAVINA3",
+    "message": "CAVINA3",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_28_CAVINA2",
+    "message": "CAVINA2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_29_CAVINA1",
+    "message": "CAVINA1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_NIHESSIUEA",
+    "message": "Nihessiuea",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_NIHESSIUE",
+    "message": "Nihessiue",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_01_CHIRODZI PONTE",
+    "message": "Chirodzi Ponte",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_02_NHAULIRI 1",
+    "message": "Nhauliri 1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_03_NHAULIRI 2",
+    "message": "Nhauliri 2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_04_NCHENGA",
+    "message": "Nchenga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_05_CHAMIMBA",
+    "message": "Chamimba",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_06_CHIRODZI NTEPE",
+    "message": "Chirodzi Ntepe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_07_NHANTSINGA",
+    "message": "Nhantsinga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_08_NHAMIDZI",
+    "message": "Nhamidzi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_09_CAVULANCIE",
+    "message": "Cavulância",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_10_CHISSUA SEDE",
+    "message": "Sede de Chissua",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_11_CHISSUA CRUZAMENTO",
+    "message": "Chissua Cruzamento",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_12_CHISSUA THALA",
+    "message": "Chissua Thala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_13_CHABONGA",
+    "message": "Chabonga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_CHIBAGADIGO",
+    "message": "Chibagadigo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_01_MATUNGULU",
+    "message": "Matungulu",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_02_MASSECHA",
+    "message": "Massacha",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_03_CHINHANDA",
+    "message": "Chinhanda",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_04_CHICOA",
+    "message": "Chicoa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_05_NHAMINHE",
+    "message": "Nhaminhe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_CHICOA NOVA",
+    "message": "Chicoa Nova",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_CHITEEIMA",
+    "message": "Chiteeima",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_01_MUALADZI SEDE",
+    "message": "sede de Mualadzi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_02_CHITUMBULA",
+    "message": "Chitumbula",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_03_CHIMBALAME",
+    "message": "Chimbalame",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_04_CHATSICA",
+    "message": "Chatsica",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_05_NAMICOMBO",
+    "message": "Namicombo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_06_SATEMA",
+    "message": "Satema",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_07_TSEBONDO",
+    "message": "Tsebondo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_08_CATAKWALA",
+    "message": "Catakwala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_09_DZIWELANGONA",
+    "message": "Dziwelangona",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_10_MUANANHANJE",
+    "message": "Muananhanje",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_11_CHOLONNGUELERA",
+    "message": "Cholonnguelera",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_12_MULAWE",
+    "message": "Mulawe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_13_NCHENGOERA",
+    "message": "Nchengoera",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_14_MANKACA 1",
+    "message": "Mankacá 1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_15_CHIRUDZI",
+    "message": "Chirudzi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_16_DAUNDELA",
+    "message": "Daundela",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_17_GOELA",
+    "message": "Goela",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_18_THIMA",
+    "message": "Thima",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_19_PHOCA",
+    "message": "Foca",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_20_GUEROSSOMO",
+    "message": "Guerossomo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_21_NKHONDA",
+    "message": "Nkhonda",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_22_MANKACA 2",
+    "message": "Mankacá 2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_23_VUBUE",
+    "message": "Vubue",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_24_MALIDZIMAERA",
+    "message": "Malidzimaera",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_25_CAWELENGA",
+    "message": "Cawelenga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_26_CHIMPOYO",
+    "message": "Chimpoió",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_27_MAGRENI",
+    "message": "Magreni",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_28_WERENGANI",
+    "message": "Werengani",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_29_AMOSSE",
+    "message": "Amosse",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_30_MBOMBE",
+    "message": "Mbombe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_31_NROLO",
+    "message": "Nrolo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_32_MPHANJAYAUTSI",
+    "message": "Mphanjayautsi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_33_MALAZA",
+    "message": "Malaza",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_34_NHATIKOWA",
+    "message": "Nhatikowa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_35_CHITHAWALE",
+    "message": "Chithawale",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_36_ANTIGA MIGRACAO",
+    "message": "Antiga Migração",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_MUALADZI",
+    "message": "Mualadzi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_CHIFUNDE",
+    "message": "Chifunde",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_01_KHAMANDE SEDE",
+    "message": "sede de Khamande",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_02_SEQUE",
+    "message": "Seque",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_03_CASSOCHELA",
+    "message": "Cassochela",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_04_MASSAUASSAUA",
+    "message": "Massauassaua",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_05_NKONDA",
+    "message": "Nkonda",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_06_MASSIMO",
+    "message": "Massimo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_07_ALISSONE",
+    "message": "Alisson",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_08_CANQUIRA",
+    "message": "Canquira",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_09_CHIGONDO",
+    "message": "Chigondo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_10_CALIDZIPIRE",
+    "message": "Calidzipire",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_11_DZICO",
+    "message": "Dzico",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_12_JASSONE",
+    "message": "Jassone",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_13_CHAWANTA",
+    "message": "Chawanta",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_14_KANKHUKU",
+    "message": "Kankhuku",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_15_KAPAMANGA",
+    "message": "Kapamanga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_16_CHICAONDA",
+    "message": "Chicaona",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_17_FAIZAZE",
+    "message": "Faizaze",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_18_MULAMBA",
+    "message": "Mulamba",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_19_TCHALE",
+    "message": "Tchale",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_KHAMANDE",
+    "message": "Khamande",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_MUALDZI",
+    "message": "Mualdzi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_ENT PS CIDADE NAMPULA",
+    "message": "Ent Ps Cidade Nampula",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_MURRUPULA",
+    "message": "Múrrupula",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_ADMIN_MO",
+    "message": "ADMIN_MO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_NAMPULA",
+    "message": "Nampula",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_01_CHIMELO",
+    "message": "CHIMELO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_02_CHIGELA",
+    "message": "CHIGELA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_03_CHIPACO",
+    "message": "CHIPACO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_04_CHIPANG A",
+    "message": "CHIPANG A",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_05_CHIPINHE",
+    "message": "CHIPINHE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_06_COLOMBO",
+    "message": "COLOMBO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_07_COTOMON A",
+    "message": "COTOMON A",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_08_FAHELO",
+    "message": "FAHELO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_09_FAMULO",
+    "message": "FAMULO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_10_HODI",
+    "message": "HODI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_11_JUNHO",
+    "message": "JUNHO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_12_MAFELENE",
+    "message": "MAFELENE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_13_MALUPIRIR",
+    "message": "MALUPIRIR",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_14_MAPIRORO",
+    "message": "MAPIRORO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_15_MARIRIU",
+    "message": "MARIRIU",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_16_MUNGO",
+    "message": "MUNGO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_17_NABOARO",
+    "message": "NABOARO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_18_NALO",
+    "message": "NALO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_19_OCALIMBO",
+    "message": "OCALIMBO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_20_OCUMALO",
+    "message": "OCUMALO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_21_OCUMO",
+    "message": "OCUMO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_22_PASSENDE",
+    "message": "PASSEIO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_23_PIRO",
+    "message": "PIRO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_24_PONACO",
+    "message": "PONACO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_25_SANTOS",
+    "message": "SANTOS",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_26_TINGACO",
+    "message": "TINGACO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_27_VERDE",
+    "message": "VERDE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_28_VIATURA",
+    "message": "VIATURA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_29_VULAGUNDE",
+    "message": "VULAGUNDA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_30_WINAZO",
+    "message": "WINAZO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_31_XIMANGO",
+    "message": "XIMANGO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_32_XIMPACO",
+    "message": "XIMPACO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_33_XINZIQUE",
+    "message": "XINZIQUE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_34_YUAMO",
+    "message": "YUAMO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_35_ZIMBAZE",
+    "message": "ZIMBAZÉ",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_36_ZUNGULE",
+    "message": "ZUNGULE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_37_INGURU",
+    "message": "INGURU",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_38_NANGURU",
+    "message": "NANGURU",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_39_MISSETA",
+    "message": "MISSETA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_40_MUCO",
+    "message": "MUCO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_41_NAMANCA",
+    "message": "NAMANCA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_42_MBUZI",
+    "message": "MBUZI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_43_CABATA",
+    "message": "CABATA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_PEMBA SEDE",
+    "message": "Sede de Pemba",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_PEMBA",
+    "message": "Pemba",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_ADMIN_MO_01_NAMPULA",
+    "message": "ADMIN_MO_01_NAMPULA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_ADMIN_MO_12_TETE",
+    "message": "ADMIN_MO_12_TETE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_CABO DELGADO",
+    "message": "Cabo Delgado",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_02_01_01_CHIMOIO SEDE",
+    "message": "Sede de Chimoio",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_02_01_CHIMOIO",
+    "message": "Chimoio",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_02_MANICA",
+    "message": "Manica",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_CABO",
+    "message": "Cabo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_NAMPULA",
+    "message": "Nampula",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_TETE",
+    "message": "Tete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_03_01_ADMIN_MO_02_CABO",
+    "message": "ADMIN_MO_02_CABO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_03_01_ADMIN_MO_10_ZAMBEZIA",
+    "message": "ADMIN_MO_10_ZAMBÉZIA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_03_CABO",
+    "message": "Cabo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_03_ZAMBEZIA",
+    "message": "Zambézia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_01_01_01_MUZIRO",
+    "message": "MUZIRO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_01_01_02_MUCHAPA",
+    "message": "MUCHAPA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_01_01_TICA SEDE",
+    "message": "Tica Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_01_TICA",
+    "message": "Tica",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_02_01_01_MUBO",
+    "message": "MUBO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_02_01_02_SANGO",
+    "message": "SANGO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_02_01_NHAMPOCA SEDE",
+    "message": "Sede de Nhampoca",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_02_NHAMPOCA",
+    "message": "Nhampoca",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_03_01_01_NHANDUMA",
+    "message": "NHANDUMA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_03_01_02_MAHAMBA",
+    "message": "MAHAMBA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_03_01_MUTUA SEDE",
+    "message": "Sede Mútua",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_03_MUTUA",
+    "message": "Mútua",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_04_01_01_MACANDE",
+    "message": "MACANDE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_04_01_02_NHACOTA",
+    "message": "NHACOTA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_04_01_LAMEGO SEDE",
+    "message": "Sede de Lamego",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_04_LAMEGO",
+    "message": "Lamego",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_05_01_01_BEBEDO VILLAGE",
+    "message": "Aldeia Bebedo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_05_01_BEBEDO SEDE",
+    "message": "Bebedo Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_05_BEBEDO",
+    "message": "Bebedo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_ADMIN_MO_04_SOFALA",
+    "message": "ADMIN_MO_04_SOFALA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_ADMIN_MO_09_INHAMBANE",
+    "message": "ADMIN_MO_09_INHAMBANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_NHAMATANDA",
+    "message": "Nhamatanda",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_01_01_01_NHAMUDE",
+    "message": "NHAMUDE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_01_01_02_MANIKA",
+    "message": "MANICA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_01_01_SAVANE SEDE",
+    "message": "Savane Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_01_SAVANE",
+    "message": "Savane",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_02_01_01_MAGOMBE",
+    "message": "MAGOMBÉ",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_02_01_02_NHATEMA",
+    "message": "NHATEMA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_02_01_MAFAMBISSE SEDE",
+    "message": "Sede de Mafambisse",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_02_MAFAMBISSE",
+    "message": "Mafambisse",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_03_01_01_MAZONDE",
+    "message": "MAZONDE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_03_01_02_LICUARI",
+    "message": "LICUARI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_03_01_CHINAMACONDO SEDE",
+    "message": "Sede Chinamacondo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_03_CHINAMACONDO",
+    "message": "Chinamacondo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_04_01_01_MARUJA",
+    "message": "MARUJA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_04_01_02_MACHIR",
+    "message": "MACIRO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_04_01_SENGO SEDE",
+    "message": "Sengo Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_04_SENGO",
+    "message": "Sengo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_DONDO",
+    "message": "Dondo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_01_01_01_MARANGA",
+    "message": "MARANGÁ",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_01_01_02_MAVICHE",
+    "message": "MAVICHE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_01_01_VUNDUZI SEDE",
+    "message": "Sede de Vunduzi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_01_VUNDUZI",
+    "message": "Vunduzi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_02_01_01_MILANGULO",
+    "message": "MILANGULO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_02_01_02_MACUNGA",
+    "message": "MACUNGA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_02_01_CHITUNGA SEDE",
+    "message": "Sede de Chitunga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_02_CHITUNGA",
+    "message": "Chitunga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_03_01_01_NHATADIMA",
+    "message": "NHATADIMA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_03_01_02_NHANDJA",
+    "message": "NHANDJA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_03_01_NHAMASSONGE SEDE",
+    "message": "Sede de Nhamassonge",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_03_NHAMASSONGE",
+    "message": "Nhamassonge",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_04_01_01_LAMBA",
+    "message": "LAMBA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_04_01_02_NHANJI",
+    "message": "NHANJI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_04_01_DINDIZA SEDE",
+    "message": "Dindiza Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_04_DINDIZA",
+    "message": "Dindiza",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_GORONGOSA",
+    "message": "Gorongosa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_01_01_01_SENGA",
+    "message": "SENGA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_01_01_02_CHICENGA",
+    "message": "CHIENGA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_01_01_NOVA SOFALA SEDE",
+    "message": "Nova Sofala Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_01_NOVA SOFALA",
+    "message": "Nova Sofala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_02_01_01_NHOHULA",
+    "message": "NHOHULA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_02_01_02_MUZOMBO",
+    "message": "MUZOMBO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_02_01_INHAMINGA SEDE",
+    "message": "Sede de Inhaminga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_02_INHAMINGA",
+    "message": "Inhaminga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_03_01_01_MAZACHA",
+    "message": "MAZACHA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_03_01_02_CHICUARI",
+    "message": "CHICUARI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_03_01_GRUDJA SEDE",
+    "message": "Grudja Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_03_GRUDJA",
+    "message": "Grudja",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_04_01_01_MAHORO",
+    "message": "MAHORO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_04_01_02_MACHUMO",
+    "message": "MACHUMO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_04_01_GUARA-GUARA SEDE",
+    "message": "Guara-Guara Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_04_GUARA-GUARA",
+    "message": "Guara-Guara",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_BUZI",
+    "message": "Búzi",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_01_01_01_CHAMBULI",
+    "message": "CAMBULI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_01_01_02_MEQUELE",
+    "message": "MEQUELE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_01_01_MARROMEU SEDE",
+    "message": "Sede de Marromeu",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_01_MARROMEU",
+    "message": "Marromeu",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_02_01_01_MATEQUE",
+    "message": "MATEQUE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_02_01_02_MACUNHE",
+    "message": "MACUNHÉ",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_02_01_CHUPANGA SEDE",
+    "message": "Chupanga Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_02_CHUPANGA",
+    "message": "Chupanga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_03_01_01_MACAVALA",
+    "message": "MACAVALA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_03_01_02_NHAXANA",
+    "message": "NHAXANA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_03_01_MORRUMBALA SEDE",
+    "message": "Sede de Morrumbala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_03_MORRUMBALA",
+    "message": "Morrumbala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_04_01_01_MECHUO",
+    "message": "MECHUO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_04_01_02_MACAHULO",
+    "message": "MACAHULO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_04_01_INHANGOMA SEDE",
+    "message": "Sede de Inhangoma",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_04_INHANGOMA",
+    "message": "Inhangoma",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_CHEMBA",
+    "message": "Chemba",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_01_01_01_CHIMBUNGA",
+    "message": "CHIMBUNGA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_01_01_02_MACHANGULO",
+    "message": "MACHANGULO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_01_01_SENA SEDE",
+    "message": "Sena Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_01_SENA",
+    "message": "Sena",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_02_01_01_NHIRO",
+    "message": "NHIRO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_02_01_02_MACHUMBO",
+    "message": "MACHUMBO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_02_01_MURRAÇA SEDE",
+    "message": "Murraça Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_02_MURRAÇA",
+    "message": "Murraça",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_03_01_01_MAFOGUENE",
+    "message": "MAFOGUENE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_03_01_02_NHASSICO",
+    "message": "NHASSICO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_03_01_CHIMUARA SEDE",
+    "message": "Chimuara Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_03_CHIMUARA",
+    "message": "Chimuara",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_04_01_01_MAZUQUA",
+    "message": "MAZUQUÁ",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_04_01_02_LICUMBA",
+    "message": "LICUMBA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_04_01_MOPEIA SEDE",
+    "message": "Sede de Mopeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_04_MOPEIA",
+    "message": "Mopeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_CAIA",
+    "message": "Caia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_INHAMBANE",
+    "message": "Inhambane",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_SOFALA",
+    "message": "Sofala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_05_01_ADMIN_MO_05_TETE",
+    "message": "ADMIN_MO_05_TETE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_05_01_ADMIN_MO_08_GAZA",
+    "message": "ADMIN_MO_08_GAZA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_05_GAZA",
+    "message": "Gaza",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_05_TETE",
+    "message": "Tete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_05_TETEA",
+    "message": "Tetéa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_01_01_MASSAVANE",
+    "message": "MASSAVANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_01_02_NHAMBAZA",
+    "message": "NHAMBAZA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_01_03_MASSUNGULO",
+    "message": "MASSUNGULO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_01_04_CHAVANE",
+    "message": "CHAVANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_01_BELA VISTA SEDE",
+    "message": "Sede Bela Vista",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_BELA VISTA",
+    "message": "Bela Vista",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_ADMIN_MO_06_MAPUTO",
+    "message": "ADMIN_MO_06_MAPUTO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_ADMIN_MO_07_MAPUTO CITY",
+    "message": "ADMIN_MO_07_CIDADE DE MAPUTO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_MATUTUINE",
+    "message": "Matutuine",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_01_01_NDUMBA",
+    "message": "NDUMBA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_01_02_MUBO",
+    "message": "MUBO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_01_03_MAGULUCO",
+    "message": "MAGULUCO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_01_04_CHANGAMBE",
+    "message": "CHANGAMBE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_01_BOANE SEDE",
+    "message": "Boane Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_BOANE VISTA",
+    "message": "Boane Vista",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_BOANE",
+    "message": "Boane",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_01_01_MACANE",
+    "message": "MACANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_01_02_MAZIVE",
+    "message": "MAZIVO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_01_03_MANGUNHANEII",
+    "message": "MANGUNHANEII",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_01_04_MAJACAZAI",
+    "message": "MAJACAZAI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_01_MARRACUENE SEDE",
+    "message": "Sede de Marracuene",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_MARRACUENEE",
+    "message": "Marracuenee",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_MARRACUENE",
+    "message": "Marracuene",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_01_01_MAPULANGA",
+    "message": "MAPULANGA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_01_02_NHAMACONDA",
+    "message": "NAMACONDA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_01_03_MASSINGA",
+    "message": "MASSINGA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_01_04_CHICHACHAEW",
+    "message": "CHICHACHAEW",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_01_MAGUDE SEDE",
+    "message": "Magude Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_MAGUDEE",
+    "message": "Magudee",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_MAGUDE",
+    "message": "Magude",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_05_01_01_01_MASSACANHE",
+    "message": "MASSACANHE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_05_01_01_02_MACALANGE",
+    "message": "MACALANGE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_05_01_01_MANHICA SEDE",
+    "message": "Sede de Manhiça",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_05_01_MANHICAE",
+    "message": "Manhiçae",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_05_MANHICA",
+    "message": "Manhiça",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_06_01_01_01_CHICUALACUALA",
+    "message": "CHICUALACUALA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_06_01_01_02_MASSIFUTA",
+    "message": "MASSIFUTA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_06_01_01_MOA SEDE",
+    "message": "Moa Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_06_01_MOAA",
+    "message": "Moaa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_06_MOA",
+    "message": "Moa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_07_01_01_01_CHIMUANA",
+    "message": "CHIMUANA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_07_01_01_02_NHAMATE",
+    "message": "NHAMATE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_07_01_01_NOME SEDE",
+    "message": "Nome Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_07_01_NOMEA",
+    "message": "Noméa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_07_NOME",
+    "message": "Nome",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_08_BOANEQ",
+    "message": "Boaneq",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_MAPUTO",
+    "message": "Maputo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_MAPUTO CITY",
+    "message": "Cidade de Maputo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_01_01_NHAGOLO",
+    "message": "NHAGOLO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_01_02_MAFALALA",
+    "message": "MAFALALA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_01_03_NHAMATCHUCO",
+    "message": "NHAMATCHUCO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_01_04_CHONWANE",
+    "message": "CHONWANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_01_KAMAXAQUENEB SEDE",
+    "message": "KaMaxaqueneb Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_KAMAXAQUENEB",
+    "message": "KaMaxaqueneb",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_01_CHICUANA",
+    "message": "CHICUANA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_02_MAQUIAVE",
+    "message": "MAQUIAVE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_03_NHAMATANDA",
+    "message": "NAMATANDA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_04_CHISSANE",
+    "message": "CHISSANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_05_CHIUUREE",
+    "message": "CHIUUREE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_06_CHIUUREE 1",
+    "message": "CHIUUREE 1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_07_CHIUUREE 2",
+    "message": "CHIUUREE 2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_08_CHIUUREE 3",
+    "message": "CHIUUREE 3",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_09_CHIUUREE 4",
+    "message": "CHIUUREE 4",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_10_MAPUTO",
+    "message": "MAPUTO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_11_CHIMBUNDE",
+    "message": "CHIMBUNDE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_12_CHIMAZI",
+    "message": "CHIMAZI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_KACHAMANCULO SEDE",
+    "message": "KaChamanculo Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_KACHAMANCULOO",
+    "message": "KaChamanculoo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_03_01_01_MASSAMBI",
+    "message": "MASSAMBI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_03_01_02_CHIMARIR",
+    "message": "CHIMARIR",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_03_01_KAMPFUMU SEDE",
+    "message": "KaMpfumu Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_03_KAMPFUMUU",
+    "message": "KaMpfumuu",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_ADMIN_MO_06_MAPUTO",
+    "message": "ADMIN_MO_06_MAPUTO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_ADMIN_MO_07_MAPUTO CITY",
+    "message": "ADMIN_MO_07_CIDADE DE MAPUTO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_KAMPFUMU",
+    "message": "KaMpfumu",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_01_01_NHAMAZANE",
+    "message": "NAMAZANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_01_02_MAZAMBIQUE",
+    "message": "MAZAMBIQUE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_01_03_CHINMARI",
+    "message": "CHINMARI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_01_04_CHIRINGU",
+    "message": "CHIRINGU",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_01_KAMAXAQUENE SEDE",
+    "message": "KaMaxaquene Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_KAMAXAQUENEA",
+    "message": "KaMaxaquenea",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_KAMAXAQUENE",
+    "message": "KaMaxaquene",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_MAPUTO",
+    "message": "Maputo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_MAPUTO CITY",
+    "message": "Cidade de Maputo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_01_01_01_MAPA",
+    "message": "MAPA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_01_01_02_CHICUZA",
+    "message": "CHICUZA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_01_01_03_CHANGANE",
+    "message": "CHANGANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_01_01_CHIBUTO SEDE",
+    "message": "Sede de Chibuto",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_01_CHIBUTOO",
+    "message": "Chibutoo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_ADMIN_MO_04_SOFALA",
+    "message": "ADMIN_MO_04_SOFALA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_ADMIN_MO_08_GAZA",
+    "message": "ADMIN_MO_08_GAZA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_CHIBUTO",
+    "message": "Chibuto",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_02_01_01_01_MACIA",
+    "message": "MÁCIA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_02_01_01_02_CHIBONGO",
+    "message": "CHIBONGO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_02_01_01_CHOKWE SEDE",
+    "message": "Sede de Chókwe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_02_01_CHOKWEE",
+    "message": "Chokwe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_02_CHOKWE",
+    "message": "Chókwe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_01_01_01_MASSANGENA",
+    "message": "MASSANGENA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_01_01_02_MABALANE",
+    "message": "MABALANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_01_01_03_CHIBALO",
+    "message": "CHIBALO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_01_01_GUIJA SEDE",
+    "message": "Guijá Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_01_GUIJAA",
+    "message": "Guijá",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_GUIJA",
+    "message": "Guijá",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_01_01_01_MACUACUA",
+    "message": "MACUACUÁ",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_01_01_02_MASSINGIR",
+    "message": "MASSINGIR",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_01_01_03_MALE",
+    "message": "MACHO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_01_01_LIMPOPO SEDE",
+    "message": "Sede do Limpopo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_01_LIMPOPOQ",
+    "message": "Limpopoque",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_LIMPOPO",
+    "message": "Limpopo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_05_01_01_01_CHIDENGUELE",
+    "message": "CHIDENGUELE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_05_01_01_02_MACARRETANE",
+    "message": "MACARRETANO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_05_01_01_MANJACAZE SEDE",
+    "message": "Sede de Manjacaze",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_05_01_MANJACAZEE",
+    "message": "Manjacazee",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_05_MANJACAZE",
+    "message": "Manjacaze",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_01_01_01_CHILANGANA",
+    "message": "CHILANGANA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_01_01_02_MATIMBA",
+    "message": "MATIMBA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_01_01_03_CHICOMA",
+    "message": "CHICOMA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_01_01_XAI-XAI SEDE",
+    "message": "Sede de Xai-Xai",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_01_XAI-XAI PA",
+    "message": "Xai Xai PA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_XAI-XAI",
+    "message": "Xai Xai",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_07_01_01_01_MACHANGULO",
+    "message": "MACHANGULO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_07_01_01_MASSINGIR SEDE",
+    "message": "Sede de Massingir",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_07_01_MASSINGIR PA",
+    "message": "Massingir-PA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_07_MASSINGIR",
+    "message": "Massingir",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_08_01_01_01_CHIGUBO",
+    "message": "CHIGUBO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_08_01_01_02_MAPAI",
+    "message": "MAPAI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_08_01_01_MABALANE SEDE",
+    "message": "Mabalane Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_08_01_MABALANEE",
+    "message": "Mabalanee",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_08_MABALANE",
+    "message": "Mabalane",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_09_01_01_01_MASSACHO",
+    "message": "MASSACHO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_09_01_01_02_MACANETA",
+    "message": "MACANETA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_09_01_01_BILENE SEDE",
+    "message": "Bilene Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_09_01_BILENEE",
+    "message": "Bileneu",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_09_BILENE",
+    "message": "Bilene",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_10_01_01_CHICUALACUALA SEDE",
+    "message": "Chicualacuala Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_10_01_CHICUALACUALA",
+    "message": "Chicualacuala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_10_CHICUALACUALAE",
+    "message": "Chicualacualae",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_GAZA",
+    "message": "Gaza",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_SOFALA",
+    "message": "Sofala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_01_01_01_MASSINGA",
+    "message": "MASSINGA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_01_01_02_CHACAME",
+    "message": "CHACAMÉ",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_01_01_03_CHIBUTO",
+    "message": "CHIBUTO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_01_01_INHARRIME SEDE",
+    "message": "Sede de Inharrime",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_01_INHARRIME",
+    "message": "Inharrime",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_ADMIN_MO_02_CABO",
+    "message": "ADMIN_MO_02_CABO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_ADMIN_MO_10_ZAMBEZIA",
+    "message": "ADMIN_MO_10_ZAMBÉZIA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_INHARRIMEA",
+    "message": "Inharrimea",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_01_MASSACATE",
+    "message": "MASSACATE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_02_CHIDENGUELE",
+    "message": "CHIDENGUELE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_03_CHICUZAI",
+    "message": "CHICUZAI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_04_CHIBUTO1",
+    "message": "CHIBUTO1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_05_CHIMACUALAA",
+    "message": "CHIMACUALAA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_06_MASSINGAI",
+    "message": "MASSINGAI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_07_MACUANE11",
+    "message": "MACUANE11",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_JANGAMO SEDE",
+    "message": "Jangamo Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_ADMIN_MO_10_02_NAISSAE",
+    "message": "ADMIN_MO_10_02_NAISSAE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_JANGAMO",
+    "message": "Jangamo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_JANGAMOO",
+    "message": "Jangamoo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_NAISSAE",
+    "message": "Naissae",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_01_MACUACHENE",
+    "message": "MACUACHENE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_02_CHICOMO",
+    "message": "CHICOMO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_03_CHICOAA",
+    "message": "CHICOAA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_04_MACUANEEE",
+    "message": "MACUANEEE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_05_MASSINGIRI",
+    "message": "MASSINGIRI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_06_CHIBUTOOO",
+    "message": "CHIBUTOOO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_MASSINGA SEDE",
+    "message": "Sede de Massinga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_ADMIN_MO_10_01_ALTO MOLOCULE",
+    "message": "ADMIN_MO_10_01_ALTO MOLÓCULA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_MASSINGA",
+    "message": "Massinga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_ALTO MOLOCULE",
+    "message": "Alto Molóculo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_MASSINGAA",
+    "message": "Massinga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_01_01_01_MUABSA",
+    "message": "MUABSA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_01_01_02_CHIMBONE",
+    "message": "CHIMBONE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_01_01_03_MACUANE",
+    "message": "MACUANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_01_01_MAXIXE SEDE",
+    "message": "Maxixe Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_01_MAXIXE",
+    "message": "Maxixe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_MAXIXEE",
+    "message": "Maxixee",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_01_01_01_CHICOA",
+    "message": "CHICOA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_01_01_02_CHICUALACUALA",
+    "message": "CHICUALACUALA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_01_01_03_MALIPA",
+    "message": "MALIPA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_01_01_FUNHALOURO SEDE",
+    "message": "Funhalouro Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_01_FUNHALOURO",
+    "message": "Funhalouro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_FUNHALOUROA",
+    "message": "Funhalouroa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_06_01_01_01_MACATANE",
+    "message": "MACATÂNE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_06_01_01_02_CHIMACUALA",
+    "message": "CHIMACULA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_06_01_01_INHASSORO SEDE",
+    "message": "Sede de Inhassoro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_06_01_INHASSORO",
+    "message": "Inhassoro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_06_INHASSOROE",
+    "message": "Inhassoroe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_01_01_01_CHIMANCHE",
+    "message": "CHIMANCHE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_01_01_02_MACHANGULO",
+    "message": "MACHANGULO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_01_01_03_MAPAI",
+    "message": "MAPAI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_01_01_MABOTE SEDE",
+    "message": "Sede de Mabote",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_01_MABOTE",
+    "message": "Mabote",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_MABOTEE",
+    "message": "Mabotee",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_08_01_01_01_CHINAMANI",
+    "message": "CHINAMANIA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_08_01_01_02_MASSACA",
+    "message": "MASSACA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_08_01_01_VILANCULOS SEDE",
+    "message": "Sede de Vilanculos",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_08_01_VILANCULOS",
+    "message": "Vilanculos",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_08_VILANCULOSE",
+    "message": "Vilanculose",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_09_01_01_01_MABALANE",
+    "message": "MABALANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_09_01_01_02_MASSINGIR",
+    "message": "MASSINGIR",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_09_01_01_ZAVALA SEDE",
+    "message": "Zavala Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_09_01_ZAVALA",
+    "message": "Zavala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_09_ZAVALAA",
+    "message": "Zavalaa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_10_FUNHALOUROE",
+    "message": "Funhalouroe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_CABO",
+    "message": "Cabo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_INHAMBANE",
+    "message": "Inhambane",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_ZAMBEZIA",
+    "message": "Zambézia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_01_LOCATION1",
+    "message": "Localização1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_02_LOCATION2",
+    "message": "Localização2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_03_LOCATION3",
+    "message": "Localização3",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_04_LOCATION4",
+    "message": "Localização4",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_05_LOCATION5",
+    "message": "Localização5",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_06_LOCATION6",
+    "message": "Localização6",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_07_LOCATION7",
+    "message": "Localização7",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_08_LOCATION8",
+    "message": "Localização8",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_09_LOCATION9",
+    "message": "Localização9",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_10_LOCATION10",
+    "message": "Localização10",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_ALTO MOLOCUE SEDE",
+    "message": "Sede do Alto Molócué",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_ALTO MOLOCUE",
+    "message": "Alto Molócué",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_ADMIN_MO_01_NAMPULA",
+    "message": "ADMIN_MO_01_NAMPULA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_ADMIN_MO_09_INHAMBANE",
+    "message": "ADMIN_MO_09_INHAMBANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_ALTO MOLOCULE",
+    "message": "Alto Molóculo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_01_REGION1",
+    "message": "Região1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_02_REGION2",
+    "message": "Região2",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_03_REGION3",
+    "message": "Região3",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_04_REGION4",
+    "message": "Região4",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_05_REGION5",
+    "message": "Região5",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_06_REGION6",
+    "message": "Região6",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_07_REGION7",
+    "message": "Região7",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_08_REGION8",
+    "message": "Região8",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_09_REGION9",
+    "message": "Região9",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_10_REGION10",
+    "message": "Região10",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_11_REGION11",
+    "message": "Região11",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_12_REGION12",
+    "message": "Região12",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_13_REGION13",
+    "message": "Região13",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_14_REGION14",
+    "message": "Região14",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_15_REGION15",
+    "message": "Região15",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_16_REGION16",
+    "message": "Região16",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_17_REGION17",
+    "message": "Região17",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_18_REGION18",
+    "message": "Região18",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_19_REGION19",
+    "message": "Região19",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_20_REGION20",
+    "message": "Região20",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_21_REGION21",
+    "message": "Região21",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_22_REGION22",
+    "message": "Região22",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_23_REGION23",
+    "message": "Região23",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_24_REGION24",
+    "message": "Região24",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_25_REGION25",
+    "message": "Região25",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_26_REGION26",
+    "message": "Região26",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_27_REGION27",
+    "message": "Região27",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_28_REGION28",
+    "message": "Região28",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_29_REGION29",
+    "message": "Região29",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_30_REGION30",
+    "message": "Região30",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_NAISSA SEDE",
+    "message": "Naissa Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_NAISSA",
+    "message": "Naissa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_NAISSAE",
+    "message": "Naissae",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_INHAMBANE",
+    "message": "Inhambane",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_NAMPULA",
+    "message": "Nampula",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_ZAMBEZIA",
+    "message": "Zambézia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_01_VILLAGEONE",
+    "message": "VilaOne",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_02_VILLAGETWO",
+    "message": "VillageTwo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_03_VILLAGETHREE",
+    "message": "Aldeia Três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_04_VILLAGEFOUR",
+    "message": "VillageFour",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_05_VILLAGEFIVE",
+    "message": "VillageFive",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_06_VILLAGESIX",
+    "message": "VillageSix",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_07_VILLAGESEVEN",
+    "message": "VillageSeven",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_08_VILLAGEEIGHT",
+    "message": "VillageEight",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_09_VILLAGENINE",
+    "message": "VillageNine",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_10_VILLAGETEN",
+    "message": "VillageTen",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_11_VILLAGEELEVEN",
+    "message": "VillageEleven",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_12_VILLAGETWELVE",
+    "message": "VillageTwelve",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_LOCALITYONE",
+    "message": "LocalidadeUm",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_01_VILLAGETHIRTEEN",
+    "message": "Aldeia Treze",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_02_VILLAGEFOURTEEN",
+    "message": "Aldeia Quatorze",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_03_VILLAGEFIFTEEN",
+    "message": "Aldeia Quinze",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_04_VILLAGESIXTEEN",
+    "message": "Aldeia Dezesseis",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_05_VILLAGESEVENTEEN",
+    "message": "Vila Dezessete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_06_VILLAGEEIGHTEEN",
+    "message": "Aldeia Dezoito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_07_VILLAGENINETEEN",
+    "message": "Vila Dezenove",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_08_VILLAGETWENTY",
+    "message": "VillageTwenty",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_09_VILLAGETWENTY-ONE",
+    "message": "VillageTwenty-one",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_10_VILLAGETWENTY-TWO",
+    "message": "VillageTwenty-two",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_11_VILLAGETWENTY-THREE",
+    "message": "VillageTwenty-três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_12_VILLAGETWENTY-FOUR",
+    "message": "VillageTwenty-four",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_LOCALITYTWO",
+    "message": "Localidade Dois",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_01_VILLAGETWENTY-FIVE",
+    "message": "VillageTwenty-five",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_02_VILLAGETWENTY-SIX",
+    "message": "Vila Vinte e seis",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_03_VILLAGETWENTY-SEVEN",
+    "message": "Vila Vinte e Sete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_04_VILLAGETWENTY-EIGHT",
+    "message": "VillageTwenty-eight",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_05_VILLAGETWENTY-NINE",
+    "message": "Vila Vinte e nove",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_06_VILLAGETHIRTY",
+    "message": "Aldeia Trinta",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_07_VILLAGETHIRTY-ONE",
+    "message": "Aldeia Trinta e Um",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_08_VILLAGETHIRTY-TWO",
+    "message": "Aldeia Trinta e Dois",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_09_VILLAGETHIRTY-THREE",
+    "message": "Aldeia Trinta e Três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_10_VILLAGETHIRTY-FOUR",
+    "message": "Aldeia Trinta e Quatro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_11_VILLAGETHIRTY-FIVE",
+    "message": "VillageTrinta e cinco",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_12_VILLAGETHIRTY-SIX",
+    "message": "Aldeia Trinta e seis",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_LOCALITYTHREE",
+    "message": "Localidade Três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_POST ADMINISTRATIVEONE",
+    "message": "Pós AdministrativoUm",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_01_VILLAGETHIRTY-SEVEN",
+    "message": "Aldeia Trinta e Sete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_02_VILLAGETHIRTY-EIGHT",
+    "message": "VillageTrinta e oito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_03_VILLAGETHIRTY-NINE",
+    "message": "Aldeia Trinta e nove",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_04_VILLAGEFORTY",
+    "message": "VillageForty",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_05_VILLAGEFORTY-ONE",
+    "message": "VillageQuarenta e um",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_06_VILLAGEFORTY-TWO",
+    "message": "VillageQuarenta e dois",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_07_VILLAGEFORTY-THREE",
+    "message": "VillageQuarenta e três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_08_VILLAGEFORTY-FOUR",
+    "message": "VillageQuarenta e quatro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_09_VILLAGEFORTY-FIVE",
+    "message": "VillageQuarenta e cinco",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_10_VILLAGEFORTY-SIX",
+    "message": "VillageQuarenta e seis",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_11_VILLAGEFORTY-SEVEN",
+    "message": "VillageQuarenta e sete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_12_VILLAGEFORTY-EIGHT",
+    "message": "VillageQuarenta e oito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_LOCALITYFOUR",
+    "message": "LocalityFour",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_01_VILLAGEFORTY-NINE",
+    "message": "VillageQuarenta e nove",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_02_VILLAGEFIFTY",
+    "message": "VillageFifty",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_03_VILLAGEFIFTY-ONE",
+    "message": "VillageFifty-one",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_04_VILLAGEFIFTY-TWO",
+    "message": "VillageFifty e dois",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_05_VILLAGEFIFTY-THREE",
+    "message": "VillageFifty-três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_06_VILLAGEFIFTY-FOUR",
+    "message": "VillageFifty-four",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_07_VILLAGEFIFTY-FIVE",
+    "message": "VillageFifty-five",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_08_VILLAGEFIFTY-SIX",
+    "message": "VillageFifty e seis",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_09_VILLAGEFIFTY-SEVEN",
+    "message": "VillageFifty e sete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_10_VILLAGEFIFTY-EIGHT",
+    "message": "VillageFifty-eight",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_11_VILLAGEFIFTY-NINE",
+    "message": "VillageFifty-nine",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_12_VILLAGESIXTY",
+    "message": "VillageSixty",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_LOCALITYFIVE",
+    "message": "LocalityFive",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_POST ADMINISTRATIVETWO",
+    "message": "Pós Administrativo Dois",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_ADMIN_MO_11_TEST PROVINCE",
+    "message": "ADMIN_MO_11_TEST PROVINCE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_ADMIN_MO_11_TETE",
+    "message": "ADMIN_MO_11_TETE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_DISTRICTONE",
+    "message": "Distrito Um",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_01_VILLAGESIXTY-ONE",
+    "message": "VillageSessenta e um",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_02_VILLAGESIXTY-TWO",
+    "message": "VillageSessenta e dois",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_03_VILLAGESIXTY-THREE",
+    "message": "VillageSessenta e três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_04_VILLAGESIXTY-FOUR",
+    "message": "VillageSessenta e quatro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_05_VILLAGESIXTY-FIVE",
+    "message": "VillageSessenta e cinco",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_06_VILLAGESIXTY-SIX",
+    "message": "VillageSessenta e seis",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_07_VILLAGESIXTY-SEVEN",
+    "message": "VillageSessenta e sete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_08_VILLAGESIXTY-EIGHT",
+    "message": "VillageSessenta e oito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_09_VILLAGESIXTY-NINE",
+    "message": "VillageSessenta e nove",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_10_VILLAGESEVENTY",
+    "message": "Aldeia Setenta",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_11_VILLAGESEVENTY-ONE",
+    "message": "Village Seventy-one",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_12_VILLAGESEVENTY-TWO",
+    "message": "Village Seventy-two",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_LOCALITYSIX",
+    "message": "LocalitySix",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_01_VILLAGESEVENTY-THREE",
+    "message": "Aldeia Setenta e três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_02_VILLAGESEVENTY-FOUR",
+    "message": "Aldeia Setenta e quatro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_03_VILLAGESEVENTY-FIVE",
+    "message": "Aldeia Setenta e cinco",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_04_VILLAGESEVENTY-SIX",
+    "message": "Aldeia Setenta e seis",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_05_VILLAGESEVENTY-SEVEN",
+    "message": "Aldeia Setenta e Sete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_06_VILLAGESEVENTY-EIGHT",
+    "message": "Village Seventy-eight",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_07_VILLAGESEVENTY-NINE",
+    "message": "Aldeia Setenta e nove",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_LOCALITYSEVEN",
+    "message": "LocalidadeSete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_POST ADMINISTRATIVETHREE",
+    "message": "Pós-Administrativo Três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_01_VILLAGEEIGHTY",
+    "message": "VillageEighty",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_02_VILLAGEEIGHTY-ONE",
+    "message": "VillageEighty-one",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_03_VILLAGEEIGHTY-TWO",
+    "message": "VillageEighty e dois",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_04_VILLAGEEIGHTY-THREE",
+    "message": "VillageOitenta e três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_05_VILLAGEEIGHTY-FOUR",
+    "message": "VillageOitenta e quatro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_06_VILLAGEEIGHTY-FIVE",
+    "message": "VillageOitenta e cinco",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_07_VILLAGEEIGHTY-SIX",
+    "message": "VillageOitenta e seis",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_08_VILLAGEEIGHTY-SEVEN",
+    "message": "VillageOitenta e sete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_09_VILLAGEEIGHTY-EIGHT",
+    "message": "VillageEighty-eight",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_10_VILLAGEEIGHTY-NINE",
+    "message": "Aldeia Oitenta e nove",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_LOCALITYEIGHT",
+    "message": "LocalityEight",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_01_VILLAGENINETY",
+    "message": "VillageNinety",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_02_VILLAGENINETY-ONE",
+    "message": "Aldeia Noventa e um",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_03_VILLAGENINETY-TWO",
+    "message": "Aldeia Noventa e dois",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_04_VILLAGENINETY-THREE",
+    "message": "Aldeia Noventa e três",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_05_VILLAGENINETY-FOUR",
+    "message": "Aldeia Noventa e quatro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_06_VILLAGENINETY-FIVE",
+    "message": "Aldeia Noventa e cinco",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_07_VILLAGENINETY-SIX",
+    "message": "Aldeia Noventa e seis",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_08_VILLAGENINETY-SEVEN",
+    "message": "Aldeia Noventa e sete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_09_VILLAGENINETY-EIGHT",
+    "message": "Aldeia Noventa e oito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_10_VILLAGENINETY-NINE",
+    "message": "Aldeia Noventa e nove",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_LOCALITYNINE",
+    "message": "LocalityNine",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_POST ADMINISTRATIVEFOUR",
+    "message": "Pós AdministrativoQuatro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_DISTRICTTWO",
+    "message": "Distrito Dois",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_TEST PROVINCE",
+    "message": "Província de teste",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_TETER",
+    "message": "Teter",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_01_01_01_MURO",
+    "message": "MURO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_01_01_02_CHIRIMBU",
+    "message": "CHIRIMBU",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_01_01_KANSENGWA SEDE",
+    "message": "Sede de Kansengwa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_01_KANSENGWA",
+    "message": "Kansengwa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_ADMIN_MO_12_TETE",
+    "message": "ADMIN_MO_12_TETE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_MOATIZE",
+    "message": "Moatize",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_MOATIZE ",
+    "message": "Moatize",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_01_01_01_NHATE",
+    "message": "NHATE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_01_01_02_MATCHESSA",
+    "message": "MATCHESSA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_01_01_ULONGUE SEDE",
+    "message": "Sede de Ulongue",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_01_ADMIN_MO_12_01_MOATIZE",
+    "message": "ADMIN_MO_12_01_MOATIZE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_01_ULONGUE",
+    "message": "Ulongue",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_ANGÓNIA",
+    "message": "Angónia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_MOATIZE",
+    "message": "Moatize",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_01_01_01_MAROE",
+    "message": "MAROE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_01_01_02_MUJA",
+    "message": "MUJA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_01_01_FURANCUNGO SEDE",
+    "message": "Furancungo Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_01_ADMIN_MO_12_02_ANGÓNIA",
+    "message": "ADMIN_MO_12_02_ANGÓNIA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_01_FURANCUNGO",
+    "message": "Furancungo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_02_01_01_NHAYARA",
+    "message": "NHAYARA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_02_01_02_CHILEMBO",
+    "message": "CHILEMBO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_02_01_MULANGUANE SEDE",
+    "message": "Sede de Mulanguane",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_02_MULANGUANE",
+    "message": "Mulanguane",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_ANGÓNIA",
+    "message": "Angónia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_TSANGANO",
+    "message": "Tsangano",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_01_01_01_SAMBINDA",
+    "message": "SAMBINDA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_01_01_02_MACHURO",
+    "message": "MACHURO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_01_01_CHITIMA SEDE",
+    "message": "Chitima Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_01_ADMIN_MO_12_03_TSANGANO",
+    "message": "ADMIN_MO_12_03_TSANGANO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_01_CHITIMA",
+    "message": "Chitima",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_02_01_01_MATCHIME",
+    "message": "JOGO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_02_01_02_MACAIA",
+    "message": "MACAIA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_02_01_MARARA SEDE",
+    "message": "Marara Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_02_MARARA",
+    "message": "Marara",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_CAHORA BASSA",
+    "message": "Cahora Bassa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_TSANGANO",
+    "message": "Tsangano",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_01_01_01_NHANDE",
+    "message": "NHANDE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_01_01_02_MACAMBULA",
+    "message": "MACAMBULA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_01_01_KAFUNFO SEDE",
+    "message": "Kafunfo Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_01_ADMIN_MO_12_04_CAHORA BASSA",
+    "message": "ADMIN_MO_12_04_CAHORA BASSA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_01_KAFUNFO",
+    "message": "Kafunfo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_02_01_01_MACOCHA",
+    "message": "MACOCHA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_02_01_02_NHAMADA",
+    "message": "NHAMADA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_02_01_SONGO SEDE",
+    "message": "Songo Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_02_SONGO",
+    "message": "Songo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_03_01_01_NHAMISSENGUE",
+    "message": "NHAMISSENGUE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_03_01_02_MACAPA",
+    "message": "MACAPÁ",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_03_01_MANDIE SEDE",
+    "message": "Mandie Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_03_MANDIE",
+    "message": "Mandie",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_CAHORA BASSA",
+    "message": "Cahora Bassa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_CHIUTA",
+    "message": "Chiuta",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_01_01_01_CHILUCA",
+    "message": "CHILUCA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_01_01_02_CHIMBUNDE",
+    "message": "CHIMBUNDE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_01_01_CHARRE SEDE",
+    "message": "Charre Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_01_ADMIN_MO_12_05_CHIUTA",
+    "message": "ADMIN_MO_12_05_CHIUTA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_01_CHARRE",
+    "message": "Charré",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_02_01_01_MAZANE",
+    "message": "MAZANE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_02_01_02_MACUE",
+    "message": "MACUE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_02_01_NHAMPOSSA SEDE",
+    "message": "Sede de Nhampossa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_02_NHAMPOSSA",
+    "message": "Nhampossa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_CHIUTA",
+    "message": "Chiuta",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_MAGOE",
+    "message": "Magoe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_01_01_01_CHIMUQUE",
+    "message": "CHIMUQUE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_01_01_02_NHAFUCO",
+    "message": "NHAFUCO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_01_01_MURROTHONE SEDE",
+    "message": "Sede Murrothone",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_01_ADMIN_MO_12_06_MAGOE",
+    "message": "ADMIN_MO_12_06_MAGOE",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_01_MURROTHONE",
+    "message": "Murrothone",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_02_01_01_MACHIPO",
+    "message": "MACHIPO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_02_01_02_CHIMBENGA",
+    "message": "CHIMBENGA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_02_01_CAFUMPA SEDE",
+    "message": "Cafumpa Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_02_CAFUMPA",
+    "message": "Cafumpa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_03_01_01_MACHAMBA",
+    "message": "MACAMBA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_03_01_02_MACARULA",
+    "message": "MACARULA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_03_01_INHAMGOMA SEDE",
+    "message": "Sede de Inhamgoma",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_03_INHAMGOMA",
+    "message": "Inhamgoma",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_MAGOE",
+    "message": "Magoe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_MUTARARA",
+    "message": "Mutarara",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_01_01_01_MALENGA",
+    "message": "MALENGA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_01_01_02_NHAURAO",
+    "message": "NHAURAO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_01_01_LUCALA SEDE",
+    "message": "Lucala Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_01_ADMIN_MO_12_07_MUTARARA",
+    "message": "ADMIN_MO_12_07_MUTARARA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_01_LUCALA",
+    "message": "Lucala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_CHANGARA",
+    "message": "Changara",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_MUTARARA",
+    "message": "Mutarara",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_01_01_01_NHAMAMBA",
+    "message": "NAMAMBA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_01_01_02_MACOTI",
+    "message": "MACOTI",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_01_01_CHIFUNDE SEDE",
+    "message": "Chifunde Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_01_ADMIN_MO_12_08_CHANGARA",
+    "message": "ADMIN_MO_12_08_CHANGARA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_01_CHIFUNDE",
+    "message": "Chifunde",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_02_01_01_NHATHANDA",
+    "message": "NATHANDA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_02_01_02_CHIRINDA",
+    "message": "CHIRINDA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_02_01_NDIMA SEDE",
+    "message": "Ndima Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_02_NDIMA",
+    "message": "Ndima",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_CHANGARA",
+    "message": "Changara",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_MACANGA",
+    "message": "Macanga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_10_01_ADMIN_MO_12_09_MACANGA",
+    "message": "ADMIN_MO_12_09_MACANGA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_10_MACANGA",
+    "message": "Macanga",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_11_01_01_01_MAVERA",
+    "message": "MAVERA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_11_01_01_02_NYAMPANDA",
+    "message": "NYAMPANDA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_11_01_01_MUCUMBURA SEDE",
+    "message": "Sede de Mucumbura",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_11_01_MUCUMBURA",
+    "message": "Mucumbura",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_11_ZUMBO",
+    "message": "Zumbo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_12_01_01_01_CHAVITSA",
+    "message": "CHAVITSA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_12_01_01_02_NHASSANGWA",
+    "message": "NHASSANGWA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_12_01_01_CHINTHOLO SEDE",
+    "message": "Chintholo Sede",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_12_01_CHINTHOLO",
+    "message": "Chintholo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_12_CHIFUNDE",
+    "message": "Chifunde",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_13_01_01_01_NHAMUCANDA",
+    "message": "NAMUCANDA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_13_01_01_02_MATARARA",
+    "message": "MATARARA",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_13_01_01_NHAMAYABWE SEDE",
+    "message": "Sede de Nhamayabwe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_13_01_NHAMAYABWE",
+    "message": "Nhamayabwe",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_13_DÔA",
+    "message": "Dôa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_TETE",
+    "message": "Tete",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_POST ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_POSTO ADMINISTRATIVO",
+    "message": "Pós-administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_PROVINCIA",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_STATE",
+    "message": "Estado",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AGE",
+    "message": "Idade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.Country",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.Distrito",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.Localidade",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.Post Administrativo",
+    "message": "Pós Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.PostAdministrativo",
+    "message": "Pós Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.State",
+    "message": "Estado",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Definir a população total e alvo após o download do modelo:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "Vá à ficha do distrito para o qual pretende definir as metas e adicione os dados da população total e alvo para cada aldeia.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Insira a população alvo e total de cada aldeia na ficha de cada distrito. Se alguma aldeia não tiver metas definidas, a ficha terá erros.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Salve a planilha com o alvo atualizado e a população total de cada aldeia no modelo Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Pressione o botão 'Navegar em meus arquivos' na tela de upload da população e selecione o arquivo salvo com toda a população alvo e total do sistema.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2",
+    "message": "Casos de erros comuns:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2_DESC_1",
+    "message": "Se o usuário não tiver definido metas ou população total para cada aldeia, o sistema gerará um erro com o número da linha onde falta a população alvo ou total.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2_DESC_2",
+    "message": "Se o usuário excluir qualquer aldeia da planilha ou excluir uma planilha de distrito completa e carregar a planilha, o sistema gerará um erro. O usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corrigidos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MICROPLAN_README_HEADER_2_DESC_3",
+    "message": "Se o usuário excluir qualquer um dos cabeçalhos da planilha e carregá-la, o sistema gerará um erro. O usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corrigidos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1",
+    "message": "Baixando modelos do Excel para definição de metas:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Baixe o modelo Excel clicando no botão “Baixar modelo”.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Abra o modelo Excel que foi baixado na etapa anterior e a primeira planilha que você verá é uma planilha “Leia-me”. As restantes folhas serão nomeadas de acordo com o nome dos distritos seleccionados no passo “Selecção de Limites”, tendo cada folha de distrito uma lista de todas as aldeias mapeadas para esse distrito.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2",
+    "message": "Definir metas após o download do modelo:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_1",
+    "message": "Vá para a ficha do distrito para o qual deseja definir metas e adicione números na coluna “Metas” para cada Aldeia. ",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Insira as metas para cada aldeia na ficha de cada distrito na coluna “Meta ao nível do limite seleccionado”. Se alguma aldeia não tiver metas definidas, a ficha terá erros.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Target” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3",
+    "message": "Casos de erros comuns:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Se o usuário não tiver definido metas para cada aldeia, o sistema gerará um erro com o número da linha onde as metas estão faltando.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Se o usuário excluir qualquer aldeia da planilha ou excluir uma planilha distrital completa e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_3",
+    "message": "Se o usuário excluir qualquer um dos cabeçalhos da planilha e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_MAINHEADER",
+    "message": "Leia-me as instruções para upload de destino",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": "Número de mosquiteiros por domicílio",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Número de indivíduos por mosquiteiro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_BEFORE_ERROR",
+    "message": "A data de término da campanha não pode ser anterior à data de início da campanha.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_ERROR",
+    "message": "Campo obrigatório!",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_MANDATORY",
+    "message": "Campo obrigatório!",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE_ERROR",
+    "message": "Campo obrigatório!",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_MZ_capacity",
+    "message": "Capacidade (Unidades: Fardos)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_mz_capacity",
+    "message": "Capacidade (Unidades: Fardos)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIN_mz_capacity",
+    "message": "Capacidade (Unidades: Fardos)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN__capacity",
+    "message": "Capacidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN_capacity",
+    "message": "Capacidade (Unidades: Blister SPAQ)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_boundaryCode",
+    "message": "Código de limite de captação (obrigatório)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityUsage",
+    "message": "Uso das instalações",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EDIT_MICROPLANS_TEXT",
+    "message": "Editar microplano",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EQUAL_TO",
+    "message": "igual a",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_LOADING_BASE_MAP",
+    "message": "Não é possível encontrar o mapa base necessário. Entre em contato com o administrador.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_READ_ME_MISSING",
+    "message": "Por favor, não altere os nomes das planilhas.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_TIMELINE",
+    "message": "Linha do tempo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_1",
+    "message": "Se não houver instalações disponíveis para seleção, a aba “Lista de instalações disponíveis” no modelo estará vazia. Para criar novos dados de instalação, adicione o nome do Nome da Instalação, Tipo de Instalação, Status da Instalação, Capacidade. A coluna “Código da Instalação” precisa ser deixada em branco se esta for uma instalação nova. Caso se trate de uma instalação sendo reaproveitada (que fica disponível no template após o download) o usuário só precisa realizar o passo 2.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Para mapear a instalação para o limite correto, o usuário precisa copiar o código de limite correto do limite da planilha “Lista de Limites de Campanha” para a qual a instalação precisa ser mapeada. Se houver uma instalação mapeada para vários limites, o administrador do sistema terá que adicionar os códigos de limite de todos os limites para os quais a instalação está mapeada, separando-os por vírgulas na célula para adicionar códigos de limite para essa instalação.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Criar novos dados de instalações/usar dados de instalações existentes após o download do modelo:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "Se não houver instalações disponíveis para seleção, a aba “Lista de instalações disponíveis” no modelo estará vazia. Para criar novos dados de instalação, adicione o nome do Nome da Instalação, Tipo de Instalação, Status da Instalação, Capacidade e Uso da Instalação.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Para mapear a instalação para o limite correto, o usuário precisa copiar o código de limite correto do limite da planilha “Dados do limite” para a qual a instalação precisa ser mapeada.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Salve a planilha com os detalhes da instalação inseridos no modelo Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Pressione o botão “Navegar em meus arquivos” na tela “Carregar dados da instalação” e selecione o arquivo salvo com todos os dados da instalação do sistema.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_2",
+    "message": "Desativando instalações existentes para uma campanha",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_2_DESC_1",
+    "message": "Depois que o usuário tiver baixado o modelo para instalações, se o sistema tiver dados de instalações existentes para serem reutilizados, o modelo será pré-preenchido com essa lista de instalações.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_2_DESC_2",
+    "message": "Se o usuário optar por não usar instalações específicas, ele poderá desativar essa instalação marcando o campo 'Uso da instalação' como 'Inativo'.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3",
+    "message": "Casos de erros comuns:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3_DESC_1",
+    "message": "Se o usuário tiver removido o código de limite da instalação para uma instalação existente na lista, o sistema emitirá uma mensagem de erro.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3_DESC_2",
+    "message": "Se o usuário excluir alguma coluna da “Lista de Instalações Disponíveis” da planilha e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MICROPLAN_README_HEADER_3_DESC_3",
+    "message": "Se o usuário excluir algum dos cabeçalhos da planilha e carregá-la, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1",
+    "message": "Baixando modelos do Excel para configuração de instalações:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Baixe o modelo Excel clicando no botão “Baixar modelo”.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Abra o modelo que foi baixado na etapa anterior e terá 3 planilhas e a primeira planilha que você verá é uma planilha “Leia-me”. A segunda Folha denominada “Lista de Instalações Disponíveis” conterá uma lista de todas as instalações disponíveis que podem ser utilizadas na campanha. Se não houver nenhuma facilidade disponível, esta folha estará vazia. A terceira folha será denominada “Lista de Limites de Campanha” que conterá todos os limites com seus respectivos Códigos de Limites.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2",
+    "message": "Criar novos dados de instalações/usar dados de instalações existentes após o download do modelo:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "Se não houver instalações disponíveis para seleção, a aba “Lista de instalações disponíveis” no modelo estará vazia. Para criar novos dados de instalação, adicione o nome do Nome da Instalação, Tipo de Instalação, Status da Instalação, Capacidade. A coluna “Código da Instalação” precisa ser deixada em branco se esta for uma instalação nova. Caso se trate de uma instalação sendo reaproveitada (que fica disponível no template após o download) o usuário só precisa realizar o passo 2.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Para mapear a instalação para o limite correto, o usuário precisa copiar o código de limite correto do limite da planilha “Lista de Limites de Campanha” para a qual a instalação precisa ser mapeada. Se houver uma instalação mapeada para vários limites, o administrador do sistema terá que adicionar os códigos de limite de todos os limites para os quais a instalação está mapeada, separando-os por vírgulas na célula para adicionar códigos de limite para essa instalação.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Facility Data” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_5",
+    "message": "Desativando Instalações existentes para uma campanha.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_6",
+    "message": "Depois que o usuário tiver baixado o modelo para instalações, se o sistema tiver dados de instalações existentes para serem reutilizados, o modelo será pré-preenchido com essa lista de instalações.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_7",
+    "message": "Se o usuário optar por não usar instalações específicas, ele poderá excluir as linhas de dados dessas instalações específicas que precisam ser removidas e carregar a planilha apenas com as instalações necessárias para a campanha com os códigos de limite corretos mapeados para essas instalações.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1",
+    "message": "Caso em que não há dados da instalação no sistema:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_1",
+    "message": "Passo 1: Quando não houver dados de instalações no sistema, o modelo “Lista de instalações disponíveis” estará vazio. Para cada instalação adicionada, o usuário precisa inserir o nome da instalação (deve ser exclusivo), tipo de instalação (armazém/instalação de saúde), status da instalação (temporário/permanente), capacidade (entrada de número)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_2",
+    "message": "Passo 2: Para mapear as instalações para um determinado limite, o usuário precisa copiar o Código do Limite correto da planilha “Dados do Limite”. Se houver mais de um limite para o qual uma instalação precisa ser mapeada, o usuário poderá adicionar todos os códigos de limite separados por vírgulas",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_3",
+    "message": "Etapa 3: Para cada instalação, o usuário precisa adicionar Ativo ou Inativo para todas as instalações na coluna “Uso da Instalação”. Todas as Instalações marcadas como “Ativas” serão utilizadas na campanha que está sendo criada, as marcadas como “Inativas” não serão utilizadas na campanha que está sendo criada.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_4",
+    "message": "Passo 4: Depois que todas as facilidades forem adicionadas, o usuário precisa salvar o arquivo em seu sistema e fazer upload do arquivo pressionando a opção “Navegar em Meus Arquivos”.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2",
+    "message": "Caso em que existem dados de instalações existentes no sistema:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_1",
+    "message": "Passo 1: Ao abrir o modelo de instalação baixado, consulte a folha Lista de instalações disponíveis. Para instalações existentes, adicione entradas na coluna Código de limite. Você pode encontrar os códigos de limite na planilha Dados de limite. Se uma instalação mapear vários limites, separe os códigos com vírgulas.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_2",
+    "message": "Etapa 2: nesta etapa, o usuário terá que adicionar entradas na coluna Uso da instalação com entradas válidas sendo Ativas ou Inativas, onde o usuário pode definir o uso de uma instalação como Ativo se a instalação estiver sendo usada para uma campanha ou então pode ser definido como Inativo. As entradas na coluna Uso da Instalação precisam ser adicionadas para todas as entradas.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_3",
+    "message": "Etapa 3: Para adicionar novas instalações que não estão presentes na lista de instalações existentes, o usuário precisa inserir o nome da instalação (deve ser exclusivo), tipo de instalação (armazém/instalação de saúde), status da instalação (temporário/permanente), capacidade (Entrada de número), Código de limite (da Folha de dados de limite) e Uso da instalação (Ativo/Inativo), conforme explicado anteriormente",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_4",
+    "message": "Passo 4: Depois que todas as facilidades forem adicionadas, o usuário precisa salvar o arquivo em seu sistema e fazer upload do arquivo pressionando a opção “Navegar em Meus Arquivos”.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3",
+    "message": "Casos de erros comuns:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Se o usuário tiver removido os códigos de instalação de uma instalação existente na lista, o sistema criará uma instalação duplicada com esses valores de coluna.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Se o usuário excluir alguma coluna da “Lista de Instalações Disponíveis” da planilha e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_3",
+    "message": "Se o usuário excluir algum dos cabeçalhos da planilha e carregá-la, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_MAINHEADER",
+    "message": "Leia-me as instruções para upload de instalações",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER",
+    "message": "Atribuidor de instalação",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FEMALE",
+    "message": "Fêmea",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FROM",
+    "message": "de",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GENDER",
+    "message": "Gênero",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GREATER_THAN",
+    "message": "maior que",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GREATER_THAN_EQUAL_TO",
+    "message": "maior ou igual a",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POST ADMINISTRATIVO",
+    "message": "Pós Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_PROVINCIA",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_AVAILABLE_FACILITIES",
+    "message": "Lista de instalações disponívei",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Código de limite",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY",
+    "message": "Código de limite (obrigatório)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY_ERROR",
+    "message": "é inválido. Deve ser retirado da planilha 'Dados de limite'",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_OLD",
+    "message": "Código de limite antigo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Dados de limite",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITIES",
+    "message": "Lista de instalações",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY",
+    "message": "Capacidade (Unidades: Fardos para redes mosquiteiras/ Blister SPAQ para SMC)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_ERROR",
+    "message": "não deve estar vazio e deve ser um número de 1 a 10 milhões",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN",
+    "message": "Capacidade (Unidades: Fardos para redes mosquiteiras/",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_LLIN-mz",
+    "message": "Capacidade (Unidades: Fardos)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_MR-DN",
+    "message": "Capacidade (Unidades: Bolhas)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CODE",
+    "message": "Código da instalação",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_FIXED_POST_MICROPLAN",
+    "message": "É posto fixo (Sim/Não)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LATITUDE_OPTIONAL_MICROPLAN",
+    "message": "Latitude (opcional)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LONGITUDE_OPTIONAL_MICROPLAN",
+    "message": "Longitude (opcional)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME",
+    "message": "Nome da instalação",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME_MICROPLAN",
+    "message": "Nome da instalação",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS",
+    "message": "Status da instalação",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS_MICROPLAN",
+    "message": "Status da instalação",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE",
+    "message": "Tipo de instalação",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE_MICROPLAN",
+    "message": "Tipo de instalação",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE",
+    "message": "Uso das instalações",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE_MICROPLAN",
+    "message": "Uso das instalações",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LAT",
+    "message": "Latitude",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LONG",
+    "message": "Longitude",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_RESIDING_BOUNDARY_CODE_MICROPLAN",
+    "message": "Código de limite residente",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET",
+    "message": "Alvo do agregado familiar ao nível da aldeia (obrigatório e a ser introduzido pelo utilizador)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_AT_THE_SELECTED_BOUNDARY_LEVEL",
+    "message": "Alvo do agregado familiar ao nível da aldeia (obrigatório e a ser introduzido pelo utilizador)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_1",
+    "message": "Alvo do agregado familiar ao nível da aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_2",
+    "message": "Sala alvo em nível de vila",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LAT_OPT",
+    "message": "Latitude (opcional)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LONG_OPT",
+    "message": "Longitude (opcional)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "População alvo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "População-alvo (12 a 59 meses de idade)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "População-alvo (3 a 11 meses de idade)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC",
+    "message": "Alvo ao nível da aldeia (obrigatório e a ser inserido pelo usuário)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_12_TO_59",
+    "message": "Alvo ao nível da aldeia - Idade dos 12 aos 59 meses (obrigatório e a inserir pelo utilizador)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_3_TO_11",
+    "message": "Alvo ao nível da aldeia - Idade dos 3 aos 11 meses (obrigatório e a inserir pelo utilizador)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "População total",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMAIL_MICROPLAN",
+    "message": "E-mail",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMPLOYMENT_TYPE",
+    "message": "Tipo de emprego (obrigatório)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LIST",
+    "message": "Criar lista de usuários",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Nome da Pessoa (Obrigatório)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME_MICROPLAN",
+    "message": "Nome",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER",
+    "message": "Número de telefone (obrigatório)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_ERROR",
+    "message": "deve ser fornecido e deve ser um número de telefone de 10 dígitos",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_MICROPLAN",
+    "message": "Número de contato",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_ROLE",
+    "message": "Função (obrigatório)",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_USAGE",
+    "message": "Ativo/Inativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_GREATER_THAN_ZERO",
+    "message": "should be greater than 0",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_README_SHEETNAME",
+    "message": "Leia-me",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_TIMELINE",
+    "message": "Linha do tempo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_POST ADMINISTRATIVE",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEIGHT",
+    "message": "Altura",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_ADMINISTRATIVEPOST",
+    "message": "Pós-administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_POST ADMINISTRATIVE",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_CAN_BE_ONLY_APPLIED_ON_ADMIN_LEVEL_ZORO",
+    "message": "Os filtros só podem ser aplicados no nível 0",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "IN_BETWEEN",
+    "message": "entre",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LESS_THAN",
+    "message": "menor que",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LESS_THAN_EQUAL_TO",
+    "message": "menor ou igual a",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIM_MZ_capacity",
+    "message": "Capacidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIM_mz_capacity",
+    "message": "Capacidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "Se não houver instalações disponíveis para seleção, a aba “Lista de instalações disponíveis” no modelo estará vazia. Para criar novos dados de instalação, adicione o nome do Nome da Instalação, Tipo de Instalação, Status da Instalação, Capacidade. A coluna “Código da Instalação” precisa ser deixada em branco se esta for uma instalação nova. Caso se trate de uma instalação sendo reaproveitada (que fica disponível no template após o download) o usuário só precisa realizar o passo 2.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "Se o usuário excluir algum dos cabeçalhos da planilha e carregá-la, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Para mapear a instalação para o limite correto, o usuário precisa copiar o código de limite correto do limite da planilha “Lista de Limites de Campanha” para a qual a instalação precisa ser mapeada. Se houver uma instalação mapeada para vários limites, o administrador do sistema terá que adicionar os códigos de limite de todos os limites para os quais a instalação está mapeada, separando-os por vírgulas na célula para adicionar códigos de limite para essa instalação.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Facility Data” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Desativando Instalações existentes para uma campanha.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "Após o usuário ter baixado o modelo para Instalações, se o sistema tiver dados de instalações existentes para serem reutilizados, o modelo será pré-preenchido com essa lista de Instalações.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "Se o usuário optar por não usar instalações específicas, ele poderá excluir as linhas de dados dessas instalações específicas que precisam ser removidas e carregar a planilha apenas com as instalações necessárias para a campanha com os códigos de limite corretos mapeados para essas instalações.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "Se o usuário tiver removido códigos de instalação para uma instalação existente na lista, o sistema criará uma instalação duplicada com esses valores de coluna.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "Se o usuário excluir alguma coluna da “Lista de Instalações Disponíveis” da planilha e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_1",
+    "message": "Criação de novos dados de instalações/utilização de dados de instalações existentes após o download do modelo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_2",
+    "message": "Casos de erros comuns:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Leia-me as instruções para upload de instalações",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER",
+    "message": "Criar novos dados de instalações/usar dados de instalações existentes após o download do modelo:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_1",
+    "message": "Definir metas após o download do modelo:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_2",
+    "message": "Casos de erros comuns:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Leia-me instruções para upload de população",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Vá para a ficha do distrito para o qual deseja definir metas e adicione números na coluna “Metas” para cada Aldeia.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Insira as metas para cada aldeia na ficha de cada distrito na coluna “Meta ao nível do limite seleccionado”. Se alguma aldeia não tiver metas definidas, a ficha terá erros.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_3",
+    "message": "Se o usuário não tiver definido metas para cada aldeia, o sistema gerará um erro com o número da linha onde as metas estão faltando.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_4",
+    "message": "Se o usuário excluir qualquer aldeia da planilha ou excluir uma planilha distrital completa e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_5",
+    "message": "Se o usuário não tiver definido metas para cada aldeia, o sistema gerará um erro com o número da linha onde as metas estão faltando.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_6",
+    "message": "Se o usuário excluir qualquer aldeia da planilha ou excluir uma planilha distrital completa e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_7",
+    "message": "Se o usuário excluir qualquer um dos cabeçalhos da planilha e fazer upload da planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_mz_capacity",
+    "message": "Capacidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MALE",
+    "message": "Macho",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ACTIVE",
+    "message": "Ativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVEPOST",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINSTRATIVEPOST",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_BOUNDARY_DATA_SHEET",
+    "message": "Dados de limite",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_COLUMN",
+    "message": "Detalhes do erro",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_COLUMN",
+    "message": "Status",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_INVALID",
+    "message": "INVÁLIDO",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_DATA_SHEET",
+    "message": "Dados da instalação",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_READ_ME_SHEET",
+    "message": "Leia-me",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEMPLATE_README_MAIN_HEADER",
+    "message": "Leia-me as instruções para upload de destino",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "Se não houver instalações disponíveis para seleção, a aba “Lista de instalações disponíveis” no modelo estará vazia. Para criar novos dados de instalação, adicione o nome do Nome da Instalação, Tipo de Instalação, Status da Instalação, Capacidade. A coluna “Código da Instalação” precisa ser deixada em branco se esta for uma instalação nova. Caso se trate de uma instalação sendo reaproveitada (que fica disponível no template após o download) o usuário só precisa realizar o passo 2.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "Se o usuário excluir algum dos cabeçalhos da planilha e carregá-la, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Para mapear a instalação para o limite correto, o usuário precisa copiar o código de limite correto do limite da planilha “Lista de Limites de Campanha” para a qual a instalação precisa ser mapeada. Se houver uma instalação mapeada para vários limites, o administrador do sistema terá que adicionar os códigos de limite de todos os limites para os quais a instalação está mapeada, separando-os por vírgulas na célula para adicionar códigos de limite para essa instalação.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Facility Data” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Desativando Instalações existentes para uma campanha.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "Após o usuário ter baixado o modelo para Instalações, se o sistema tiver dados de instalações existentes para serem reutilizados, o modelo será pré-preenchido com essa lista de Instalações.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "Se o usuário optar por não usar instalações específicas, ele poderá excluir as linhas de dados dessas instalações específicas que precisam ser removidas e carregar a planilha apenas com as instalações necessárias para a campanha com os códigos de limite corretos mapeados para essas instalações.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "Se o usuário tiver removido códigos de instalação para uma instalação existente na lista, o sistema criará uma instalação duplicada com esses valores de coluna.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "Se o usuário excluir alguma coluna da “Lista de Instalações Disponíveis” da planilha e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_1",
+    "message": "Criação de novos dados de instalações/utilização de dados de instalações existentes após o download do modelo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_2",
+    "message": "Casos de erros comuns:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Leia-me as instruções para upload de instalações",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_1",
+    "message": "Definir metas após o download do modelo:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_2",
+    "message": "Casos de erros comuns:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Leia-me instruções para upload de população",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Vá para a ficha do distrito para o qual deseja definir metas e adicione números na coluna “Metas” para cada Aldeia.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Insira as metas para cada aldeia na planilha de cada distrito na coluna “Metas”. Se alguma aldeia não tiver metas definidas, a planilha conterá erros.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Target” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_5",
+    "message": "Se o usuário não tiver definido metas para cada aldeia, o sistema gerará um erro com o número da linha onde as metas estão faltando.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_6",
+    "message": "Se o usuário excluir qualquer aldeia da planilha ou excluir uma planilha distrital completa e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_7",
+    "message": "Se o usuário excluir qualquer um dos cabeçalhos da planilha e fazer upload da planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_capacity",
+    "message": "Capacidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW BOUNDARY_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEWTEST0005_ADMINISTRATIVEPOST",
+    "message": "Posto Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEWTEST0005_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEWTEST0005_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEWTEST0005_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEWTEST0005_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEWTEST0005_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_ALDEIA",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_LOCALIDADE",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_POST ADMINISTRATIVO",
+    "message": "Pós Administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_STATE",
+    "message": "Estado",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "OTHER_TARGETS",
+    "message": "Outros alvos",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER",
+    "message": "Aprovador de estimativa",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER",
+    "message": "Aprovador de populacionais",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Atribuição de instalação raiz",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Aprovador de estimativa raiz",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER",
+    "message": "Aprovador de populacionais raiz",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Svefewg4YCb",
+    "message": "Múrrupula",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TARGET_HOUSEHOLDS",
+    "message": "Famílias-alvo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_CITY",
+    "message": "Cidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_REGION",
+    "message": "Região",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_STATE",
+    "message": "Estado",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_WARD",
+    "message": "Ala",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_ZONE",
+    "message": "Zona",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TESTD_DISTRITO",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TO",
+    "message": "para",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Orientações para preenchimento da ficha de usuário",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "Consulte a planilha 'Funções do usuário' para ler e compreender a acessibilidade de cada função.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Por favor, preencha os dados do usuário (Nome, número de contato e e-mail) em cada uma das planilhas pertencentes à função adequadamente.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Não atribua o usuário duplicado nas funções de aprovador de estimativa de microplano e aprovador de estimativa de microplano nacional.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Não atribua usuários duplicados nas funções de atribuidor de limites de instalações e de atribuidor de limites de instalações nacionais.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_5",
+    "message": "Não atribua usuários duplicados nas funções de aprovador de dados populacionais e de aprovador de dados populacionais nacionais.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1",
+    "message": "Baixando modelos do Excel para criação de usuários:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Baixe o modelo Excel clicando no botão “Baixar modelo”.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Abra o modelo Excel que foi baixado na etapa anterior terá 3 planilhas e a primeira planilha que você verá é uma planilha “Leia-me”. A segunda Planilha denominada “Criar Lista de Usuários“ que será uma planilha vazia onde o usuário deverá inserir os dados para criar usuários para a campanha. A terceira folha será denominada “Lista de Limites de Campanha” que terá todos os limites selecionados na etapa “Detalhes dos Limites” com seus respectivos códigos de limites.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2",
+    "message": "Criando usuários para a campanha:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "O administrador do sistema terá que criar uma entrada separada para cada usuário. O administrador do sistema terá que adicionar o nome do usuário (obrigatório), número de telefone (obrigatório), função (obrigatório), tipo de emprego (obrigatório), código de limite (obrigatório).",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Cada usuário criado precisa ser atribuído a um limite usando o Código de Limite do limite necessário, que pode ser encontrado na “Lista de Limites de Campanha",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Target” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3",
+    "message": "Casos de erros comuns:",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Se o usuário não adicionou códigos de limite para todas as entradas do usuário, o sistema gerará um erro com o número da linha onde o código de limite está faltando",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Se o usuário excluir algum dos cabeçalhos da planilha e carregá-la, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_MAINHEADER",
+    "message": "Leia-me instruções para upload do usuário",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN1",
+    "message": "Função do usuário",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN2",
+    "message": "Descrição",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_ROLES",
+    "message": "Funções de usuário",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE1",
+    "message": "Aprovador de estimativa de plano",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE10",
+    "message": "Esta função terá acesso para atribuir a instalação às áreas de influência do limite administrativo atribuído",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE11",
+    "message": "Atribuidor de limite de instalação raiz",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE12",
+    "message": "Esta função terá acesso para atribuir e finalizar a instalação para as áreas de influência do país",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE13",
+    "message": "Visualizador de microplano",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE14",
+    "message": "Esta função terá acesso para visualizar estimativas de microplano do limite administrativo atribuído.",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE2",
+    "message": "Esta função terá acesso para editar as suposições do microplano e aprovar a estimativa do microplano para todas as aldeias do limite administrativo atribuído",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE3",
+    "message": "Aprovador de estimativa de plano raiz",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE4",
+    "message": "Esta função terá acesso para editar as suposições do microplano, aprovar e finalizar a estimativa do microplano para todas as aldeias do país",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE5",
+    "message": "Aprovador de dados populacionais",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE6",
+    "message": "Esta função terá acesso para validar e aprovar os dados populacionais das aldeias da fronteira administrativa atribuída",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE7",
+    "message": "Aprovador de dados populacionais raiz",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE8",
+    "message": "Esta função terá acesso para validar, aprovar e finalizar os dados populacionais de todas as aldeias do país",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE9",
+    "message": "Atribuidor de limite de instalação",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_DISTRICT",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_LOCALITY",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_PROVINCE",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_VILLAGE",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VFTw0jbRf1y",
+    "message": "Cavina1",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WEIGHT",
+    "message": "Peso",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "f5F6xAskA05",
+    "message": "Nampula",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "facilityUsage",
+    "message": "Uso das instalações",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_COUNTRY",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_Country",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_District",
+    "message": "Distrito",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_Locality",
+    "message": "Localidade",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_Post administrative",
+    "message": "Pós-administrativo",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_Province",
+    "message": "Província",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_Village",
+    "message": "Aldeia",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_country",
+    "message": "País",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mz",
+    "message": "Moçambique",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "w22L4En0Zgg",
+    "message": "Nihessiue",
+    "module": "hcm-admin-schemas",
+    "locale": "pt_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/pt_MZ/hcm_admin_schemas.json
+++ b/localisation/Microplanning/v0.1/pt_MZ/hcm_admin_schemas.json
@@ -1,0 +1,38 @@
+[
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1",
+    "message": "Orientações para preenchimento da ficha de usuário",
+    "module": "hcm_admin_schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_1",
+    "message": "Consulte a planilha 'Funções do usuário' para ler e compreender a acessibilidade de cada função.",
+    "module": "hcm_admin_schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_2",
+    "message": "Por favor, preencha os dados do usuário (Nome, número de contato e e-mail) em cada uma das planilhas pertencentes à função adequadamente.",
+    "module": "hcm_admin_schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_3",
+    "message": "Não atribua o usuário duplicado nas funções de aprovador de estimativa de microplano e aprovador de estimativa de microplano nacional.",
+    "module": "hcm_admin_schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_4",
+    "message": "Não atribua usuários duplicados nas funções de atribuidor de limites de instalações e de atribuidor de limites de instalações nacionais.",
+    "module": "hcm_admin_schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_MICROPLAN_README_HEADER_1_DESC_5",
+    "message": "Não atribua usuários duplicados nas funções de aprovador de dados populacionais e de aprovador de dados populacionais nacionais.",
+    "module": "hcm_admin_schemas",
+    "locale": "pt_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/pt_MZ/rainmaker-campaignmanager.json
+++ b/localisation/Microplanning/v0.1/pt_MZ/rainmaker-campaignmanager.json
@@ -1,0 +1,4256 @@
+[
+  {
+    "code": " CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR",
+    "message": "Por favor preencha todos os campos obrigatórios.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR ",
+    "message": "Por favor preencha todos os campos obrigatórios.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " EQUAL_TO",
+    "message": "igual a",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " GREATER_THAN",
+    "message": "maior que",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " GREATER_THAN_EQUAL_TO",
+    "message": "maior ou igual a",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Código de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Dados de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Nome da Pessoa (Obrigatório)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " HCM_PLEASE_WAIT_LOADING_BOUNDARY",
+    "message": "Por favor, aguarde",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " IN_BETWEEN",
+    "message": "entre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " LESSER_THAN_EQUAL_TO",
+    "message": "menor ou igual a",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " LESS_THAN",
+    "message": "menor que",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_DISTRIBUTOR",
+    "message": "Distribuidor",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_DISTRICT_SUPERVISOR",
+    "message": "Supervisor Distrital",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_HEALTH_FACILITY_WORKER",
+    "message": "Trabalhador de estabelecimento de saúde",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_NATIONAL_SUPERVISOR",
+    "message": "Supervisor Nacional",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_PROVINCIAL_SUPERVISOR",
+    "message": "Supervisor Provincial",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_TEAM_SUPERVISOR",
+    "message": "Supervisor de equipe",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACCESSCONTROL_ROLES_ROLES_WAREHOUSE_MANAGER",
+    "message": "Gerente de Armazém",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION",
+    "message": "Ação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_CREATE_CHECKLIST",
+    "message": "Criar lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_CONFIGURE_APP",
+    "message": "Configurar aplicativo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_RETRY",
+    "message": "Tentar novamente",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_UPDATE_BOUNDARY_DETAILS",
+    "message": "Atualizar campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_UPDATE_DATES",
+    "message": "Atualizar datas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_LABEL_VIEW_TIMELINE",
+    "message": "Baixar credenciais do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_",
+    "message": "Configurar campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_0HOME",
+    "message": "Lar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_1CAMPAIGN",
+    "message": "Minhas campanhas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CAMPAIGN_CYCLE",
+    "message": "Ciclo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CAMPAIGN_HOME",
+    "message": "Lar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CAMPAIGN_MANAGER",
+    "message": "Gerente de campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CREATECAMPAIGN",
+    "message": "Minhas campanhas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_CREATE_NEW_HIERARCHY",
+    "message": "Gerenciar limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_LOCALISATION",
+    "message": "Localização",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MDMS",
+    "message": "MDMS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MY_CAMPAIGN",
+    "message": "Minhas campanhas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_NATIONAL",
+    "message": "Nacional",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_PREVIEW_CAMPAIGN",
+    "message": "Visualizar campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_PROVINCIAL",
+    "message": "Provincial",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_CAMPAIGN",
+    "message": "Criar nova campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_CAMPAIGN_FROM_MICROPLAN",
+    "message": "Configurar campanha da Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_CAMPAIGN_FROM_MICROPLAN ",
+    "message": "Configurar campanha da Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_UPDATE_CHECKLIST",
+    "message": "Lista de verificação de atualização",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_VIEW_CHECKLIST",
+    "message": "Ver lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_BOUNDARY_HIERARCHY_LEVEL",
+    "message": "Adicionar nível de hierarquia de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_COMMENT",
+    "message": "Adicionar comentário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_COMMENT_(OR)",
+    "message": "Adicionar comentário (ou)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_HIERARCHY_LEVEL",
+    "message": "Adicionar nível de hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_NEW_CHECKLIST",
+    "message": "Adicionar nova lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_OPTIONS",
+    "message": "Adicionar opções para pergunta",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_QUESTION",
+    "message": "Adicionar pergunta",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AT_LEAST_ONE_FILE_REQUIRED_ERROR",
+    "message": "Erro: é necessário pelo menos um arquivo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BACK",
+    "message": "Voltar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BAD_REQUEST",
+    "message": "Erro interno. Por favor, tente novamente.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BEDNET",
+    "message": "Rede mosquiteira",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_DATA_FROM_GEOPODE",
+    "message": "Dados de limite do GeoPoDe.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_DATA_MANAGEMENT",
+    "message": "Gerenciamento de dados de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_DOWNLOADED",
+    "message": "Dados de limite baixados",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_DOWNLOAD_MESSAGE",
+    "message": "Baixe o modelo Excel que contém os dados de limite selecionados. Depois de fazer o download, preencha o modelo com os dados de destino corretos e carregue a planilha.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_HIERARCHY_INFO_MSG",
+    "message": "Adicione seus níveis de hierarquia de limite clicando no botão “Adicionar novo nível de hierarquia de limite”. Se você quiser remover um nível, clique no ícone de exclusão próximo ao nível que deseja excluir.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_LOCALISATION_ERROR",
+    "message": "Falha na criação do limite. Erro de localização.!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MANAGEMENT",
+    "message": "Gerenciamento de limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_2",
+    "message": "As validações são apenas para a coluna Código de limite e Alvo na coluna de nível de limite selecionado.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_SHEET_UPLOADED_INVALID_ERROR",
+    "message": "Folha inválida",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMAPAIGN_DELIVERY_TAB_TEXT",
+    "message": "Entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ACTIONS",
+    "message": "Ações",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_MORE_ATTRIBUTE_TEXT",
+    "message": "Adicionar mais atributos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_MORE_DELIVERY_BUTTON",
+    "message": "Adicione mais condições de entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_MORE_PRODUCT_BUTTON",
+    "message": "Adicionar recursos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCTS_BUTTON_TEXT",
+    "message": "Adicione recursos a serem entregues",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCTS_LABEL",
+    "message": "Recursos a serem entregues",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR",
+    "message": "Por favor preencha os campos obrigatórios.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_PRODUCT_MANDATORY_ERROR ",
+    "message": "Por favor preencha todos os campos obrigatórios.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ADD_START_END_DATE_TEXT",
+    "message": "Adicione datas de início e término para ciclos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_AGE",
+    "message": "Idade (em meses)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": " Número de mosquiteiros por domicílio",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Número de indivíduos por mosquiteiro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_GENDER",
+    "message": "Gênero (masculino ou feminino)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_HEIGHT",
+    "message": "Altura (em cm)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_LABEL",
+    "message": "Atributo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_MEMBERCOUNT",
+    "message": "Número de mosquiteiros por domicílio",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_TYPE_OF_STRUCTURE",
+    "message": "Tipo de estrutura",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ATTRIBUTE_WEIGHT",
+    "message": "Peso (em Kgs)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": " Número de mosquiteiros por domicílio",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Número de indivíduos por mosquiteiro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE",
+    "message": "Tipo de beneficiário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_PLEASE_WAIT",
+    "message": "Por favor, espere um pouco.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CANNOT_REMOVE_PREVIOUS_BOUNDARIES",
+    "message": "Não é possível remover limites anteriores.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_COMPLETED",
+    "message": "Concluído",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CONDITION",
+    "message": "Doença",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_COUNT_LABEL",
+    "message": "Contar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CREATION_TAKES_SOME_TIME_PLEASE_WAIT",
+    "message": "A criação da campanha leva algum tempo. Por favor, aguarde!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE",
+    "message": "Ciclo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING",
+    "message": "O número de ciclos e entregas em cada ciclo são pré-carregados para campanha SMC",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_IRS-MZ",
+    "message": "Configuração para campanha do IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_LLIN-MOZ",
+    "message": "Configuração específica de Moçambique para Campanhas LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_LLIN-MZ",
+    "message": "Configuração para campanha LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_CONFIGURE_HEADING_MR-DN",
+    "message": "Configuração para campanha multi-rodada",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_IRS-MZ",
+    "message": "Os ciclos e entregas em cada ciclo são configurados de acordo com as diretrizes da OMS para campanhas de “Pulverização Residual em Interiores”. ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_IRS_MZ",
+    "message": "Os ciclos e entregas em cada ciclo são configurados de acordo com as diretrizes da OMS para campanhas de “Pulverização Residual em Interiores”. ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_LLIN-MZ",
+    "message": "De acordo com as directrizes da OMS, as LLINs devem ser distribuídas de três em três anos. Esta recomendação baseia-se na vida útil média das LLINs. Com base nesta diretriz, o número de ciclos e entregas é definido como 1 cada.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_INFO_MR-DN",
+    "message": "Informamos que o número de ciclos e partos em cada ciclo listado abaixo são configurados de acordo com as diretrizes fornecidas pela OMS para campanhas de “Quimioprevenção Sazonal da Malária”. Se desejar modificar o número de ciclos ou entregas em cada ciclo, poderá fazê-lo pressionando os ícones “+” ou “-” de ciclos e entregas de acordo com suas preferências.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_CYCLE_TAB_TEXT",
+    "message": "Ciclo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELETE_CONDITION_LABEL",
+    "message": "Excluir condição",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELETE_QUESTION",
+    "message": "Excluir pergunta",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELETE_ROW_TEXT",
+    "message": "Excluir",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY",
+    "message": "Entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_DETAILS",
+    "message": "Detalhes da entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_RULE_LABEL",
+    "message": "Condição de entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_IRS",
+    "message": "Configurar condição de entrega para campanha do IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_IRS-MZ",
+    "message": "Configurar condição de entrega para campanha do IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_LLIN-MZ",
+    "message": "Configurar condição de entrega para campanha LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DELIVERY_TAB_SUB_TEXT_MR-DN",
+    "message": "Configurar condição de entrega para campanha MR-DN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DETAILS",
+    "message": "Detalhes da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DOWNLOAD_USER_CRED",
+    "message": "Baixar credenciais do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DRAFTS",
+    "message": "Rascunhos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_EDIT",
+    "message": "Editar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE",
+    "message": "Data de término da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_BEFORE_ERROR",
+    "message": "A data de término da campanha não pode ser anterior à data de início da campanha.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_ERROR",
+    "message": "Campo obrigatório!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_SAME_ERROR",
+    "message": "As datas de início e término de uma campanha não podem ser iguais!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FAILED",
+    "message": "Fracassado",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_ERROR_MANDATORY",
+    "message": "Campo obrigatório!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_MANDATORY",
+    "message": "Campo obrigatório!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FROM_LABEL",
+    "message": "De",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_HOME",
+    "message": "Lar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_IN_BETWEEN_ERROR",
+    "message": "O campo De deve ser menor que o campo Para para a seleção do operador Entre.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME",
+    "message": "Nome da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_ERROR",
+    "message": "Este nome de campanha já existe! Tente com outro nome válido.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_FIELD_ERROR",
+    "message": "Campo obrigatório!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_FIELD_ERROR ",
+    "message": "Campo obrigatório!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_LONG_ERROR",
+    "message": "Erro! Nome longo da campanha ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_MISSING_TYPE_ERROR",
+    "message": "Insira um nome de campanha!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME_TOO_LONG_ERROR",
+    "message": "O nome da campanha não pode ter mais de 250 caracteres.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NEW_PRODUCT_TEXT",
+    "message": "Não consegue encontrar seu recurso na lista de recursos?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_CYCLE",
+    "message": "Número de ciclos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_CYCLES",
+    "message": "Número de ciclos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_DELIVERIES",
+    "message": "Número de entregas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NO_OF_DELIVERY",
+    "message": "Número de entregas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_ONGOING",
+    "message": "Em andamento",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_OPERATOR_LABEL",
+    "message": "Operador",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCTS_MODAL_HEADER_TEXT",
+    "message": "Configurar recursos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCTS_MODAL_SECONDARY_ACTION",
+    "message": "Adicionar recursos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCTS_MODAL_SUBMIT_TEXT",
+    "message": "Confirmar recursos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_LABEL",
+    "message": "Recurso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_MISSING_ERROR",
+    "message": "Preencha os recursos a serem entregues.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_NAME_ERROR",
+    "message": "Os campos obrigatórios devem ter apenas entre 2 e 100 caracteres.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PRODUCT_VARIANT_ERROR",
+    "message": "Os campos obrigatórios devem ter apenas entre 2 e 100 caracteres.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_DEFAULT1",
+    "message": "Configuração para tipo padrão",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_IRS-MZ",
+    "message": "Campanha do IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_IRS_MZ",
+    "message": "Campanha do IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-MOZ",
+    "message": "Configuração específica de Moçambique para Campanhas LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-MZ",
+    "message": "Configuração para campanha LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-Moz",
+    "message": "Configuração específica de Moçambique para Campanhas LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN-mz",
+    "message": "Configuração específica de Moçambique para Campanhas LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN_MOZ",
+    "message": "Configuração Específica de Moçambique para Campanhas LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_LLIN_MZ",
+    "message": "Configuração para campanha LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_MR-DN",
+    "message": "Configuração para campanha multi-rodada",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_MR_DN",
+    "message": "Configuração para campanha multi-rodada",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_PROJECT_SMC",
+    "message": "SMC",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_RESOURCE",
+    "message": "Recurso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SEARCH_NAME",
+    "message": "Nome da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SEARCH_TITLE",
+    "message": "Minhas campanhas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SEARCH_TYPE",
+    "message": "Tipo de campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Os limites são as áreas administrativas definidas nas quais você deseja executar uma campanha. Comece a selecionar os limites do primeiro nível para que os limites presentes no próximo nível estejam disponíveis para seleção.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARY",
+    "message": "Selecione os limites onde deseja veicular a campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARY_BUTTON",
+    "message": "Confirmar limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_HIERARCHY",
+    "message": "Selecione hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE",
+    "message": "Data de início da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE_ERROR",
+    "message": "A data de início deve ser anterior apenas à data de término.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_STATUS_CREATING_MESSAGE",
+    "message": "A lista de usuários da campanha está sendo criada. Por favor, tente novamente depois de algum tempo.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_ATTRIBUTES_ACTION",
+    "message": "Adicionar atributos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_DATE_ACTION",
+    "message": "Adicionar data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_DELIVERY_TYPE_ACTION",
+    "message": "Adicionar tipo de entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_PRODUCT_ACTION",
+    "message": "Adicionar produto",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ADD_VALUES_ACTION",
+    "message": "Adicionar valores",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_ATTRIBUTES_MISSING_ERROR",
+    "message": "Faltam atributos no ciclo {CYCLE_NO} de entrega {DELIVERY_NO} para a condição de entrega {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_DATE_MISSING_ERROR",
+    "message": "Faltam datas no ciclo {CYCLE_NO}",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_DELIVERY_TYPE_MISSING_ERROR",
+    "message": "Tipo de entrega ausente no ciclo {CYCLE_NO} entrega {DELIVERY_NO} para condição de entrega {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_NA",
+    "message": "Para ser atualizado",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_PRODUCT_MISSING_ERROR",
+    "message": "Faltam produtos no ciclo {CYCLE_NO} de entrega {DELIVERY_NO} para a condição de entrega {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SUMMARY_VALUES_MISSING_ERROR",
+    "message": "Faltam valores no ciclo {CYCLE_NO} de entrega {DELIVERY_NO} para a condição de entrega {CONDITION_NO}.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_INFO_TEXT_IRS-MZ",
+    "message": "Os ciclos e entregas em cada ciclo são configurados de acordo com as diretrizes da OMS para campanhas de “Pulverização Residual em Interiores”. ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_INFO_TEXT_LLIN-MZ",
+    "message": "O valor de 1,8 para o parâmetro “Número de beneficiários por mosquiteiro” baseia-se nas directrizes da OMS. O usuário pode escolher alterar esse valor se isso não funcionar para o caso de uso do seu país.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_INFO_TEXT_MR-DN",
+    "message": "Informamos que as condições listadas abaixo são configuradas de acordo com as diretrizes fornecidas pela OMS para campanhas de “Quimioprevenção Sazonal da Malária”. Se desejar modificar quaisquer condições ou recursos específicos a serem entregues, você poderá fazê-lo editando as regras de entrega de acordo com suas preferências.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT",
+    "message": "As condições de entrega que você configurar nesta etapa decidirão os critérios de elegibilidade para seus beneficiários. Você pode configurar diversas condições de entrega com base nos diferentes critérios de elegibilidade seguidos na campanha. Cada critério de elegibilidade deve ser criado como uma condição de entrega separada. Cada condição para um tipo de beneficiário individual pode ser criada usando 4 atributos, ou seja, Idade, Peso, Altura e Sexo.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_IRS-MZ",
+    "message": "Configuração para campanha do IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-MOZ",
+    "message": "Configuração específica de Moçambique para Campanhas LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-MZ",
+    "message": "Configuração para campanha LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-Moz",
+    "message": "Configuração específica de Moçambique para Campanhas LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_LLIN-mz",
+    "message": "Configuração específica de Moçambique para Campanhas LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_SUB_TEXT_MR-DN",
+    "message": "Configuração para campanha multi-rodada",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TAB_TEXT",
+    "message": "Configurar condições de entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TO_LABEL",
+    "message": "Para",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE",
+    "message": "Tipo de campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_HOUSEHOLD",
+    "message": "Doméstico",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_INDIVIDUAL",
+    "message": "Individual",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_UPCOMING",
+    "message": "Por vir",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_UPDATE_DATES",
+    "message": "Atualizar datas da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_UPDATE_DATE_SUBMIT",
+    "message": "Confirmar alteração de data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_USER_GENERATION_SUCCESS",
+    "message": "Credencial de usuário gerada com sucesso. Faça o download.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VALIDATION_INPROGRESS",
+    "message": "Por favor, aguarde. A validação está em andamento.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VALUE_LABEL",
+    "message": "Valor",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VALUE_ZERO_ERROR",
+    "message": "O valor não pode ser zero para as condições de entrega.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CANCEL",
+    "message": "Cancelar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CEMENT",
+    "message": "Cimento",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHECKLIST_CREATED_FAILED",
+    "message": "Falha na criação da lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHECKLIST_CREATED_LOCALISATION_ERROR",
+    "message": "Falha na localização criada na lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHECKLIST_NAME",
+    "message": "Nome da lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHECKLIST_PREVIEW",
+    "message": "Visualização da lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHECKLIST_ROLE",
+    "message": "Papel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHECKLIST_TOBE_CONFIGURED",
+    "message": "Para ser configurado",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHECKLIST_TYPE",
+    "message": "Tipo de lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHECKLIST_UPDATE_FAILED",
+    "message": "Falha na atualização da lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHECKLIST_UPDATE_LOCALISATION_ERROR",
+    "message": "Falha na localização atualizada da lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHOOSE_MEANS_TO_CREATE_BOUNDARY",
+    "message": "Escolha meios para criar limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CLAY",
+    "message": "Argila",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CLEAR",
+    "message": "Claro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CLOSE",
+    "message": "Fechar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CMN_ALL_DATA_FETCH_DONE",
+    "message": "Todo o mapeamento foi concluído",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CMN_ATLEAST_ONE_HIERARCHY",
+    "message": "Insira pelo menos um nível de hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_CREATE",
+    "message": "Criar tipo de hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_DATA_CREAT",
+    "message": "Dados de limite de Creta",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_DATA_CREATE",
+    "message": "Criar dados de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CMN_BOUNDARY_REL_DATA_CREATE_PREVIEW",
+    "message": "Próximo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CMN_FILLORDELETE_CREATED_HIERARCHY",
+    "message": "Por favor preencha todos os campos ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CMN_NOOPTION",
+    "message": "Nenhuma opção disponível",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CM_CREATE_REQUEST",
+    "message": "Criar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CM_DRAFT_TYPE",
+    "message": "Tipo de rascunho",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CM_UPDATE_REQUEST",
+    "message": "Atualizar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COMMON_BACK",
+    "message": "Voltar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COMMON_NO_RESULTS_FOUND",
+    "message": "Nenhum resultado encontrado para este critério de pesquisa.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIGURE_CHECKLIST",
+    "message": "Configurar lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIRM_BOUNDARY_DATA",
+    "message": "Confirme os dados do limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIRM_BOUNDARY_HIERARCHY_LEVEL",
+    "message": "Confirme o nível de hierarquia de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE",
+    "message": "Criar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE_BOUNDARY_HIERARCHY",
+    "message": "Criar hierarquia de limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE_BOUNDARY_HIERARCHY_TYPE",
+    "message": "Gerenciar limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE_CHECKLIST",
+    "message": "Configurar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE_MY_OWN_BOUNDARY_DATA",
+    "message": "Criar meus próprios dados de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE_NEW_BOUNDARY_DATA",
+    "message": "Criar novos dados de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE_NEW_CAMPAIGN",
+    "message": "Configurar campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE_NEW_CHECKLIST",
+    "message": "Criar nova lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATING_CAMPAIGN_BASED_ON_MICROPLAN",
+    "message": "Criação de nova campanha com base no Microplan selecionado",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATION_DATE",
+    "message": "Data de criação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_ACTION_CONFIGURE_APP",
+    "message": "Configurar aplicativo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_ACTION_HCM_CONFIGURE_APP",
+    "message": "Configurar aplicativo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_ACTION_HCM_UPDATE_CAMPAIGN",
+    "message": "Atualizar campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_ACTION_HCM_UPDATE_DATES",
+    "message": "Atualizar datas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_ACTION_UPDATE_DATES",
+    "message": "Alterar datas da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_BOUNDARY_dATA_NEW_RESPONSE_ACTION",
+    "message": "Ver limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_CHECKLIST_NEW_RESPONSE_ACTION",
+    "message": "Configurar aplicativo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_COMMON_ROWS_PER_PAGE",
+    "message": "Linhas por página",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_COMMON_ROWS_PER_PAGE :",
+    "message": "Linhas por página",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_HOME",
+    "message": "Lar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CURRENT_HIERARCHIES",
+    "message": "Hierarquias atuais",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CYCLE",
+    "message": "Ciclo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CYCLE 1",
+    "message": "Ciclo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CYCLE_NUMBER",
+    "message": "Número de ciclos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Campaign_name_missing_type_error",
+    "message": "Preencha o campo obrigatório para prosseguir.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Confirm Addition of Products",
+    "message": "Confirme a adição de recursos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Create_New_Checklist",
+    "message": "Criar nova lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DATA_CREATION_IN_PROGRESS",
+    "message": "Criação de dados em andamento",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DATA_FECTHING_FROM_SERVER",
+    "message": "Dados do Microplan sendo buscados",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DATA_SYNC_WITH_SERVER",
+    "message": "Carregando...",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DELETE",
+    "message": "Excluir",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_DATE_ERROR",
+    "message": "As datas de início e término dos ciclos de entrega estão vazias. Por favor preencha os valores.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_DETAILS",
+    "message": "Detalhes da entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_EMPTY_ERROR",
+    "message": "Número de ciclos e entregas vazias. Por favor preencha os valores.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DELIVERY_CYCLE_MISMATCH_LENGTH_ERROR",
+    "message": "As datas de início e término dos ciclos de entrega estão vazias. Por favor preencha os valores.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DELIVERY_NUMBER",
+    "message": "Número de entregas por ciclo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DELIVERY_RULES_ERROR",
+    "message": "Preencha todos os valores nas condições de entrega junto com os recursos a serem entregues.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DIGIT_CLOSE",
+    "message": "Fechar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DIGIT_CONFIRM_SELECTION",
+    "message": "Confirmar seleção",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DIGIT_SELECT",
+    "message": "Selecionado",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DIRECT",
+    "message": "Entrega direta",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD",
+    "message": "Download",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_EXCEL_TEMPLATE",
+    "message": "Baixe o modelo do Excel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_EXCEL_TEMPLATE_FOR_BOUNDARY",
+    "message": "Baixe o modelo Excel para limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_TEMPLATE_BOUNDARY",
+    "message": "Baixar modelo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_THE_FACILITY_TEMPLATE",
+    "message": "Baixando o modelo da instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_THE_TARGET_TEMPLATE",
+    "message": "Baixando o modelo de destino",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_THE_USER_TEMPLATE",
+    "message": "Baixando o modelo do usuário ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DRUG",
+    "message": "Medicamento",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DUPLICATE_RECORD",
+    "message": "A hierarquia de limite com o tenantId e o tipo de hierarquia fornecidos já existe",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EDIT_BOUNDARY_DATA",
+    "message": "Editar dados de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EMPTY_TEMPLATE_GENERTAION_NOTCOMPLETED_STILL_PROCEEDING",
+    "message": "A geração do modelo expirou, procedendo à busca do Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "END_DATE",
+    "message": "Data de término",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EQUAL_TO",
+    "message": "Igual a",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_FETCHING_CAMPAIGN",
+    "message": "Erro ao buscar dados da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_WHILE_DOWNLOADING",
+    "message": "Foi encontrado algum problema durante o download do modelo. Por favor, tente novamente mais tarde.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_HRMS_INVALID_CITY",
+    "message": "Selecione um nome de cidade válido.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_ADD_PRODUCT_TITLE",
+    "message": "Recurso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_BOUNDARY_DATA_CREATED_SUCCESS_RESPONSE",
+    "message": "Dados de limite criados com sucesso!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_BOUNDARY_SUMMARY_HEADING",
+    "message": "Resumo dos detalhes do limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_ADD_PRODUCT_BUTTON",
+    "message": "Confirme a adição de recursos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_ADD_PRODUCT_LINK",
+    "message": "Adicionar novo recurso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_BOUNDARY_MODAL_BACK",
+    "message": "Sim",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_BOUNDARY_MODAL_SUBMIT",
+    "message": "Não",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_CHANGE_DATE_CONFIRM",
+    "message": "Tem certeza de que deseja alterar as datas?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_CREATE_SUCCESS_RESPONSE",
+    "message": "Dados da campanha registrados com sucesso!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_CREATE_SUCCESS_RESPONSE_TEXT",
+    "message": "Os dados da campanha foram capturados com sucesso e levará alguns minutos para criar a campanha. Depois que a campanha for criada, você poderá baixar as credenciais do usuário e outros dados da campanha na tela 'Minhas campanhas'.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_DATE_CHANGE_SUCCESS",
+    "message": "Data alterada com sucesso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_DATE_CHANGE_WITH_BOUNDARY_SUCCESS",
+    "message": "Data alterada com sucesso para os limites selecionados!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_DOWNLOAD_USER_DETAILS",
+    "message": "Baixar credenciais do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_NO_DOCUMENTS_AVAILABLE",
+    "message": "Por favor, carregue uma planilha Excel válida.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_RESPONSE_ACTION",
+    "message": "Ir para casa",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_SUCCESS_INFO_TEXT",
+    "message": "ID da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_TIMELINE",
+    "message": "Linha do tempo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_BOUNDARY_MODAL_HEADER",
+    "message": "Tem certeza de que deseja atualizar os limites da sua campanha?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_BOUNDARY_MODAL_TEXT",
+    "message": "Se você alterar os dados de limite da campanha nesta etapa, os arquivos enviados nas etapas seguintes serão excluídos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_TYPE_MODAL_HEADER",
+    "message": "Tem certeza de que deseja atualizar o tipo de campanha?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPDATE_TYPE_MODAL_TEXT",
+    "message": "Se você alterar o tipo de campanha nesta etapa, todos os dados serão excluídos.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_HEADER",
+    "message": "Baixe o modelo do Excel para o destino",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_TEXT",
+    "message": "Baixe o modelo Excel que contém os dados de limite selecionados. Depois de fazer o download, preencha o modelo com os dados de destino corretos e carregue a planilha.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_HEADER",
+    "message": "Baixe o modelo Excel para dados de instalações",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_TEXT",
+    "message": "Baixe o modelo Excel que contém a lista de instalações permanentes e a lista de dados de limites selecionados. Depois de fazer o download, preencha o modelo com os dados corretos da instalação e carregue a planilha.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_FACILITY_DATA_TEXT",
+    "message": "Baixe o modelo Excel que contém a lista de instalações permanentes e a lista de dados de limites selecionados. Depois de fazer o download, preencha o modelo com os dados corretos da instalação e carregue a planilha.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_USER_DATA_MODAL_HEADER",
+    "message": "Baixe o modelo Excel para detalhes do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_USER_DATA_MODAL_TEXT",
+    "message": "Baixe o modelo Excel que contém os dados de limite selecionados. Depois de fazer o download, preencha o modelo com os dados corretos do usuário e carregue a planilha.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_UPLOAD_USER_DATA_MODAL_TEXT ",
+    "message": "Baixe o modelo Excel que contém os dados de limite selecionados. Depois de fazer o download, preencha o modelo com os dados corretos do usuário e carregue a planilha.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CHECKLIST_CREATE_SUCCESS_RESPONSE",
+    "message": "Lista de verificação criada com sucesso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CHECKLIST_RESPONSE_ACTION",
+    "message": "Vá para minhas campanhas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CHECKLIST_UPDATE_SUCCESS_RESPONSE",
+    "message": "Lista de verificação atualizada com sucesso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_SEARCH",
+    "message": "Claro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_PLEASE_ENTER_ALL_MANDATORY_FIELDS",
+    "message": "Insira um nome de campanha válido para passar para a próxima etapa.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_SEARCH",
+    "message": "Procurar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_TAKE_ACTION",
+    "message": "Tome uma atitude",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_FORGOT_PASSWORD_DESC",
+    "message": "Insira o número do celular do usuário.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE",
+    "message": "Recurso criado com sucesso!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_BOLD_TEXT",
+    "message": "Recurso a ser entregue",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_POST_TEXT",
+    "message": "menu suspenso no pop-up de configuração de recursos.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_PRE_TEXT",
+    "message": "Os recursos recém-criados serão preenchidos no ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_CREATE_SUCCESS_RESPONSE_TEXT",
+    "message": "Os recursos recém-criados serão preenchidos na lista suspensa “Recurso a ser entregue” no pop-up de configuração de recursos.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_PRODUCT_RESPONSE_ACTION",
+    "message": "Volte",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_REQUIRED",
+    "message": "Obrigatório",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_TQM_SUMMARY_HEADING",
+    "message": "Resumo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "End Date",
+    "message": "Data de término",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1",
+    "message": "Caso em que não há dados da instalação no sistema:",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_1",
+    "message": "Passo 1: Quando não houver dados de instalações no sistema, o modelo “Lista de instalações disponíveis” estará vazio. Para cada instalação adicionada, o usuário precisa inserir o nome da instalação (deve ser exclusivo), tipo de instalação (armazém/instalação de saúde), status da instalação (temporário/permanente), capacidade (entrada de número)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_2",
+    "message": "Passo 2: Para mapear as instalações para um determinado limite, o usuário precisa copiar o Código do Limite correto da planilha “Dados do Limite”. Se houver mais de um limite para o qual uma instalação precisa ser mapeada, o usuário poderá adicionar todos os códigos de limite separados por vírgulas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_3",
+    "message": "Etapa 3: Para cada instalação, o usuário precisa adicionar Ativo ou Inativo para todas as instalações na coluna “Uso da Instalação”. Todas as Instalações marcadas como “Ativas” serão utilizadas na campanha que está sendo criada, as marcadas como “Inativas” não serão utilizadas na campanha que está sendo criada.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_4",
+    "message": "Passo 4: Depois que todas as facilidades forem adicionadas, o usuário precisa salvar o arquivo em seu sistema e fazer upload do arquivo pressionando a opção “Navegar em Meus Arquivos”.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2",
+    "message": "Caso em que existem dados de instalações existentes no sistema:",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_1",
+    "message": "Passo 1: Ao abrir o modelo de instalação baixado, consulte a folha Lista de instalações disponíveis. Para instalações existentes, adicione entradas na coluna Código de limite. Você pode encontrar os códigos de limite na planilha Dados de limite. Se uma instalação mapear vários limites, separe os códigos com vírgulas.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_2",
+    "message": "Etapa 2: nesta etapa, o usuário terá que adicionar entradas na coluna Uso da instalação com entradas válidas sendo Ativas ou Inativas, onde o usuário pode definir o uso de uma instalação como Ativo se a instalação estiver sendo usada para uma campanha ou então pode ser definido como Inativo. As entradas na coluna Uso da Instalação precisam ser adicionadas para todas as entradas.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_3",
+    "message": "Etapa 3: Para adicionar novas instalações que não estão presentes na lista de instalações existentes, o usuário precisa inserir o nome da instalação (deve ser exclusivo), tipo de instalação (armazém/instalação de saúde), status da instalação (temporário/permanente), capacidade (Entrada de número), Código de limite (da Folha de dados de limite) e Uso da instalação (Ativo/Inativo), conforme explicado anteriormente",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_4",
+    "message": "Passo 4: Depois que todas as facilidades forem adicionadas, o usuário precisa salvar o arquivo em seu sistema e fazer upload do arquivo pressionando a opção “Navegar em Meus Arquivos”.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITY_DETAILS",
+    "message": "Detalhes da instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITY_DETAILS_ERROR",
+    "message": "Por favor, adicione o arquivo excel dos detalhes da instalação.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITY_FILE_MISSING",
+    "message": "Falta a ficha de instalação.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FEMALE",
+    "message": "Fêmea",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FETCHED_ALLMAPPING_DATA_FROM_MICROPLAN",
+    "message": "Obteve todos os dados de mapeamento do Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_BOUNDARIRES_FROM_MICROPLAN",
+    "message": "Buscando limites de campanha da Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_DATA_FROM_MICROPLAN",
+    "message": "Buscando dados de campanha do Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_FACILITY_FROM_MICROPLAN",
+    "message": "Buscando dados de instalações do mapeamento de captação de instalações da Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_TARGET_FROM_MICROPLAN",
+    "message": "Buscando dados de destino aprovados dos dados do censo da Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_TYPE_FROM_MICROPLAN",
+    "message": "Buscando tipo de campanha da Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FETCHING_CAMPAIGN_USER_FROM_MICROPLAN",
+    "message": "Buscando os usuários da campanha necessários para a campanha com base na fórmula e nas suposições da Microplan ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FETCHING_MICROPLAN_DATA",
+    "message": "Buscando dados do Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FILE_UPLOADED_SUCCESSFULLY",
+    "message": "Arquivo enviado com sucesso!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FILE_UPLOAD_FAILED",
+    "message": "Falha no upload do arquivo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FILLING_CAMPAIGN_FACILITY_DATA_FROM_MICROPLAN",
+    "message": "Preenchimento de dados da Facility da Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FILLING_CAMPAIGN_TARGET_DATA_FROM_MICROPLAN",
+    "message": "Preenchendo dados de destino do canpaign da Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FILLING_CAMPAIGN_USER_DATA_FROM_MICROPLAN",
+    "message": "Preenchimento de dados do usuário Campaign da Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FROM_DATE",
+    "message": "Data de início",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "From_date",
+    "message": "A partir da data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GENERATING_ALL_THE_TEMPLATES",
+    "message": "Gerando todos os modelos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GET_BOUNDARY_DATA_FROM_GEOPODE",
+    "message": "Obtenha dados de limite do GeoPoDe",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GLASS",
+    "message": "Vidro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GREATER_THAN",
+    "message": "Maior que",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GREATER_THAN_EQUAL_TO",
+    "message": "Maior ou igual a",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_AVAILABLE_FACILITIES",
+    "message": "Lista de instalações disponíveis",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Código de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_OLD",
+    "message": "Código de limite antigo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Dados de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITIES",
+    "message": "Lista de instalações",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY",
+    "message": "Capacidade (Unidades: Fardos para redes mosquiteiras/ Blister SPAQ para SMC)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CODE",
+    "message": "Código da instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME",
+    "message": "Nome da instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS",
+    "message": "Status da instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE",
+    "message": "Tipo de instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE",
+    "message": "Uso das instalações",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LAT",
+    "message": "Latitude",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_LONG",
+    "message": "Longitude",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_AT_THE_SELECTED_BOUNDARY_LEVEL",
+    "message": "Alvo no nível do limite selecionado",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LAT_OPT",
+    "message": "Latitude (opcional)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LONG_OPT",
+    "message": "Longitude (opcional)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "População alvo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "População-alvo (12 a 59 meses de idade)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "População-alvo (3 a 11 meses de idade)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC",
+    "message": "Alvo ao nível da aldeia (obrigatório e a ser inserido pelo usuário)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "População total",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMPLOYMENT_TYPE",
+    "message": "Tipo de emprego (obrigatório)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LIST",
+    "message": "Criar lista de usuários",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LISTTTTTTTT",
+    "message": "Lista de usuários",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Nome da Pessoa (Obrigatório)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER",
+    "message": "Número de telefone (obrigatório)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBERRR",
+    "message": "Número de telefone (obrigatório)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_ROLE",
+    "message": "Função (obrigatório)",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BACK",
+    "message": "Voltar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BENEFICIARY_TYPE",
+    "message": "Tipo de beneficiário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_CLOSE",
+    "message": "Fechar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_DETAILS",
+    "message": "Detalhes do limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_DETAILS_VERTICAL",
+    "message": "Detalhes do limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INF0",
+    "message": "Se você não conseguir encontrar sua hierarquia de limites, entre em contato com a equipe L1 em ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INF0 ",
+    "message": "Se você não conseguir encontrar sua hierarquia de limites, entre em contato com a equipe L1 em ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INFO",
+    "message": "Se você não conseguir encontrar sua hierarquia de limites, entre em contato com a equipe L1 em ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_INFO ",
+    "message": "Se você não conseguir encontrar sua hierarquia de limites, entre em contato com a equipe L1 em ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_MESSAGE",
+    "message": "Preencha o modelo baixado com dados de destino e carregue a planilha Excel.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION",
+    "message": "Adicione seus novos recursos. Os recursos recém-criados serão preenchidos na lista suspensa “Recursos a serem entregues” no pop-up de configuração de recursos.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION_BOLD_TEXT",
+    "message": "Recurso a ser entregue",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION_POST_TEXT",
+    "message": "menu suspenso no pop-up de configuração de recursos.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_DESCRIPTION_PRE_TEXT",
+    "message": "Adicione seus novos recursos. Os recursos recém-criados serão preenchidos no ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ADD_NEW_PRODUCT_HEADER",
+    "message": "Adicionar novo recurso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_ALL_THE_LEVELS_ARE_MANDATORY",
+    "message": "Por favor preencha todos os campos obrigatórios.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CHILD_NOT_PRESENT",
+    "message": "os limites do nível inferior estão faltando. Selecione os limites até o nível mais baixo.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CREATION",
+    "message": "Campanha criada com sucesso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CREATION_PROGRESS",
+    "message": "Progresso da criação da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATE",
+    "message": "Data da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES",
+    "message": "Datas da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_CHANGE_BOUNDARY_HEADER",
+    "message": "Altere as datas da campanha para limites específicos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_CHANGE_BOUNDARY_SUB_TEXT",
+    "message": "Selecione seus limites para alterar as datas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_DESCRIPTION",
+    "message": "Escolha a 'Data de início' e a 'Data de término' da sua campanha. Uma vez selecionadas, as datas refletirão nas próximas etapas de configuração da campanha.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATES_HEADER",
+    "message": "Qual é a data de início e término da campanha?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DATE_MISSING",
+    "message": "Insira a data de início e término da campanha!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS",
+    "message": "Detalhes da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS_SUMMARY",
+    "message": "Resumo detalhado da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DOWNLOAD_TEMPLATE",
+    "message": "Baixar modelo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_END_DATE_BEFORE_START_DATE",
+    "message": "A data de início da campanha não pode ser posterior à data de término da campanha.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_END_DATE_EQUAL_START_DATE",
+    "message": "As datas de início e término de uma campanha não podem ser iguais.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_FOR",
+    "message": "Para",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME",
+    "message": "Nome da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME_DESCRIPTION",
+    "message": "Dê um nome à sua campanha. A prática recomendada para nomear sua campanha é usar uma combinação do tipo de campanha que está sendo configurada, meses e anos da campanha e o limite onde a campanha está sendo executada.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME_EXAMPLE",
+    "message": "Nome de exemplo: CampaignType_Boundary_Dates",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_NAME_HEADER",
+    "message": "Qual é o nome da sua campanha?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SELECT_BOUNDARY_DATA_LABEL",
+    "message": "Selecione o limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SELECT_BOUNDARY_HIERARCHY_LEVEL",
+    "message": "Selecione um nível de hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SETUP_DETAILS",
+    "message": "Detalhes da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_SUCCESS_RESPONSE_ACTION",
+    "message": "Vá para minhas campanhas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE",
+    "message": "Tipo de campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE_DESCRIPTION",
+    "message": "O tipo de campanha determinará o tipo de beneficiário da sua campanha. Suas regras de entrega serão pré-carregadas com base no tipo de campanha selecionado.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE_HEADER",
+    "message": "Qual é o tipo de campanha que você deseja realizar?",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_UPLOAD_CANCEL",
+    "message": "Cancelar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_ACTION",
+    "message": "Ação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_CLEAR",
+    "message": "Claro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_CREATE",
+    "message": "Configurar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_OPTION",
+    "message": "Opção",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_QUESTION",
+    "message": "Pergunta",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_ROLE",
+    "message": "Selecione a função",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_STATUS",
+    "message": "Status",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_ELIGIBILITY",
+    "message": "Elegibilidade",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_ASMT",
+    "message": "Avaliação de estabelecimentos de saúde",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_DRUG_SE_CC",
+    "message": "Encaminhamento para unidade de saúde: efeito colateral do medicamento do ciclo atual",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_DRUG_SE_PC",
+    "message": "Encaminhamento para unidade de saúde: efeito colateral do medicamento do ciclo anterior",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_FEVER",
+    "message": "Encaminhamento para Unidade de Saúde: Febre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_HF_RF_SICK",
+    "message": "Encaminhamento para Unidade de Saúde: Doente",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_IEC",
+    "message": "CEI",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_TEAM_FORMATION",
+    "message": "Formação de Equipe",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_TRAINING_SUPERVISION",
+    "message": "Supervisão de Treinamento",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_TYPE_WAREHOUSE",
+    "message": "Armazém",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECKLIST_VIEW",
+    "message": "Visualizar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CHECK_FILE_AGAIN",
+    "message": "Existem alguns erros na planilha. Baixe o arquivo enviado novamente.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CLEAR_ALL",
+    "message": "Limpar tudo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CONFIGURE_APP",
+    "message": "Configurar aplicativo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CONFIGURE_APP_RESPONSE_ACTION",
+    "message": "Configurar aplicativo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CONFIRMING_RESOURCE_CREATION",
+    "message": "Criação de recursos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CREATE_BOUNDARY_HIERARCHY",
+    "message": "Crie uma nova hierarquia de limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CURRENT",
+    "message": "Atual",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CYCLES",
+    "message": "Ciclos e Entregas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATA_ALLOWED_VALUES_ARE",
+    "message": ". Os valores permitidos são:",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATA_AT_ROW",
+    "message": "Dados na linha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_10_DIGIT",
+    "message": "Número de telefone (obrigatório)' deve ser um número de 10 dígitos.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_GREATER_THAN_ZERO",
+    "message": "deve ser maior que 0",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_LESS_THAN_MAXIMUM",
+    "message": "deve ser inferior a cem milhões",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_BE_NUMBER",
+    "message": "deveria ser um número",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATA_SHOULD_NOT_BE_EMPTY",
+    "message": "não deveria estar vazio",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATA_UPLOAD",
+    "message": "Carregamento de dados",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATA_UPLOAD_SUMMARY",
+    "message": "Resumo de upload de dados",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DATE_CHANGE_SUCCESS_RESPONSE_ACTION",
+    "message": "Voltar ao resumo da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_DETAILS",
+    "message": "Detalhes da entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_DETAILS_SUMMARY",
+    "message": "Resumo dos detalhes da entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_RULES",
+    "message": "Regras de entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DELIVERY_TYPE",
+    "message": "Tipo de entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_EMPTY_SHEET",
+    "message": "A planilha carregada não deve estar vazia.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_END_DATE",
+    "message": "Data de término",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ERROR",
+    "message": "Erro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ERROR_INVALID_FILE_TYPE",
+    "message": "Faça upload de um arquivo Excel válido apenas conforme o modelo.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ERROR_MORE_THAN_ONE_FILE",
+    "message": "Apenas um arquivo válido de planilha Excel pode ser carregado.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_CREATION",
+    "message": "Criação de instalações",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_DETAILS",
+    "message": "Detalhes da instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_MAPPING",
+    "message": "Instalações mapeadas para campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_MESSAGE",
+    "message": "Preencha o modelo baixado com os dados da instalação e carregue a planilha Excel.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_USAGE_VALIDATION",
+    "message": "Preencha a coluna obrigatória 'Uso da instalação' apenas com Ativo/Inativo. Pelo menos um 'Uso da instalação' deve estar ativo.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FETCH_FROM_PLAN_INFO",
+    "message": "Gerar um objeto de campanha a partir do Microplan selecionado, buscar os dados do Microplan, criar um modelo de campanha vazio, adicionar datas à planilha gerada, validar os dados do campo e atualizar as planilhas com detalhes da campanha – aguarde enquanto o processo de busca de dados é finalizado.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FILE_VALIDATION",
+    "message": "A validação do arquivo falhou. Carregue o arquivo de dados correto.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FILE_VALIDATION_ERROR",
+    "message": "Por favor carregue um arquivo válido.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FILE_VALIDATION_PROGRESS",
+    "message": "A validação do arquivo está em andamento.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_HIERARCHY_TYPE",
+    "message": "Tipo de hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_INVALID_BOUNDARY_SHEET",
+    "message": "Uma das planilhas do arquivo enviado parece ter um nome incorreto. Baixe o modelo novamente e carregue-o com os dados corretos.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_INVALID_FACILITY_SHEET",
+    "message": "Uma das planilhas do arquivo enviado parece ter um nome incorreto. Baixe o modelo novamente e carregue-o com os dados corretos.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_INVALID_USER_SHEET",
+    "message": "Uma das planilhas do arquivo enviado parece ter um nome incorreto. Baixe o modelo novamente e carregue-o com os dados corretos.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_IN_COLUMN",
+    "message": "na coluna",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_IS_INVALID",
+    "message": "é inválido.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_IS_MAXIMUM_VALUE",
+    "message": "deve ser inferior a 100 milhões",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_LEVEL",
+    "message": "Nível",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_LEVEL_IS_MANDATORY",
+    "message": "Por favor preencha os campos obrigatórios.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MANAGE_CHECKLIST",
+    "message": "Gerenciar lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MISSING_HEADERS",
+    "message": "Uma ou mais colunas ou cabeçalhos estão faltando no arquivo enviado e não correspondem ao modelo. Baixe o modelo novamente e carregue o modelo correto com dados.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MISSING_TARGET",
+    "message": "Os valores da coluna de destino estão ausentes ou incorretos. Preencha apenas os valores de 1 a 100.000.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_NEXT",
+    "message": "Próximo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_PLEASE_WAIT",
+    "message": "Por favor, aguarde",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_PLEASE_WAIT_LOADING_BOUNDARY",
+    "message": "Por favor, espere um pouco.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_PLEASE_WAIT_TRY_IN_SOME_TIME",
+    "message": "Aguarde. A geração do modelo está em andamento.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_PRODUCT_NAME",
+    "message": "Nome do recurso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_PRODUCT_TYPE",
+    "message": "Tipo de recurso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_PRODUCT_VARIANT",
+    "message": "Variante de recurso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_RESOURCE_MAPPING",
+    "message": "Recursos adicionados à campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_REVIEW_DETAILS",
+    "message": "Resumo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_SELECTED",
+    "message": "Selecionado",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_SELECT_BOUNDARY",
+    "message": "Selecione a hierarquia de limites para seguir em frente.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_SHOW_LESS",
+    "message": "Ver menos etapas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_SHOW_LESS_ALL",
+    "message": "Mostrar menos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_SHOW_LESS_SELECTED",
+    "message": "Mostrar menos selecionados",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_SHOW_MORE",
+    "message": "Veja mais etapas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_SHOW_MORE_ALL",
+    "message": "Mostrar mais",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_STAFF_CREATION",
+    "message": "Criação de usuário do aplicativo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_STAFF_MAPPING",
+    "message": "Usuários do aplicativo mapeados para a campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_START_DATE",
+    "message": "Data de início",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_SUBMIT",
+    "message": "Criar campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_SUMMARY",
+    "message": "Resumo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_TARGETS",
+    "message": "Detalhes do alvo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_TARGET_AND_DELIVERY_RULES_CREATION",
+    "message": "Criação de regras de destino e entrega",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_TARGET_VALIDATION_ERROR",
+    "message": "Os valores alvo devem ser maiores que 0 e menores que 100.000.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_TIMELINE",
+    "message": "Linha do tempo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPCOMING",
+    "message": "Por vir",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPDATE",
+    "message": "Atualizar campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPDATE_DATE",
+    "message": "Atualizar datas da campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPDATE_DATE_INFO",
+    "message": "A data de início selecionada já passou, então você foi redirecionado para a tela Datas da Campanha. Clique em 'Avançar' para salvar as alterações feitas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_BOUNDARY",
+    "message": "Gerenciar limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_DATA",
+    "message": "Carregar dados",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_FACILITY",
+    "message": "Carregar dados da instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_FACILITY_DATA",
+    "message": "Carregar dados da instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_TARGET",
+    "message": "Carregar dados de destino",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_TARGET_DATA",
+    "message": "Carregar dados de destino",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_USER",
+    "message": "Carregar dados do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_USER_DATA",
+    "message": "Carregar dados do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_USER_DETAILS",
+    "message": "Detalhes do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_USER_MESSAGE",
+    "message": "Preencha o modelo baixado com os dados do usuário e carregue a planilha Excel.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_COMPLETED",
+    "message": "A validação do arquivo foi concluída e bem-sucedida.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_FAILED",
+    "message": "O processo de validação do arquivo falhou.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_IN_PROGRESS",
+    "message": "Validação em andamento",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_VIEW_PROGRESS",
+    "message": "Ver progresso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHY",
+    "message": "Tipo de hierarquia de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_ADMINISTRATIVEPOST",
+    "message": "Posto administrativo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHY_CREATED_SUCCESSFULLY",
+    "message": "Hierarquia criada com sucesso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHY_CREATION_FAILED",
+    "message": "Falha na criação da hierarquia ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHY_NAME",
+    "message": "Nome da hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHY_PLEASE_WAIT",
+    "message": "Aguarde alguns minutos enquanto a hierarquia de limites está sendo criada",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHY_PLEASE_WAIT ",
+    "message": "Criando hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HOUSEHOLD",
+    "message": "Doméstico",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INDIRECT",
+    "message": "Entrega indireta",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INDIVIDUAL",
+    "message": "Individual",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INTERNAL_SERVER_ERROR",
+    "message": "Erro do Servidor Interno",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INVALID_FILE_FORMAT",
+    "message": "Formato de arquivo inválido. Faça upload do arquivo .xlsx ou .xls",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "IN_BETWEEN",
+    "message": "Entre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "IRS-mz",
+    "message": "Campanha do IRS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LAST_MODIFIED_TIME",
+    "message": "Hora da última modificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LESSER_THAN_EQUAL_TO",
+    "message": "Menor ou igual a",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LESS_THAN",
+    "message": "Menor que",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LESS_THAN_EQUAL_TO",
+    "message": "Menor ou igual a",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LEVEL",
+    "message": "Nível",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LEVELS",
+    "message": "Níveis",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LEVELS_CANNOT_BE_EMPTY",
+    "message": "Os níveis não podem estar vazios.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LINK_NESTED_CHECKLIST",
+    "message": "Lista de verificação aninhada de links",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN-Moz",
+    "message": "Configuração específica de Moçambique para Campanhas LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN-mz",
+    "message": "Configuração para campanha LLIN",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MALE",
+    "message": "Macho",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MASTER_LANDING_SCREEN_BOUNDARY_SETTINGS",
+    "message": "Configuração de limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MASTER_LANDING_SCREEN_CHECKLIST",
+    "message": "Lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MASTER_LANDING_SCREEN_MASTER_LANDING_SETTING",
+    "message": "Configuração mestre",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "METAL",
+    "message": "Metal",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "METAL/GLASS",
+    "message": "Metal / Vidro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "METAL_OR_GLASS",
+    "message": "Metal / Vidro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_COMPELTED_STEPS",
+    "message": "Concluído ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_OUT_OFF",
+    "message": "sair de ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR-DN",
+    "message": "Configuração para campanha multi-rodada",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MSG",
+    "message": "Adicione seus níveis de hierarquia de limite clicando no botão “Adicionar novo nível de hierarquia de limite”. Se você quiser remover um nível, clique no ícone de exclusão próximo ao nível que deseja excluir.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MY_CAMPAIGN",
+    "message": "Minhas campanhas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MY_FETCH_FROM_MICROPLAN_HEADING",
+    "message": "Buscando dados do Microplan",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MY_MICROPLANS_HEADING",
+    "message": "Microplanos Aprovados",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MultiValueList",
+    "message": "Caixa de seleção",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NAME_OF_CHECKLIST",
+    "message": "Nome da lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NAME_OF_MICROPLAN",
+    "message": "Nome do Microplano",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW13_ADMINISTRATIVEPOST",
+    "message": "ADMINISTRATIVO DE PÓS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW13_COUNTRY",
+    "message": "PAÍS",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW13_DISTRICT",
+    "message": "DISTRITO",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW13_LOCALITY",
+    "message": "LOCALIDADE",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW13_PROVINCE",
+    "message": "PROVÍNCIA",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW13_VILLAGE",
+    "message": "ALDEIA",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEWLY_ADDED_BOUNDARY_DATA",
+    "message": "Dados de limite recentemente adicionados",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEXT",
+    "message": "Próximo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO",
+    "message": "Não",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_CAMPAIGN_DETAILS_FOUND_FOR_GIVEN_CAMPAIGN_ID",
+    "message": "Por favor, tente novamente clicando no botão 'Salvar e prosseguir'.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_DOCUMENTS_AVAILABLE",
+    "message": "Não há documentos disponíveis para credenciais.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Number of Individuals per bed net",
+    "message": "Número de indivíduos por mosquiteiro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "OTHER",
+    "message": "Outro",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "OTHERS",
+    "message": "Outros",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "OTHER_TARGETS",
+    "message": "Outros alvos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLEASE_WAIT_AND_RETRY_AFTER_SOME_TIME",
+    "message": "A geração está em andamento. Por favor, tente novamente depois de algum tempo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLS_WAIT_UNTIL_PAGE_REDIRECTS",
+    "message": "A tela obtém redirecionamento automático para configurar a campanha. Aguarde que a busca de dados esteja em andamento",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PREVIEW_CHECKLIST",
+    "message": "Lista de verificação de visualização",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PREVIEW_ON_MAP",
+    "message": "Visualizar no mapa",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PROJECT_TYPE_UNDEFINED_ERROR",
+    "message": "Selecione um tipo de campanha para passar para a próxima etapa.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "QUESTION",
+    "message": "Pergunta",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "REEDS",
+    "message": "Juncos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "REQUIRED",
+    "message": "Obrigatório",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESIDUAL_SPRAY",
+    "message": "Pulverizar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROLE",
+    "message": "Papel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_BOUNDARY_LEVEL_ERROR",
+    "message": "Selecione os limites primeiro.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_CHECKLIST_TYPE",
+    "message": "Selecione o tipo de lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_HIERARCHY_AND_BOUNDARY_ERROR",
+    "message": "Selecione Hierarquia e limite primeiro.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SHORT_ANSWER",
+    "message": "Resposta curta",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SOME_ERROR_OCCURED_IN_FETCH",
+    "message": "Erro ao buscar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SOME_ERROR_OCCURED_IN_FETCH_RETRYING",
+    "message": "Erro ao buscar, tentando novamente!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "START_DATE",
+    "message": "Data de início",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "STATUS",
+    "message": "Status",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Search",
+    "message": "Procurar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SingleValueList",
+    "message": "Botão de opção",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Start Date",
+    "message": "Data de início",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TABLET",
+    "message": "Comprimido",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TARGET_DETAILS",
+    "message": "Detalhes do alvo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TARGET_DETAILS_ERROR",
+    "message": "Por favor, adicione o arquivo Excel de detalhes do alvo.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TARGET_FILE_MISSING",
+    "message": "A planilha de destino está faltando",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATED_SUCCESSFULLY",
+    "message": "Modelo gerado com sucesso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATED_SUCCESSFULLY ",
+    "message": "Modelo gerado com sucesso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_FAILED",
+    "message": "Falha na geração do modelo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_IN_PROGRESS",
+    "message": "Geração de modelo em andamento",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_IN_PROGRESS ",
+    "message": "Criando modelo de hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEMPLATE_GENERATION_TIMEOUT",
+    "message": "Falha na geração do modelo. Erro de tempo limite!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TONIC",
+    "message": "Tônico",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TO_DATE",
+    "message": "Data de término",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TRANSGENDER",
+    "message": "Transgênero",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TYPE_OF_CHECKLIST",
+    "message": "Tipo de lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TYPE_OF_STRUCTURE",
+    "message": "Tipo de estrutura",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TYPE_YOUR_QUESTION_HERE",
+    "message": "Digite sua pergunta aqui ",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "To_date",
+    "message": "A data",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPDATED_CAMPAIGN_WITH_UPLODAED_DATA",
+    "message": "Campanha atualizada com recursos carregados",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPDATE_CAMPAIGN",
+    "message": "Atualizar campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPDATE_CHECKLIST",
+    "message": "Lista de verificação de atualização",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_AND_CYCLE_HEADER",
+    "message": "Atualizar datas e ciclo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE",
+    "message": "Alterar datas de campanha",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE_INFO_TEXT",
+    "message": "1. A data de início e de término da campanha não pode ser atualizada se for pelo menos 24 horas antes da hora atual e começar após o dia seguinte em diante.                           2.As datas do ciclo não podem ser escolhidas como datas passadas a partir da data de hoje.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE_INFO_TEXT1",
+    "message": "1. A data de início e de término da campanha não pode ser atualizada se for pelo menos 24 horas antes da hora atual e começar após o dia seguinte em diante.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_CHANGE_INFO_TEXT2",
+    "message": "2.As datas do ciclo não podem ser escolhidas como datas passadas a partir da data de hoje.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPDATE_DATE_MANDATORY_FIELDS_MISSING",
+    "message": "Por favor preencha todos os campos obrigatórios.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOAD_EXCEL",
+    "message": "Carregar Excel",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOAD_EXCEL_FOR_ALL_BOUNDARIES",
+    "message": "Carregar Excel para todos os limites",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOAD_GEOJSONS",
+    "message": "Carregar geojson",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_DETAILS",
+    "message": "Detalhes do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_DETAILS_ERROR",
+    "message": "Adicione os detalhes do usuário no arquivo Excel.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_FILE_MISSING",
+    "message": "A planilha do usuário está faltando",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_GENERATE_DETAILS",
+    "message": "Detalhes da credencial do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USE_TEMPLATE",
+    "message": "Usar modelo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VALIDATING_THE_USER_TEMPLATE",
+    "message": "Validando todas as planilhas arquivadas",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VALIDATION_ERROR",
+    "message": "Limite já presente no sistema",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VIEW",
+    "message": "Visualizar",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VIEW_CHECKLIST",
+    "message": "Ver lista de verificação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VIEW_EXISTING_BOUNDARY_DATA",
+    "message": "Visualizar dados de limites existentes",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WAREHOUSE",
+    "message": "Armazém",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_ADD_LEVEL",
+    "message": "Adicionar nível",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_FAIL",
+    "message": "Erro na criação do limite",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_FAIL: DUPLICATE_RECORD.",
+    "message": "Ops! Parece que você já inseriu isso. Insira um nome de hierarquia diferente.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_FAIL: INTERNAL_SERVER_ERROR.",
+    "message": "O arquivo enviado não está de acordo com o modelo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_BOUNDARY_CREATION_TIMEOUT",
+    "message": "Falha na criação de dados de limite. Erro de tempo limite!",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_BULK_BROWSE_FILES",
+    "message": "Navegue em meus arquivos",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_CAMPAIGN_CREATED",
+    "message": "Arquivo enviado com sucesso.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_CREATE_HIERARCHY",
+    "message": "Criar hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DELETE",
+    "message": "Excluir",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DOWLOAD_TEMPLATE",
+    "message": "Baixar modelo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD",
+    "message": "Download",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_FACILITY",
+    "message": "Baixe a instalação atual",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_TARGET",
+    "message": "Baixar alvo atual",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_USER",
+    "message": "Baixar dados atuais do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_CURRENT_USERDATA",
+    "message": "Baixar dados atuais do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_TEMPLATE",
+    "message": "Baixar modelo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DRAG_DROP",
+    "message": "Arraste e solte sua planilha Excel preenchida ou",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_ERROR_MORE_THAN_ONE_FILE",
+    "message": "Não é possível adicionar mais de um arquivo",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_CREATED",
+    "message": "Hierarquia e limite criados com sucesso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_DETAILS",
+    "message": "Detalhes da hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_NAME",
+    "message": "Nome da hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_STATUS_COMPLETED",
+    "message": "Hierarquia criada com sucesso",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_HIERARCHY_TYPE",
+    "message": "Selecione o tipo de hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_LOC_BULK_UPLOAD_XLS",
+    "message": "Limites de upload em massa",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_OPERATION_INCOMPLETE",
+    "message": "Falha na criação do limite.",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_UNABLE_TO_FIND_HIERARCHY_TYPE",
+    "message": "Criar novo tipo de hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_BOUNDARY",
+    "message": "Limite de upload",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_FACILITY",
+    "message": "Carregar dados da instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_Facility",
+    "message": "Carregar dados da instalação",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_TARGET",
+    "message": "Carregar dados de destino",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_USER",
+    "message": "Carregar dados do usuário",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "YES",
+    "message": "Sim",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "YOU_WON'T_BE_ABLE_TO_UNDO_THIS_STEP_OF_CREATING_HIERARCHY",
+    "message": "Você não poderá desfazer esta etapa de criação de hierarquia",
+    "module": "rainmaker-campaignmanager",
+    "locale": "pt_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/pt_MZ/rainmaker-common.json
+++ b/localisation/Microplanning/v0.1/pt_MZ/rainmaker-common.json
@@ -1,0 +1,56 @@
+[
+  {
+  "code": "MICROPLAN_MODULE_SETUP",
+  "message": "Configuração do microplano",
+  "module": "rainmaker-common",
+  "locale": "pt_MZ"
+},
+{
+"code": "SETUP_MICROPLAN",
+"message": "Configurar Microplano",
+"module": "rainmaker-common",
+"locale": "pt_MZ"
+},
+{
+"code": "SEARCH_MICROPLANS",
+"message": "Microplanos abertos",
+"module": "rainmaker-common",
+"locale": "pt_MZ"
+},
+{
+"code": "USER_MANAGEMENT",
+"message": "Gerenciamento de usuários",
+"module": "rainmaker-common",
+"locale": "pt_MZ"
+},
+{
+"code": "MICROPLAN_MODULE_PROCESS",
+"message": "Processo Microplano",
+"module": "rainmaker-common",
+"locale": "pt_MZ"
+},
+{
+"code": "MY_MICROPLANS",
+"message": "Meus Microplanos",
+"module": "rainmaker-common",
+"locale": "pt_MZ"
+},
+  {
+    "code": "ACTION_TEST_OPEN_MICROPLAN",
+    "message": "Microplano aberto",
+    "module": "rainmaker-common",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_USER_MANAGEMENT",
+    "message": "Gerenciamento de usuários",
+    "module": "rainmaker-common",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MY_MICROPLAN",
+    "message": "Meus Microplanos",
+    "module": "rainmaker-common",
+    "locale": "pt_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/pt_MZ/rainmaker-hcm-admin-schemas.json
+++ b/localisation/Microplanning/v0.1/pt_MZ/rainmaker-hcm-admin-schemas.json
@@ -1,0 +1,7634 @@
+[
+  {
+    "code": "ADMIN10_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN10_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN10_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN10_POST ADMINISTRATIVO",
+    "message": "Pós Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN10_STATE",
+    "message": "Estado",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN11_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN11_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN11_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN11_POST ADMINISTRATIVO",
+    "message": "Pós Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN11_STATE",
+    "message": "Estado",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN1_PROVINCIA",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN2_PROVINCIA",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_POST ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN3_PROVINCIA",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMINE_QA",
+    "message": "Controle de qualidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMINU_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_CONSOLE_TARGET",
+    "message": "Alvo do agregado familiar ao nível da aldeia (obrigatório e a ser introduzido pelo utilizador)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO",
+    "message": "Moçambique",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_01_CANGUD ZI",
+    "message": "CANGUD ZI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_01_CAVINA1",
+    "message": "Cavina1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_02_CANDOD O",
+    "message": "CANDODO O",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_02_CAVINA2",
+    "message": "Cavina2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_03_CARANG ACHE",
+    "message": "DOR DE CARANG",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_03_CAVINA3",
+    "message": "Cavina3",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_04_CAVINA4",
+    "message": "Cavina4",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_04_NHANTS UNGUI",
+    "message": "NHANTS UNGUI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_05_CAVINA5",
+    "message": "Cavina5",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_05_CHITHA NDO",
+    "message": "CHITHA NDO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_06_CAVINA6",
+    "message": "Cavina6",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_06_GUEBUZ A",
+    "message": "GUEBUZ A",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_07_CADONG OLO",
+    "message": "CADONG OLO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_07_CAVINA7",
+    "message": "Cavina7",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_08_BOROMA",
+    "message": "BOROMA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_08_CAVINA8",
+    "message": "Cavina8",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_09_CAHO",
+    "message": "CAHO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_09_CAVINA9",
+    "message": "Cavina9",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_10_1 DE M AIO",
+    "message": "1 DE M AIO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_10_CAVINA10",
+    "message": "Cavina10",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_11_CATOND O",
+    "message": "CATOND O",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_11_CAVINA11",
+    "message": "Cavina11",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_12_CAVINA12",
+    "message": "Cavina12",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_12_JOSINA MACHEL",
+    "message": "JOSINA MACHEL",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_13_25 DE JUNHO",
+    "message": "25 DE JUNHO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_13_CAVINA13",
+    "message": "Cavina13",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_14_CAVINA14",
+    "message": "Cavina14",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_14_VALE",
+    "message": "VALE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_15_CAVINA15",
+    "message": "Cavina15",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_15_CAWIRA B",
+    "message": "CAWIRA B",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_16_CAVINA16",
+    "message": "Cavina16",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_16_CAWIRA A",
+    "message": "CAWIRA A",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_17_CAVINA17",
+    "message": "Cavina17",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_18_CAVINA18",
+    "message": "Cavina18",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_19_CAVINA19",
+    "message": "Cavina19",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_20_CAVINA20",
+    "message": "Cavina20",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_21_CAVINA21",
+    "message": "Cavina21",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_22_CAVINA22",
+    "message": "Cavina22",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_23_CAVINA23",
+    "message": "Cavina23",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_24_CAVINA24",
+    "message": "Cavina24",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_25_CAVINA25",
+    "message": "Cavina25",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_26_CAVINA26",
+    "message": "Cavina26",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_27_CAVINA27",
+    "message": "Cavina27",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_28_CAVINA28",
+    "message": "Cavina28",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_29_CAVINA29",
+    "message": "Cavina29",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_CHITIMA SEDE",
+    "message": "Chitima Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_01_NIHESSIUEA",
+    "message": "Nihessiuea",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_01_NACULUER1",
+    "message": "Naculuer1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_02_NACULUER2",
+    "message": "Naculuer2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_03_NACULUER3",
+    "message": "Naculuer3",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_04_NACULUER4",
+    "message": "Naculuer4",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_05_NACULUER5",
+    "message": "Naculuer5",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_06_NACULUER6",
+    "message": "Naculuer6",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_07_NACULUER7",
+    "message": "Naculuer7",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_08_NACULUER8",
+    "message": "Naculuer8",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_09_NACULUER9",
+    "message": "Naculuer9",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_10_NACULUER10",
+    "message": "Naculuer10",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_02_MULHANIUA",
+    "message": "Mulhaniua",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_01_NACOCOLOA1",
+    "message": "Nacocoloa1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_02_NACOCOLOA2",
+    "message": "Nacocoloa2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_03_NACOCOLOA3",
+    "message": "Nacocoloa3",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_04_NACOCOLOA4",
+    "message": "Nacocoloa4",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_05_NACOCOLOA5",
+    "message": "Nacocoloa5",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_06_NACOCOLOA6",
+    "message": "Nacocoloa6",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_07_NACOCOLOA7",
+    "message": "Nacocoloa7",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_08_NACOCOLOA8",
+    "message": "Nacocoloa8",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_09_NACOCOLOA9",
+    "message": "Nacocoloa9",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_03_NACOCOLO",
+    "message": "Nacocolo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_CHITIMA",
+    "message": "Chitima",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_01_NIHESSIUE",
+    "message": "Nihessiue",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_01_CAWIRA A",
+    "message": "Cawira A",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_01_THEQUESSE",
+    "message": "Thequesse",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_02_CAWIRA B",
+    "message": "Cawira B",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_02_ZANICHI",
+    "message": "Zanichi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_03_MACATA",
+    "message": "Macatá",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_03_VALE",
+    "message": "Vale",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_04_25 DE JUNHO",
+    "message": "25 de junho",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_04_JULIO CHAMALULO",
+    "message": "Júlio Chamalulo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_05_COFATI 1",
+    "message": "Cofati 1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_05_JOSINA MACHEL",
+    "message": "Josina Machel",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_06_AFULEDI",
+    "message": "Afuledi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_06_CATOND O",
+    "message": "Catond O",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_07_1 DE M AIO",
+    "message": "1 De M Aio",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_07_ADAMO",
+    "message": "Adão",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_08_ACUSE",
+    "message": "Acusar",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_08_CAHO",
+    "message": "Caho",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_09_BOROMA",
+    "message": "Boroma",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_09_NTUITI",
+    "message": "Ntuiti",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_10_CADONG OLO",
+    "message": "Cadong Olo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_10_NCUMBZI 1",
+    "message": "Ncumbzi 1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_11_GUEBUZ A",
+    "message": "Guebuz A",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_11_NCUMBUZI 2",
+    "message": "Ncumbuzi 2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_12_ACHINTSUE",
+    "message": "Achintsue",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_12_CHITHA NDO",
+    "message": "Chitha Ndo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_13_AMBULEZI",
+    "message": "Ambulézi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_13_NHANTS UNGUI",
+    "message": "Nhants Ungui",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_14_CARANG ACHE",
+    "message": "Dor de Carang",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_14_KAPHIRI KA MPANDA",
+    "message": "Kaphiri ka mpanda",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_15_CANDOD O",
+    "message": "Candod O",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_15_COFATI 2",
+    "message": "Café 2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_16_CANGUD ZI",
+    "message": "Cangud Zi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_16_TSHIRIZA",
+    "message": "Tshiriza",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_17_ANANIAS",
+    "message": "Ananias",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_18_MAXENECA",
+    "message": "Maxeneca",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_19_CAPOCHI",
+    "message": "Capochi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_20_CHANGUI",
+    "message": "Changui",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_21_LIPIRANI",
+    "message": "Lipirani",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_22_MPHEMBERE",
+    "message": "Mphembere",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_23_MOAMBEDZI",
+    "message": "Moambedzi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_ANG'OMBE",
+    "message": "Ang'ombe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_01_CHITIMA SEDE",
+    "message": "Chitima Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_CHITIMA ",
+    "message": "Chitima",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_02_NSADZO",
+    "message": "Nsadzo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_MOSSURILEE",
+    "message": "Mossurilê",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_MOSSURILEE ",
+    "message": "Mossurilê",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_01_MURRUPULA",
+    "message": "Múrrupula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_01_NACOCOLOA9",
+    "message": "NACOCOLOA9",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_02_NACOCOLOA8",
+    "message": "NACOCOLOA8",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_03_NACOCOLOA7",
+    "message": "NACOCOLOA7",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_04_NACOCOLOA6",
+    "message": "NACOCOLOA6",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_05_NACOCOLOA5",
+    "message": "NACOCOLOA5",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_06_NACOCOLOA4",
+    "message": "NACOCOLOA4",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_07_NACOCOLOA3",
+    "message": "NACOCOLOA3",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_08_NACOCOLOA2",
+    "message": "NACOCOLOA2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_09_NACOCOLOA1",
+    "message": "NACOCOLOA1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_01_NACOCOLO",
+    "message": "Nacocolo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_01_NACULUER10",
+    "message": "NACULUER10",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_02_NACULUER9",
+    "message": "NACULUER9",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_03_NACULUER8",
+    "message": "NACULUER8",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_04_NACULUER7",
+    "message": "NACULUER7",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_05_NACULUER6",
+    "message": "NACULUER6",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_06_NACULUER5",
+    "message": "NACULUER5",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_07_NACULUER4",
+    "message": "NACULUER4",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_08_NACULUER3",
+    "message": "NACULUER3",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_09_NACULUER2",
+    "message": "NACULUER2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_10_NACULUER1",
+    "message": "NACULUER1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_02_MULHANIUA",
+    "message": "Mulhaniua",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_01_CAVINA29",
+    "message": "CAVINA29",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_02_CAVINA28",
+    "message": "CAVINA28",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_03_CAVINA27",
+    "message": "CAVINA27",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_04_CAVINA26",
+    "message": "CAVINA26",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_05_CAVINA25",
+    "message": "CAVINA25",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_06_CAVINA24",
+    "message": "CAVINA24",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_07_CAVINA23",
+    "message": "CAVINA23",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_08_CAVINA22",
+    "message": "CAVINA22",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_09_CAVINA21",
+    "message": "CAVINA21",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_10_CAVINA20",
+    "message": "CAVINA20",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_11_CAVINA19",
+    "message": "CAVINA19",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_12_CAVINA18",
+    "message": "CAVINA18",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_13_CAVINA17",
+    "message": "CAVINA17",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_14_CAVINA16",
+    "message": "CAVINA16",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_15_CAVINA15",
+    "message": "CAVINA15",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_16_CAVINA14",
+    "message": "CAVINA14",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_17_CAVINA13",
+    "message": "CAVINA13",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_18_CAVINA12",
+    "message": "CAVINA12",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_19_CAVINA11",
+    "message": "CAVINA11",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_20_CAVINA10",
+    "message": "CAVINA10",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_21_CAVINA9",
+    "message": "CAVINA9",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_22_CAVINA8",
+    "message": "CAVINA8",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_23_CAVINA7",
+    "message": "CAVINA7",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_24_CAVINA6",
+    "message": "CAVINA6",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_25_CAVINA5",
+    "message": "CAVINA5",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_26_CAVINA4",
+    "message": "CAVINA4",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_27_CAVINA3",
+    "message": "CAVINA3",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_28_CAVINA2",
+    "message": "CAVINA2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_29_CAVINA1",
+    "message": "CAVINA1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_03_NIHESSIUEA",
+    "message": "Nihessiuea",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_01_NIHESSIUE",
+    "message": "Nihessiue",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_01_CHIRODZI PONTE",
+    "message": "Chirodzi Ponte",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_02_NHAULIRI 1",
+    "message": "Nhauliri 1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_03_NHAULIRI 2",
+    "message": "Nhauliri 2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_04_NCHENGA",
+    "message": "Nchenga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_05_CHAMIMBA",
+    "message": "Chamimba",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_06_CHIRODZI NTEPE",
+    "message": "Chirodzi Ntepe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_07_NHANTSINGA",
+    "message": "Nhantsinga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_08_NHAMIDZI",
+    "message": "Nhamidzi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_09_CAVULANCIE",
+    "message": "Cavulância",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_10_CHISSUA SEDE",
+    "message": "Sede de Chissua",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_11_CHISSUA CRUZAMENTO",
+    "message": "Chissua Cruzamento",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_12_CHISSUA THALA",
+    "message": "Chissua Thala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_13_CHABONGA",
+    "message": "Chabonga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_01_CHIBAGADIGO",
+    "message": "Chibagadigo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_01_MATUNGULU",
+    "message": "Matungulu",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_02_MASSECHA",
+    "message": "Massacha",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_03_CHINHANDA",
+    "message": "Chinhanda",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_04_CHICOA",
+    "message": "Chicoa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_05_NHAMINHE",
+    "message": "Nhaminhe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_02_CHICOA NOVA",
+    "message": "Chicoa Nova",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_02_CHITEEIMA",
+    "message": "Chiteeima",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_01_MUALADZI SEDE",
+    "message": "sede de Mualadzi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_02_CHITUMBULA",
+    "message": "Chitumbula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_03_CHIMBALAME",
+    "message": "Chimbalame",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_04_CHATSICA",
+    "message": "Chatsica",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_05_NAMICOMBO",
+    "message": "Namicombo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_06_SATEMA",
+    "message": "Satema",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_07_TSEBONDO",
+    "message": "Tsebondo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_08_CATAKWALA",
+    "message": "Catakwala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_09_DZIWELANGONA",
+    "message": "Dziwelangona",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_10_MUANANHANJE",
+    "message": "Muananhanje",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_11_CHOLONNGUELERA",
+    "message": "Cholonnguelera",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_12_MULAWE",
+    "message": "Mulawe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_13_NCHENGOERA",
+    "message": "Nchengoera",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_14_MANKACA 1",
+    "message": "Mankacá 1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_15_CHIRUDZI",
+    "message": "Chirudzi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_16_DAUNDELA",
+    "message": "Daundela",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_17_GOELA",
+    "message": "Goela",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_18_THIMA",
+    "message": "Thima",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_19_PHOCA",
+    "message": "Foca",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_20_GUEROSSOMO",
+    "message": "Guerossomo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_21_NKHONDA",
+    "message": "Nkhonda",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_22_MANKACA 2",
+    "message": "Mankacá 2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_23_VUBUE",
+    "message": "Vubue",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_24_MALIDZIMAERA",
+    "message": "Malidzimaera",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_25_CAWELENGA",
+    "message": "Cawelenga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_26_CHIMPOYO",
+    "message": "Chimpoió",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_27_MAGRENI",
+    "message": "Magreni",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_28_WERENGANI",
+    "message": "Werengani",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_29_AMOSSE",
+    "message": "Amosse",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_30_MBOMBE",
+    "message": "Mbombe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_31_NROLO",
+    "message": "Nrolo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_32_MPHANJAYAUTSI",
+    "message": "Mphanjayautsi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_33_MALAZA",
+    "message": "Malaza",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_34_NHATIKOWA",
+    "message": "Nhatikowa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_35_CHITHAWALE",
+    "message": "Chithawale",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_36_ANTIGA MIGRACAO",
+    "message": "Antiga Migração",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_01_MUALADZI",
+    "message": "Mualadzi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_03_CHIFUNDE",
+    "message": "Chifunde",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_01_KHAMANDE SEDE",
+    "message": "sede de Khamande",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_02_SEQUE",
+    "message": "Seque",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_03_CASSOCHELA",
+    "message": "Cassochela",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_04_MASSAUASSAUA",
+    "message": "Massauassaua",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_05_NKONDA",
+    "message": "Nkonda",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_06_MASSIMO",
+    "message": "Massimo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_07_ALISSONE",
+    "message": "Alisson",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_08_CANQUIRA",
+    "message": "Canquira",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_09_CHIGONDO",
+    "message": "Chigondo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_10_CALIDZIPIRE",
+    "message": "Calidzipire",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_11_DZICO",
+    "message": "Dzico",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_12_JASSONE",
+    "message": "Jassone",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_13_CHAWANTA",
+    "message": "Chawanta",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_14_KANKHUKU",
+    "message": "Kankhuku",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_15_KAPAMANGA",
+    "message": "Kapamanga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_16_CHICAONDA",
+    "message": "Chicaona",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_17_FAIZAZE",
+    "message": "Faizaze",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_18_MULAMBA",
+    "message": "Mulamba",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_19_TCHALE",
+    "message": "Tchale",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_01_KHAMANDE",
+    "message": "Khamande",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_04_MUALDZI",
+    "message": "Mualdzi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_ENT PS CIDADE NAMPULA",
+    "message": "Ent Ps Cidade Nampula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_02_MURRUPULA",
+    "message": "Múrrupula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_ADMIN_MO",
+    "message": "ADMIN_MO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_01_NAMPULA",
+    "message": "Nampula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_01_CHIMELO",
+    "message": "CHIMELO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_02_CHIGELA",
+    "message": "CHIGELA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_03_CHIPACO",
+    "message": "CHIPACO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_04_CHIPANG A",
+    "message": "CHIPANG A",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_05_CHIPINHE",
+    "message": "CHIPINHE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_06_COLOMBO",
+    "message": "COLOMBO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_07_COTOMON A",
+    "message": "COTOMON A",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_08_FAHELO",
+    "message": "FAHELO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_09_FAMULO",
+    "message": "FAMULO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_10_HODI",
+    "message": "HODI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_11_JUNHO",
+    "message": "JUNHO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_12_MAFELENE",
+    "message": "MAFELENE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_13_MALUPIRIR",
+    "message": "MALUPIRIR",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_14_MAPIRORO",
+    "message": "MAPIRORO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_15_MARIRIU",
+    "message": "MARIRIU",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_16_MUNGO",
+    "message": "MUNGO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_17_NABOARO",
+    "message": "NABOARO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_18_NALO",
+    "message": "NALO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_19_OCALIMBO",
+    "message": "OCALIMBO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_20_OCUMALO",
+    "message": "OCUMALO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_21_OCUMO",
+    "message": "OCUMO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_22_PASSENDE",
+    "message": "PASSEIO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_23_PIRO",
+    "message": "PIRO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_24_PONACO",
+    "message": "PONACO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_25_SANTOS",
+    "message": "SANTOS",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_26_TINGACO",
+    "message": "TINGACO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_27_VERDE",
+    "message": "VERDE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_28_VIATURA",
+    "message": "VIATURA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_29_VULAGUNDE",
+    "message": "VULAGUNDA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_30_WINAZO",
+    "message": "WINAZO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_31_XIMANGO",
+    "message": "XIMANGO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_32_XIMPACO",
+    "message": "XIMPACO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_33_XINZIQUE",
+    "message": "XINZIQUE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_34_YUAMO",
+    "message": "YUAMO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_35_ZIMBAZE",
+    "message": "ZIMBAZÉ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_36_ZUNGULE",
+    "message": "ZUNGULE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_37_INGURU",
+    "message": "INGURU",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_38_NANGURU",
+    "message": "NANGURU",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_39_MISSETA",
+    "message": "MISSETA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_40_MUCO",
+    "message": "MUCO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_41_NAMANCA",
+    "message": "NAMANCA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_42_MBUZI",
+    "message": "MBUZI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_43_CABATA",
+    "message": "CABATA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_01_PEMBA SEDE",
+    "message": "Sede de Pemba",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_01_PEMBA",
+    "message": "Pemba",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_ADMIN_MO_01_NAMPULA",
+    "message": "ADMIN_MO_01_NAMPULA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_ADMIN_MO_12_TETE",
+    "message": "ADMIN_MO_12_TETE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_01_CABO DELGADO",
+    "message": "Cabo Delgado",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_02_01_01_CHIMOIO SEDE",
+    "message": "Sede de Chimoio",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_02_01_CHIMOIO",
+    "message": "Chimoio",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_02_MANICA",
+    "message": "Manica",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_CABO",
+    "message": "Cabo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_NAMPULA",
+    "message": "Nampula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_02_TETE",
+    "message": "Tete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_03_01_ADMIN_MO_02_CABO",
+    "message": "ADMIN_MO_02_CABO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_03_01_ADMIN_MO_10_ZAMBEZIA",
+    "message": "ADMIN_MO_10_ZAMBÉZIA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_03_CABO",
+    "message": "Cabo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_03_ZAMBEZIA",
+    "message": "Zambézia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_01_01_01_MUZIRO",
+    "message": "MUZIRO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_01_01_02_MUCHAPA",
+    "message": "MUCHAPA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_01_01_TICA SEDE",
+    "message": "Tica Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_01_TICA",
+    "message": "Tica",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_02_01_01_MUBO",
+    "message": "MUBO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_02_01_02_SANGO",
+    "message": "SANGO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_02_01_NHAMPOCA SEDE",
+    "message": "Sede de Nhampoca",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_02_NHAMPOCA",
+    "message": "Nhampoca",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_03_01_01_NHANDUMA",
+    "message": "NHANDUMA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_03_01_02_MAHAMBA",
+    "message": "MAHAMBA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_03_01_MUTUA SEDE",
+    "message": "Sede Mútua",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_03_MUTUA",
+    "message": "Mútua",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_04_01_01_MACANDE",
+    "message": "MACANDE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_04_01_02_NHACOTA",
+    "message": "NHACOTA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_04_01_LAMEGO SEDE",
+    "message": "Sede de Lamego",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_04_LAMEGO",
+    "message": "Lamego",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_05_01_01_BEBEDO VILLAGE",
+    "message": "Aldeia Bebedo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_05_01_BEBEDO SEDE",
+    "message": "Bebedo Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_05_BEBEDO",
+    "message": "Bebedo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_ADMIN_MO_04_SOFALA",
+    "message": "ADMIN_MO_04_SOFALA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_ADMIN_MO_09_INHAMBANE",
+    "message": "ADMIN_MO_09_INHAMBANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_01_NHAMATANDA",
+    "message": "Nhamatanda",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_01_01_01_NHAMUDE",
+    "message": "NHAMUDE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_01_01_02_MANIKA",
+    "message": "MANICA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_01_01_SAVANE SEDE",
+    "message": "Savane Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_01_SAVANE",
+    "message": "Savane",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_02_01_01_MAGOMBE",
+    "message": "MAGOMBÉ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_02_01_02_NHATEMA",
+    "message": "NHATEMA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_02_01_MAFAMBISSE SEDE",
+    "message": "Sede de Mafambisse",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_02_MAFAMBISSE",
+    "message": "Mafambisse",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_03_01_01_MAZONDE",
+    "message": "MAZONDE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_03_01_02_LICUARI",
+    "message": "LICUARI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_03_01_CHINAMACONDO SEDE",
+    "message": "Sede Chinamacondo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_03_CHINAMACONDO",
+    "message": "Chinamacondo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_04_01_01_MARUJA",
+    "message": "MARUJA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_04_01_02_MACHIR",
+    "message": "MACIRO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_04_01_SENGO SEDE",
+    "message": "Sengo Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_04_SENGO",
+    "message": "Sengo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_02_DONDO",
+    "message": "Dondo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_01_01_01_MARANGA",
+    "message": "MARANGÁ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_01_01_02_MAVICHE",
+    "message": "MAVICHE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_01_01_VUNDUZI SEDE",
+    "message": "Sede de Vunduzi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_01_VUNDUZI",
+    "message": "Vunduzi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_02_01_01_MILANGULO",
+    "message": "MILANGULO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_02_01_02_MACUNGA",
+    "message": "MACUNGA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_02_01_CHITUNGA SEDE",
+    "message": "Sede de Chitunga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_02_CHITUNGA",
+    "message": "Chitunga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_03_01_01_NHATADIMA",
+    "message": "NHATADIMA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_03_01_02_NHANDJA",
+    "message": "NHANDJA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_03_01_NHAMASSONGE SEDE",
+    "message": "Sede de Nhamassonge",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_03_NHAMASSONGE",
+    "message": "Nhamassonge",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_04_01_01_LAMBA",
+    "message": "LAMBA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_04_01_02_NHANJI",
+    "message": "NHANJI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_04_01_DINDIZA SEDE",
+    "message": "Dindiza Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_04_DINDIZA",
+    "message": "Dindiza",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_03_GORONGOSA",
+    "message": "Gorongosa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_01_01_01_SENGA",
+    "message": "SENGA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_01_01_02_CHICENGA",
+    "message": "CHIENGA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_01_01_NOVA SOFALA SEDE",
+    "message": "Nova Sofala Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_01_NOVA SOFALA",
+    "message": "Nova Sofala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_02_01_01_NHOHULA",
+    "message": "NHOHULA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_02_01_02_MUZOMBO",
+    "message": "MUZOMBO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_02_01_INHAMINGA SEDE",
+    "message": "Sede de Inhaminga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_02_INHAMINGA",
+    "message": "Inhaminga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_03_01_01_MAZACHA",
+    "message": "MAZACHA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_03_01_02_CHICUARI",
+    "message": "CHICUARI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_03_01_GRUDJA SEDE",
+    "message": "Grudja Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_03_GRUDJA",
+    "message": "Grudja",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_04_01_01_MAHORO",
+    "message": "MAHORO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_04_01_02_MACHUMO",
+    "message": "MACHUMO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_04_01_GUARA-GUARA SEDE",
+    "message": "Guara-Guara Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_04_GUARA-GUARA",
+    "message": "Guara-Guara",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_04_BUZI",
+    "message": "Búzi",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_01_01_01_CHAMBULI",
+    "message": "CAMBULI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_01_01_02_MEQUELE",
+    "message": "MEQUELE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_01_01_MARROMEU SEDE",
+    "message": "Sede de Marromeu",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_01_MARROMEU",
+    "message": "Marromeu",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_02_01_01_MATEQUE",
+    "message": "MATEQUE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_02_01_02_MACUNHE",
+    "message": "MACUNHÉ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_02_01_CHUPANGA SEDE",
+    "message": "Chupanga Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_02_CHUPANGA",
+    "message": "Chupanga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_03_01_01_MACAVALA",
+    "message": "MACAVALA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_03_01_02_NHAXANA",
+    "message": "NHAXANA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_03_01_MORRUMBALA SEDE",
+    "message": "Sede de Morrumbala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_03_MORRUMBALA",
+    "message": "Morrumbala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_04_01_01_MECHUO",
+    "message": "MECHUO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_04_01_02_MACAHULO",
+    "message": "MACAHULO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_04_01_INHANGOMA SEDE",
+    "message": "Sede de Inhangoma",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_04_INHANGOMA",
+    "message": "Inhangoma",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_05_CHEMBA",
+    "message": "Chemba",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_01_01_01_CHIMBUNGA",
+    "message": "CHIMBUNGA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_01_01_02_MACHANGULO",
+    "message": "MACHANGULO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_01_01_SENA SEDE",
+    "message": "Sena Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_01_SENA",
+    "message": "Sena",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_02_01_01_NHIRO",
+    "message": "NHIRO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_02_01_02_MACHUMBO",
+    "message": "MACHUMBO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_02_01_MURRAÇA SEDE",
+    "message": "Murraça Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_02_MURRAÇA",
+    "message": "Murraça",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_03_01_01_MAFOGUENE",
+    "message": "MAFOGUENE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_03_01_02_NHASSICO",
+    "message": "NHASSICO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_03_01_CHIMUARA SEDE",
+    "message": "Chimuara Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_03_CHIMUARA",
+    "message": "Chimuara",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_04_01_01_MAZUQUA",
+    "message": "MAZUQUÁ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_04_01_02_LICUMBA",
+    "message": "LICUMBA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_04_01_MOPEIA SEDE",
+    "message": "Sede de Mopeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_04_MOPEIA",
+    "message": "Mopeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_06_CAIA",
+    "message": "Caia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_INHAMBANE",
+    "message": "Inhambane",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_04_SOFALA",
+    "message": "Sofala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_05_01_ADMIN_MO_05_TETE",
+    "message": "ADMIN_MO_05_TETE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_05_01_ADMIN_MO_08_GAZA",
+    "message": "ADMIN_MO_08_GAZA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_05_GAZA",
+    "message": "Gaza",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_05_TETE",
+    "message": "Tete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_05_TETEA",
+    "message": "Tetéa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_01_01_MASSAVANE",
+    "message": "MASSAVANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_01_02_NHAMBAZA",
+    "message": "NHAMBAZA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_01_03_MASSUNGULO",
+    "message": "MASSUNGULO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_01_04_CHAVANE",
+    "message": "CHAVANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_01_BELA VISTA SEDE",
+    "message": "Sede Bela Vista",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_01_BELA VISTA",
+    "message": "Bela Vista",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_ADMIN_MO_06_MAPUTO",
+    "message": "ADMIN_MO_06_MAPUTO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_ADMIN_MO_07_MAPUTO CITY",
+    "message": "ADMIN_MO_07_CIDADE DE MAPUTO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_01_MATUTUINE",
+    "message": "Matutuine",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_01_01_NDUMBA",
+    "message": "NDUMBA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_01_02_MUBO",
+    "message": "MUBO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_01_03_MAGULUCO",
+    "message": "MAGULUCO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_01_04_CHANGAMBE",
+    "message": "CHANGAMBE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_01_BOANE SEDE",
+    "message": "Boane Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_01_BOANE VISTA",
+    "message": "Boane Vista",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_02_BOANE",
+    "message": "Boane",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_01_01_MACANE",
+    "message": "MACANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_01_02_MAZIVE",
+    "message": "MAZIVO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_01_03_MANGUNHANEII",
+    "message": "MANGUNHANEII",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_01_04_MAJACAZAI",
+    "message": "MAJACAZAI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_01_MARRACUENE SEDE",
+    "message": "Sede de Marracuene",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_01_MARRACUENEE",
+    "message": "Marracuenee",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_03_MARRACUENE",
+    "message": "Marracuene",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_01_01_MAPULANGA",
+    "message": "MAPULANGA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_01_02_NHAMACONDA",
+    "message": "NAMACONDA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_01_03_MASSINGA",
+    "message": "MASSINGA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_01_04_CHICHACHAEW",
+    "message": "CHICHACHAEW",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_01_MAGUDE SEDE",
+    "message": "Magude Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_01_MAGUDEE",
+    "message": "Magudee",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_04_MAGUDE",
+    "message": "Magude",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_05_01_01_01_MASSACANHE",
+    "message": "MASSACANHE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_05_01_01_02_MACALANGE",
+    "message": "MACALANGE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_05_01_01_MANHICA SEDE",
+    "message": "Sede de Manhiça",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_05_01_MANHICAE",
+    "message": "Manhiçae",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_05_MANHICA",
+    "message": "Manhiça",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_06_01_01_01_CHICUALACUALA",
+    "message": "CHICUALACUALA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_06_01_01_02_MASSIFUTA",
+    "message": "MASSIFUTA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_06_01_01_MOA SEDE",
+    "message": "Moa Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_06_01_MOAA",
+    "message": "Moaa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_06_MOA",
+    "message": "Moa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_07_01_01_01_CHIMUANA",
+    "message": "CHIMUANA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_07_01_01_02_NHAMATE",
+    "message": "NHAMATE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_07_01_01_NOME SEDE",
+    "message": "Nome Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_07_01_NOMEA",
+    "message": "Noméa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_07_NOME",
+    "message": "Nome",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_08_BOANEQ",
+    "message": "Boaneq",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_MAPUTO",
+    "message": "Maputo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_06_MAPUTO CITY",
+    "message": "Cidade de Maputo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_01_01_NHAGOLO",
+    "message": "NHAGOLO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_01_02_MAFALALA",
+    "message": "MAFALALA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_01_03_NHAMATCHUCO",
+    "message": "NHAMATCHUCO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_01_04_CHONWANE",
+    "message": "CHONWANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_01_KAMAXAQUENEB SEDE",
+    "message": "KaMaxaqueneb Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_01_KAMAXAQUENEB",
+    "message": "KaMaxaqueneb",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_01_CHICUANA",
+    "message": "CHICUANA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_02_MAQUIAVE",
+    "message": "MAQUIAVE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_03_NHAMATANDA",
+    "message": "NAMATANDA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_04_CHISSANE",
+    "message": "CHISSANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_05_CHIUUREE",
+    "message": "CHIUUREE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_06_CHIUUREE 1",
+    "message": "CHIUUREE 1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_07_CHIUUREE 2",
+    "message": "CHIUUREE 2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_08_CHIUUREE 3",
+    "message": "CHIUUREE 3",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_09_CHIUUREE 4",
+    "message": "CHIUUREE 4",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_10_MAPUTO",
+    "message": "MAPUTO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_11_CHIMBUNDE",
+    "message": "CHIMBUNDE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_12_CHIMAZI",
+    "message": "CHIMAZI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_01_KACHAMANCULO SEDE",
+    "message": "KaChamanculo Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_02_KACHAMANCULOO",
+    "message": "KaChamanculoo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_03_01_01_MASSAMBI",
+    "message": "MASSAMBI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_03_01_02_CHIMARIR",
+    "message": "CHIMARIR",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_03_01_KAMPFUMU SEDE",
+    "message": "KaMpfumu Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_03_KAMPFUMUU",
+    "message": "KaMpfumuu",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_ADMIN_MO_06_MAPUTO",
+    "message": "ADMIN_MO_06_MAPUTO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_ADMIN_MO_07_MAPUTO CITY",
+    "message": "ADMIN_MO_07_CIDADE DE MAPUTO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_01_KAMPFUMU",
+    "message": "KaMpfumu",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_01_01_NHAMAZANE",
+    "message": "NAMAZANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_01_02_MAZAMBIQUE",
+    "message": "MAZAMBIQUE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_01_03_CHINMARI",
+    "message": "CHINMARI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_01_04_CHIRINGU",
+    "message": "CHIRINGU",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_01_KAMAXAQUENE SEDE",
+    "message": "KaMaxaquene Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_01_KAMAXAQUENEA",
+    "message": "KaMaxaquenea",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_02_KAMAXAQUENE",
+    "message": "KaMaxaquene",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_MAPUTO",
+    "message": "Maputo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_07_MAPUTO CITY",
+    "message": "Cidade de Maputo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_01_01_01_MAPA",
+    "message": "MAPA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_01_01_02_CHICUZA",
+    "message": "CHICUZA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_01_01_03_CHANGANE",
+    "message": "CHANGANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_01_01_CHIBUTO SEDE",
+    "message": "Sede de Chibuto",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_01_CHIBUTOO",
+    "message": "Chibutoo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_ADMIN_MO_04_SOFALA",
+    "message": "ADMIN_MO_04_SOFALA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_ADMIN_MO_08_GAZA",
+    "message": "ADMIN_MO_08_GAZA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_01_CHIBUTO",
+    "message": "Chibuto",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_02_01_01_01_MACIA",
+    "message": "MÁCIA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_02_01_01_02_CHIBONGO",
+    "message": "CHIBONGO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_02_01_01_CHOKWE SEDE",
+    "message": "Sede de Chókwe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_02_01_CHOKWEE",
+    "message": "Chokwe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_02_CHOKWE",
+    "message": "Chókwe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_01_01_01_MASSANGENA",
+    "message": "MASSANGENA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_01_01_02_MABALANE",
+    "message": "MABALANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_01_01_03_CHIBALO",
+    "message": "CHIBALO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_01_01_GUIJA SEDE",
+    "message": "Guijá Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_01_GUIJAA",
+    "message": "Guijá",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_03_GUIJA",
+    "message": "Guijá",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_01_01_01_MACUACUA",
+    "message": "MACUACUÁ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_01_01_02_MASSINGIR",
+    "message": "MASSINGIR",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_01_01_03_MALE",
+    "message": "MACHO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_01_01_LIMPOPO SEDE",
+    "message": "Sede do Limpopo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_01_LIMPOPOQ",
+    "message": "Limpopoque",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_04_LIMPOPO",
+    "message": "Limpopo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_05_01_01_01_CHIDENGUELE",
+    "message": "CHIDENGUELE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_05_01_01_02_MACARRETANE",
+    "message": "MACARRETANO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_05_01_01_MANJACAZE SEDE",
+    "message": "Sede de Manjacaze",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_05_01_MANJACAZEE",
+    "message": "Manjacazee",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_05_MANJACAZE",
+    "message": "Manjacaze",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_01_01_01_CHILANGANA",
+    "message": "CHILANGANA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_01_01_02_MATIMBA",
+    "message": "MATIMBA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_01_01_03_CHICOMA",
+    "message": "CHICOMA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_01_01_XAI-XAI SEDE",
+    "message": "Sede de Xai-Xai",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_01_XAI-XAI PA",
+    "message": "Xai Xai PA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_06_XAI-XAI",
+    "message": "Xai Xai",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_07_01_01_01_MACHANGULO",
+    "message": "MACHANGULO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_07_01_01_MASSINGIR SEDE",
+    "message": "Sede de Massingir",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_07_01_MASSINGIR PA",
+    "message": "Massingir-PA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_07_MASSINGIR",
+    "message": "Massingir",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_08_01_01_01_CHIGUBO",
+    "message": "CHIGUBO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_08_01_01_02_MAPAI",
+    "message": "MAPAI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_08_01_01_MABALANE SEDE",
+    "message": "Mabalane Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_08_01_MABALANEE",
+    "message": "Mabalanee",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_08_MABALANE",
+    "message": "Mabalane",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_09_01_01_01_MASSACHO",
+    "message": "MASSACHO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_09_01_01_02_MACANETA",
+    "message": "MACANETA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_09_01_01_BILENE SEDE",
+    "message": "Bilene Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_09_01_BILENEE",
+    "message": "Bileneu",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_09_BILENE",
+    "message": "Bilene",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_10_01_01_CHICUALACUALA SEDE",
+    "message": "Chicualacuala Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_10_01_CHICUALACUALA",
+    "message": "Chicualacuala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_10_CHICUALACUALAE",
+    "message": "Chicualacualae",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_GAZA",
+    "message": "Gaza",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_08_SOFALA",
+    "message": "Sofala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_01_01_01_MASSINGA",
+    "message": "MASSINGA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_01_01_02_CHACAME",
+    "message": "CHACAMÉ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_01_01_03_CHIBUTO",
+    "message": "CHIBUTO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_01_01_INHARRIME SEDE",
+    "message": "Sede de Inharrime",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_01_INHARRIME",
+    "message": "Inharrime",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_ADMIN_MO_02_CABO",
+    "message": "ADMIN_MO_02_CABO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_ADMIN_MO_10_ZAMBEZIA",
+    "message": "ADMIN_MO_10_ZAMBÉZIA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_01_INHARRIMEA",
+    "message": "Inharrimea",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_01_MASSACATE",
+    "message": "MASSACATE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_02_CHIDENGUELE",
+    "message": "CHIDENGUELE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_03_CHICUZAI",
+    "message": "CHICUZAI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_04_CHIBUTO1",
+    "message": "CHIBUTO1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_05_CHIMACUALAA",
+    "message": "CHIMACUALAA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_06_MASSINGAI",
+    "message": "MASSINGAI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_07_MACUANE11",
+    "message": "MACUANE11",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_01_JANGAMO SEDE",
+    "message": "Jangamo Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_ADMIN_MO_10_02_NAISSAE",
+    "message": "ADMIN_MO_10_02_NAISSAE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_01_JANGAMO",
+    "message": "Jangamo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_JANGAMOO",
+    "message": "Jangamoo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_02_NAISSAE",
+    "message": "Naissae",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_01_MACUACHENE",
+    "message": "MACUACHENE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_02_CHICOMO",
+    "message": "CHICOMO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_03_CHICOAA",
+    "message": "CHICOAA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_04_MACUANEEE",
+    "message": "MACUANEEE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_05_MASSINGIRI",
+    "message": "MASSINGIRI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_06_CHIBUTOOO",
+    "message": "CHIBUTOOO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_01_MASSINGA SEDE",
+    "message": "Sede de Massinga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_ADMIN_MO_10_01_ALTO MOLOCULE",
+    "message": "ADMIN_MO_10_01_ALTO MOLÓCULA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_01_MASSINGA",
+    "message": "Massinga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_ALTO MOLOCULE",
+    "message": "Alto Molóculo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_03_MASSINGAA",
+    "message": "Massinga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_01_01_01_MUABSA",
+    "message": "MUABSA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_01_01_02_CHIMBONE",
+    "message": "CHIMBONE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_01_01_03_MACUANE",
+    "message": "MACUANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_01_01_MAXIXE SEDE",
+    "message": "Maxixe Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_01_MAXIXE",
+    "message": "Maxixe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_04_MAXIXEE",
+    "message": "Maxixee",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_01_01_01_CHICOA",
+    "message": "CHICOA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_01_01_02_CHICUALACUALA",
+    "message": "CHICUALACUALA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_01_01_03_MALIPA",
+    "message": "MALIPA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_01_01_FUNHALOURO SEDE",
+    "message": "Funhalouro Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_01_FUNHALOURO",
+    "message": "Funhalouro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_05_FUNHALOUROA",
+    "message": "Funhalouroa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_06_01_01_01_MACATANE",
+    "message": "MACATÂNE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_06_01_01_02_CHIMACUALA",
+    "message": "CHIMACULA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_06_01_01_INHASSORO SEDE",
+    "message": "Sede de Inhassoro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_06_01_INHASSORO",
+    "message": "Inhassoro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_06_INHASSOROE",
+    "message": "Inhassoroe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_01_01_01_CHIMANCHE",
+    "message": "CHIMANCHE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_01_01_02_MACHANGULO",
+    "message": "MACHANGULO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_01_01_03_MAPAI",
+    "message": "MAPAI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_01_01_MABOTE SEDE",
+    "message": "Sede de Mabote",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_01_MABOTE",
+    "message": "Mabote",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_07_MABOTEE",
+    "message": "Mabotee",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_08_01_01_01_CHINAMANI",
+    "message": "CHINAMANIA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_08_01_01_02_MASSACA",
+    "message": "MASSACA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_08_01_01_VILANCULOS SEDE",
+    "message": "Sede de Vilanculos",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_08_01_VILANCULOS",
+    "message": "Vilanculos",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_08_VILANCULOSE",
+    "message": "Vilanculose",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_09_01_01_01_MABALANE",
+    "message": "MABALANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_09_01_01_02_MASSINGIR",
+    "message": "MASSINGIR",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_09_01_01_ZAVALA SEDE",
+    "message": "Zavala Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_09_01_ZAVALA",
+    "message": "Zavala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_09_ZAVALAA",
+    "message": "Zavalaa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_10_FUNHALOUROE",
+    "message": "Funhalouroe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_CABO",
+    "message": "Cabo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_INHAMBANE",
+    "message": "Inhambane",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_09_ZAMBEZIA",
+    "message": "Zambézia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_01_LOCATION1",
+    "message": "Localização1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_02_LOCATION2",
+    "message": "Localização2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_03_LOCATION3",
+    "message": "Localização3",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_04_LOCATION4",
+    "message": "Localização4",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_05_LOCATION5",
+    "message": "Localização5",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_06_LOCATION6",
+    "message": "Localização6",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_07_LOCATION7",
+    "message": "Localização7",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_08_LOCATION8",
+    "message": "Localização8",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_09_LOCATION9",
+    "message": "Localização9",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_10_LOCATION10",
+    "message": "Localização10",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_01_ALTO MOLOCUE SEDE",
+    "message": "Sede do Alto Molócué",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_01_ALTO MOLOCUE",
+    "message": "Alto Molócué",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_ADMIN_MO_01_NAMPULA",
+    "message": "ADMIN_MO_01_NAMPULA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_ADMIN_MO_09_INHAMBANE",
+    "message": "ADMIN_MO_09_INHAMBANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_01_ALTO MOLOCULE",
+    "message": "Alto Molóculo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_01_REGION1",
+    "message": "Região1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_02_REGION2",
+    "message": "Região2",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_03_REGION3",
+    "message": "Região3",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_04_REGION4",
+    "message": "Região4",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_05_REGION5",
+    "message": "Região5",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_06_REGION6",
+    "message": "Região6",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_07_REGION7",
+    "message": "Região7",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_08_REGION8",
+    "message": "Região8",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_09_REGION9",
+    "message": "Região9",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_10_REGION10",
+    "message": "Região10",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_11_REGION11",
+    "message": "Região11",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_12_REGION12",
+    "message": "Região12",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_13_REGION13",
+    "message": "Região13",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_14_REGION14",
+    "message": "Região14",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_15_REGION15",
+    "message": "Região15",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_16_REGION16",
+    "message": "Região16",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_17_REGION17",
+    "message": "Região17",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_18_REGION18",
+    "message": "Região18",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_19_REGION19",
+    "message": "Região19",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_20_REGION20",
+    "message": "Região20",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_21_REGION21",
+    "message": "Região21",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_22_REGION22",
+    "message": "Região22",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_23_REGION23",
+    "message": "Região23",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_24_REGION24",
+    "message": "Região24",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_25_REGION25",
+    "message": "Região25",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_26_REGION26",
+    "message": "Região26",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_27_REGION27",
+    "message": "Região27",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_28_REGION28",
+    "message": "Região28",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_29_REGION29",
+    "message": "Região29",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_30_REGION30",
+    "message": "Região30",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_01_NAISSA SEDE",
+    "message": "Naissa Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_01_NAISSA",
+    "message": "Naissa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_02_NAISSAE",
+    "message": "Naissae",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_INHAMBANE",
+    "message": "Inhambane",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_NAMPULA",
+    "message": "Nampula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_10_ZAMBEZIA",
+    "message": "Zambézia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_01_VILLAGEONE",
+    "message": "VilaOne",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_02_VILLAGETWO",
+    "message": "VillageTwo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_03_VILLAGETHREE",
+    "message": "Aldeia Três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_04_VILLAGEFOUR",
+    "message": "VillageFour",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_05_VILLAGEFIVE",
+    "message": "VillageFive",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_06_VILLAGESIX",
+    "message": "VillageSix",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_07_VILLAGESEVEN",
+    "message": "VillageSeven",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_08_VILLAGEEIGHT",
+    "message": "VillageEight",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_09_VILLAGENINE",
+    "message": "VillageNine",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_10_VILLAGETEN",
+    "message": "VillageTen",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_11_VILLAGEELEVEN",
+    "message": "VillageEleven",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_12_VILLAGETWELVE",
+    "message": "VillageTwelve",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_01_LOCALITYONE",
+    "message": "LocalidadeUm",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_01_VILLAGETHIRTEEN",
+    "message": "Aldeia Treze",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_02_VILLAGEFOURTEEN",
+    "message": "Aldeia Quatorze",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_03_VILLAGEFIFTEEN",
+    "message": "Aldeia Quinze",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_04_VILLAGESIXTEEN",
+    "message": "Aldeia Dezesseis",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_05_VILLAGESEVENTEEN",
+    "message": "Vila Dezessete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_06_VILLAGEEIGHTEEN",
+    "message": "Aldeia Dezoito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_07_VILLAGENINETEEN",
+    "message": "Vila Dezenove",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_08_VILLAGETWENTY",
+    "message": "VillageTwenty",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_09_VILLAGETWENTY-ONE",
+    "message": "VillageTwenty-one",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_10_VILLAGETWENTY-TWO",
+    "message": "VillageTwenty-two",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_11_VILLAGETWENTY-THREE",
+    "message": "VillageTwenty-três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_12_VILLAGETWENTY-FOUR",
+    "message": "VillageTwenty-four",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_02_LOCALITYTWO",
+    "message": "Localidade Dois",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_01_VILLAGETWENTY-FIVE",
+    "message": "VillageTwenty-five",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_02_VILLAGETWENTY-SIX",
+    "message": "Vila Vinte e seis",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_03_VILLAGETWENTY-SEVEN",
+    "message": "Vila Vinte e Sete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_04_VILLAGETWENTY-EIGHT",
+    "message": "VillageTwenty-eight",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_05_VILLAGETWENTY-NINE",
+    "message": "Vila Vinte e nove",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_06_VILLAGETHIRTY",
+    "message": "Aldeia Trinta",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_07_VILLAGETHIRTY-ONE",
+    "message": "Aldeia Trinta e Um",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_08_VILLAGETHIRTY-TWO",
+    "message": "Aldeia Trinta e Dois",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_09_VILLAGETHIRTY-THREE",
+    "message": "Aldeia Trinta e Três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_10_VILLAGETHIRTY-FOUR",
+    "message": "Aldeia Trinta e Quatro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_11_VILLAGETHIRTY-FIVE",
+    "message": "VillageTrinta e cinco",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_12_VILLAGETHIRTY-SIX",
+    "message": "Aldeia Trinta e seis",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_03_LOCALITYTHREE",
+    "message": "Localidade Três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_01_POST ADMINISTRATIVEONE",
+    "message": "Pós AdministrativoUm",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_01_VILLAGETHIRTY-SEVEN",
+    "message": "Aldeia Trinta e Sete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_02_VILLAGETHIRTY-EIGHT",
+    "message": "VillageTrinta e oito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_03_VILLAGETHIRTY-NINE",
+    "message": "Aldeia Trinta e nove",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_04_VILLAGEFORTY",
+    "message": "VillageForty",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_05_VILLAGEFORTY-ONE",
+    "message": "VillageQuarenta e um",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_06_VILLAGEFORTY-TWO",
+    "message": "VillageQuarenta e dois",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_07_VILLAGEFORTY-THREE",
+    "message": "VillageQuarenta e três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_08_VILLAGEFORTY-FOUR",
+    "message": "VillageQuarenta e quatro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_09_VILLAGEFORTY-FIVE",
+    "message": "VillageQuarenta e cinco",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_10_VILLAGEFORTY-SIX",
+    "message": "VillageQuarenta e seis",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_11_VILLAGEFORTY-SEVEN",
+    "message": "VillageQuarenta e sete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_12_VILLAGEFORTY-EIGHT",
+    "message": "VillageQuarenta e oito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_01_LOCALITYFOUR",
+    "message": "LocalityFour",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_01_VILLAGEFORTY-NINE",
+    "message": "VillageQuarenta e nove",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_02_VILLAGEFIFTY",
+    "message": "VillageFifty",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_03_VILLAGEFIFTY-ONE",
+    "message": "VillageFifty-one",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_04_VILLAGEFIFTY-TWO",
+    "message": "VillageFifty e dois",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_05_VILLAGEFIFTY-THREE",
+    "message": "VillageFifty-três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_06_VILLAGEFIFTY-FOUR",
+    "message": "VillageFifty-four",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_07_VILLAGEFIFTY-FIVE",
+    "message": "VillageFifty-five",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_08_VILLAGEFIFTY-SIX",
+    "message": "VillageFifty e seis",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_09_VILLAGEFIFTY-SEVEN",
+    "message": "VillageFifty e sete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_10_VILLAGEFIFTY-EIGHT",
+    "message": "VillageFifty-eight",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_11_VILLAGEFIFTY-NINE",
+    "message": "VillageFifty-nine",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_12_VILLAGESIXTY",
+    "message": "VillageSixty",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_02_LOCALITYFIVE",
+    "message": "LocalityFive",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_02_POST ADMINISTRATIVETWO",
+    "message": "Pós Administrativo Dois",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_ADMIN_MO_11_TEST PROVINCE",
+    "message": "ADMIN_MO_11_TEST PROVINCE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_ADMIN_MO_11_TETE",
+    "message": "ADMIN_MO_11_TETE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_01_DISTRICTONE",
+    "message": "Distrito Um",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_01_VILLAGESIXTY-ONE",
+    "message": "VillageSessenta e um",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_02_VILLAGESIXTY-TWO",
+    "message": "VillageSessenta e dois",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_03_VILLAGESIXTY-THREE",
+    "message": "VillageSessenta e três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_04_VILLAGESIXTY-FOUR",
+    "message": "VillageSessenta e quatro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_05_VILLAGESIXTY-FIVE",
+    "message": "VillageSessenta e cinco",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_06_VILLAGESIXTY-SIX",
+    "message": "VillageSessenta e seis",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_07_VILLAGESIXTY-SEVEN",
+    "message": "VillageSessenta e sete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_08_VILLAGESIXTY-EIGHT",
+    "message": "VillageSessenta e oito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_09_VILLAGESIXTY-NINE",
+    "message": "VillageSessenta e nove",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_10_VILLAGESEVENTY",
+    "message": "Aldeia Setenta",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_11_VILLAGESEVENTY-ONE",
+    "message": "Village Seventy-one",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_12_VILLAGESEVENTY-TWO",
+    "message": "Village Seventy-two",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_01_LOCALITYSIX",
+    "message": "LocalitySix",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_01_VILLAGESEVENTY-THREE",
+    "message": "Aldeia Setenta e três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_02_VILLAGESEVENTY-FOUR",
+    "message": "Aldeia Setenta e quatro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_03_VILLAGESEVENTY-FIVE",
+    "message": "Aldeia Setenta e cinco",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_04_VILLAGESEVENTY-SIX",
+    "message": "Aldeia Setenta e seis",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_05_VILLAGESEVENTY-SEVEN",
+    "message": "Aldeia Setenta e Sete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_06_VILLAGESEVENTY-EIGHT",
+    "message": "Village Seventy-eight",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_07_VILLAGESEVENTY-NINE",
+    "message": "Aldeia Setenta e nove",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_02_LOCALITYSEVEN",
+    "message": "LocalidadeSete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_01_POST ADMINISTRATIVETHREE",
+    "message": "Pós-Administrativo Três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_01_VILLAGEEIGHTY",
+    "message": "VillageEighty",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_02_VILLAGEEIGHTY-ONE",
+    "message": "VillageEighty-one",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_03_VILLAGEEIGHTY-TWO",
+    "message": "VillageEighty e dois",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_04_VILLAGEEIGHTY-THREE",
+    "message": "VillageOitenta e três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_05_VILLAGEEIGHTY-FOUR",
+    "message": "VillageOitenta e quatro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_06_VILLAGEEIGHTY-FIVE",
+    "message": "VillageOitenta e cinco",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_07_VILLAGEEIGHTY-SIX",
+    "message": "VillageOitenta e seis",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_08_VILLAGEEIGHTY-SEVEN",
+    "message": "VillageOitenta e sete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_09_VILLAGEEIGHTY-EIGHT",
+    "message": "VillageEighty-eight",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_10_VILLAGEEIGHTY-NINE",
+    "message": "Aldeia Oitenta e nove",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_01_LOCALITYEIGHT",
+    "message": "LocalityEight",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_01_VILLAGENINETY",
+    "message": "VillageNinety",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_02_VILLAGENINETY-ONE",
+    "message": "Aldeia Noventa e um",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_03_VILLAGENINETY-TWO",
+    "message": "Aldeia Noventa e dois",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_04_VILLAGENINETY-THREE",
+    "message": "Aldeia Noventa e três",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_05_VILLAGENINETY-FOUR",
+    "message": "Aldeia Noventa e quatro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_06_VILLAGENINETY-FIVE",
+    "message": "Aldeia Noventa e cinco",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_07_VILLAGENINETY-SIX",
+    "message": "Aldeia Noventa e seis",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_08_VILLAGENINETY-SEVEN",
+    "message": "Aldeia Noventa e sete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_09_VILLAGENINETY-EIGHT",
+    "message": "Aldeia Noventa e oito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_10_VILLAGENINETY-NINE",
+    "message": "Aldeia Noventa e nove",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_02_LOCALITYNINE",
+    "message": "LocalityNine",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_02_POST ADMINISTRATIVEFOUR",
+    "message": "Pós AdministrativoQuatro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_02_DISTRICTTWO",
+    "message": "Distrito Dois",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_TEST PROVINCE",
+    "message": "Província de teste",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_11_TETER",
+    "message": "Teter",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_01_01_01_MURO",
+    "message": "MURO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_01_01_02_CHIRIMBU",
+    "message": "CHIRIMBU",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_01_01_KANSENGWA SEDE",
+    "message": "Sede de Kansengwa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_01_KANSENGWA",
+    "message": "Kansengwa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_ADMIN_MO_12_TETE",
+    "message": "ADMIN_MO_12_TETE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_MOATIZE",
+    "message": "Moatize",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_01_MOATIZE ",
+    "message": "Moatize",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_01_01_01_NHATE",
+    "message": "NHATE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_01_01_02_MATCHESSA",
+    "message": "MATCHESSA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_01_01_ULONGUE SEDE",
+    "message": "Sede de Ulongue",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_01_ADMIN_MO_12_01_MOATIZE",
+    "message": "ADMIN_MO_12_01_MOATIZE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_01_ULONGUE",
+    "message": "Ulongue",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_ANGÓNIA",
+    "message": "Angónia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_02_MOATIZE",
+    "message": "Moatize",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_01_01_01_MAROE",
+    "message": "MAROE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_01_01_02_MUJA",
+    "message": "MUJA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_01_01_FURANCUNGO SEDE",
+    "message": "Furancungo Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_01_ADMIN_MO_12_02_ANGÓNIA",
+    "message": "ADMIN_MO_12_02_ANGÓNIA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_01_FURANCUNGO",
+    "message": "Furancungo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_02_01_01_NHAYARA",
+    "message": "NHAYARA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_02_01_02_CHILEMBO",
+    "message": "CHILEMBO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_02_01_MULANGUANE SEDE",
+    "message": "Sede de Mulanguane",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_02_MULANGUANE",
+    "message": "Mulanguane",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_ANGÓNIA",
+    "message": "Angónia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_03_TSANGANO",
+    "message": "Tsangano",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_01_01_01_SAMBINDA",
+    "message": "SAMBINDA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_01_01_02_MACHURO",
+    "message": "MACHURO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_01_01_CHITIMA SEDE",
+    "message": "Chitima Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_01_ADMIN_MO_12_03_TSANGANO",
+    "message": "ADMIN_MO_12_03_TSANGANO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_01_CHITIMA",
+    "message": "Chitima",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_02_01_01_MATCHIME",
+    "message": "JOGO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_02_01_02_MACAIA",
+    "message": "MACAIA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_02_01_MARARA SEDE",
+    "message": "Marara Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_02_MARARA",
+    "message": "Marara",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_CAHORA BASSA",
+    "message": "Cahora Bassa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_04_TSANGANO",
+    "message": "Tsangano",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_01_01_01_NHANDE",
+    "message": "NHANDE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_01_01_02_MACAMBULA",
+    "message": "MACAMBULA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_01_01_KAFUNFO SEDE",
+    "message": "Kafunfo Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_01_ADMIN_MO_12_04_CAHORA BASSA",
+    "message": "ADMIN_MO_12_04_CAHORA BASSA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_01_KAFUNFO",
+    "message": "Kafunfo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_02_01_01_MACOCHA",
+    "message": "MACOCHA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_02_01_02_NHAMADA",
+    "message": "NHAMADA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_02_01_SONGO SEDE",
+    "message": "Songo Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_02_SONGO",
+    "message": "Songo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_03_01_01_NHAMISSENGUE",
+    "message": "NHAMISSENGUE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_03_01_02_MACAPA",
+    "message": "MACAPÁ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_03_01_MANDIE SEDE",
+    "message": "Mandie Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_03_MANDIE",
+    "message": "Mandie",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_CAHORA BASSA",
+    "message": "Cahora Bassa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_05_CHIUTA",
+    "message": "Chiuta",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_01_01_01_CHILUCA",
+    "message": "CHILUCA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_01_01_02_CHIMBUNDE",
+    "message": "CHIMBUNDE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_01_01_CHARRE SEDE",
+    "message": "Charre Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_01_ADMIN_MO_12_05_CHIUTA",
+    "message": "ADMIN_MO_12_05_CHIUTA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_01_CHARRE",
+    "message": "Charré",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_02_01_01_MAZANE",
+    "message": "MAZANE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_02_01_02_MACUE",
+    "message": "MACUE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_02_01_NHAMPOSSA SEDE",
+    "message": "Sede de Nhampossa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_02_NHAMPOSSA",
+    "message": "Nhampossa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_CHIUTA",
+    "message": "Chiuta",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_06_MAGOE",
+    "message": "Magoe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_01_01_01_CHIMUQUE",
+    "message": "CHIMUQUE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_01_01_02_NHAFUCO",
+    "message": "NHAFUCO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_01_01_MURROTHONE SEDE",
+    "message": "Sede Murrothone",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_01_ADMIN_MO_12_06_MAGOE",
+    "message": "ADMIN_MO_12_06_MAGOE",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_01_MURROTHONE",
+    "message": "Murrothone",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_02_01_01_MACHIPO",
+    "message": "MACHIPO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_02_01_02_CHIMBENGA",
+    "message": "CHIMBENGA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_02_01_CAFUMPA SEDE",
+    "message": "Cafumpa Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_02_CAFUMPA",
+    "message": "Cafumpa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_03_01_01_MACHAMBA",
+    "message": "MACAMBA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_03_01_02_MACARULA",
+    "message": "MACARULA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_03_01_INHAMGOMA SEDE",
+    "message": "Sede de Inhamgoma",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_03_INHAMGOMA",
+    "message": "Inhamgoma",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_MAGOE",
+    "message": "Magoe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_07_MUTARARA",
+    "message": "Mutarara",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_01_01_01_MALENGA",
+    "message": "MALENGA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_01_01_02_NHAURAO",
+    "message": "NHAURAO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_01_01_LUCALA SEDE",
+    "message": "Lucala Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_01_ADMIN_MO_12_07_MUTARARA",
+    "message": "ADMIN_MO_12_07_MUTARARA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_01_LUCALA",
+    "message": "Lucala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_CHANGARA",
+    "message": "Changara",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_08_MUTARARA",
+    "message": "Mutarara",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_01_01_01_NHAMAMBA",
+    "message": "NAMAMBA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_01_01_02_MACOTI",
+    "message": "MACOTI",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_01_01_CHIFUNDE SEDE",
+    "message": "Chifunde Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_01_ADMIN_MO_12_08_CHANGARA",
+    "message": "ADMIN_MO_12_08_CHANGARA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_01_CHIFUNDE",
+    "message": "Chifunde",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_02_01_01_NHATHANDA",
+    "message": "NATHANDA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_02_01_02_CHIRINDA",
+    "message": "CHIRINDA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_02_01_NDIMA SEDE",
+    "message": "Ndima Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_02_NDIMA",
+    "message": "Ndima",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_CHANGARA",
+    "message": "Changara",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_09_MACANGA",
+    "message": "Macanga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_10_01_ADMIN_MO_12_09_MACANGA",
+    "message": "ADMIN_MO_12_09_MACANGA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_10_MACANGA",
+    "message": "Macanga",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_11_01_01_01_MAVERA",
+    "message": "MAVERA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_11_01_01_02_NYAMPANDA",
+    "message": "NYAMPANDA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_11_01_01_MUCUMBURA SEDE",
+    "message": "Sede de Mucumbura",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_11_01_MUCUMBURA",
+    "message": "Mucumbura",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_11_ZUMBO",
+    "message": "Zumbo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_12_01_01_01_CHAVITSA",
+    "message": "CHAVITSA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_12_01_01_02_NHASSANGWA",
+    "message": "NHASSANGWA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_12_01_01_CHINTHOLO SEDE",
+    "message": "Chintholo Sede",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_12_01_CHINTHOLO",
+    "message": "Chintholo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_12_CHIFUNDE",
+    "message": "Chifunde",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_13_01_01_01_NHAMUCANDA",
+    "message": "NAMUCANDA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_13_01_01_02_MATARARA",
+    "message": "MATARARA",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_13_01_01_NHAMAYABWE SEDE",
+    "message": "Sede de Nhamayabwe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_13_01_NHAMAYABWE",
+    "message": "Nhamayabwe",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_13_DÔA",
+    "message": "Dôa",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_MO_12_TETE",
+    "message": "Tete",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_POST ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_POSTO ADMINISTRATIVO",
+    "message": "Pós-administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_PROVINCIA",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_STATE",
+    "message": "Estado",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AGE",
+    "message": "Idade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AU_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.Country",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.Distrito",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.Localidade",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.Post Administrativo",
+    "message": "Pós Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.PostAdministrativo",
+    "message": "Pós Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Admin9.State",
+    "message": "Estado",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1",
+    "message": "Baixando modelos do Excel para definição de metas:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Baixe o modelo Excel clicando no botão “Baixar modelo”.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Abra o modelo Excel que foi baixado na etapa anterior e a primeira planilha que você verá é uma planilha “Leia-me”. As restantes folhas serão nomeadas de acordo com o nome dos distritos seleccionados no passo “Selecção de Limites”, tendo cada folha de distrito uma lista de todas as aldeias mapeadas para esse distrito.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2",
+    "message": "Definir metas após o download do modelo:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_1",
+    "message": "Vá para a ficha do distrito para o qual deseja definir metas e adicione números na coluna “Metas” para cada Aldeia. ",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Insira as metas para cada aldeia na ficha de cada distrito na coluna “Meta ao nível do limite seleccionado”. Se alguma aldeia não tiver metas definidas, a ficha terá erros.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Target” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3",
+    "message": "Casos de erros comuns:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Se o usuário não tiver definido metas para cada aldeia, o sistema gerará um erro com o número da linha onde as metas estão faltando.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Se o usuário excluir qualquer aldeia da planilha ou excluir uma planilha distrital completa e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_HEADER_3_DESC_3",
+    "message": "Se o usuário excluir qualquer um dos cabeçalhos da planilha e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_README_MAINHEADER",
+    "message": "Leia-me instruções para upload de destino",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_HOUSEHOLD_LABEL",
+    "message": "Número de mosquiteiros por domicílio",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BEDNET_INDIVIDUAL_LABEL",
+    "message": "Número de indivíduos por mosquiteiro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_BEFORE_ERROR",
+    "message": "A data de término da campanha não pode ser anterior à data de início da campanha.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE_ERROR",
+    "message": "Campo obrigatório!",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_FIELD_MANDATORY",
+    "message": "Campo obrigatório!",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE_ERROR",
+    "message": "Campo obrigatório!",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CC_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_MZ_capacity",
+    "message": "Capacidade (Unidades: Fardos)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIM_mz_capacity",
+    "message": "Capacidade (Unidades: Fardos)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_LLIN_mz_capacity",
+    "message": "Capacidade (Unidades: Fardos)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN__capacity",
+    "message": "Capacidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_MR_DN_capacity",
+    "message": "Capacidade (Unidades: Blister SPAQ)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_boundaryCode",
+    "message": "Código de limite de captação (obrigatório)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityUsage",
+    "message": "Uso das instalações",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EDIT_MICROPLANS_TEXT",
+    "message": "Editar microplano",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EQUAL_TO",
+    "message": "igual a",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_LOADING_BASE_MAP",
+    "message": "Não é possível encontrar o mapa base necessário. Entre em contato com o administrador.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_READ_ME_MISSING",
+    "message": "Por favor, não altere os nomes das planilhas.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_CAMPAIGN_TIMELINE",
+    "message": "Linha do tempo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_1",
+    "message": "Se não houver instalações disponíveis para seleção, a aba “Lista de instalações disponíveis” no modelo estará vazia. Para criar novos dados de instalação, adicione o nome do Nome da Instalação, Tipo de Instalação, Status da Instalação, Capacidade. A coluna “Código da Instalação” precisa ser deixada em branco se esta for uma instalação nova. Caso se trate de uma instalação sendo reaproveitada (que fica disponível no template após o download) o usuário só precisa realizar o passo 2.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Para mapear a instalação para o limite correto, o usuário precisa copiar o código de limite correto do limite da planilha “Lista de Limites de Campanha” para a qual a instalação precisa ser mapeada. Se houver uma instalação mapeada para vários limites, o administrador do sistema terá que adicionar os códigos de limite de todos os limites para os quais a instalação está mapeada, separando-os por vírgulas na célula para adicionar códigos de limite para essa instalação.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1",
+    "message": "Baixando modelos do Excel para configuração de instalações:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Baixe o modelo Excel clicando no botão “Baixar modelo”.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Abra o modelo que foi baixado na etapa anterior e terá 3 planilhas e a primeira planilha que você verá é uma planilha “Leia-me”. A segunda Folha denominada “Lista de Instalações Disponíveis” conterá uma lista de todas as instalações disponíveis que podem ser utilizadas na campanha. Se não houver nenhuma facilidade disponível, esta folha estará vazia. A terceira folha será denominada “Lista de Limites de Campanha“ que conterá todos os limites com seus respectivos Códigos de Limites.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2",
+    "message": "Criar novos dados de instalações/usar dados de instalações existentes após o download do modelo:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "Se não houver instalações disponíveis para seleção, a aba “Lista de instalações disponíveis” no modelo estará vazia. Para criar novos dados de instalação, adicione o nome do Nome da Instalação, Tipo de Instalação, Status da Instalação, Capacidade. A coluna “Código da Instalação” precisa ser deixada em branco se esta for uma instalação nova. Caso se trate de uma instalação sendo reaproveitada (que fica disponível no template após o download) o usuário só precisa realizar o passo 2.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Para mapear a instalação para o limite correto, o usuário precisa copiar o código de limite correto do limite da planilha “Lista de Limites de Campanha” para a qual a instalação precisa ser mapeada. Se houver uma instalação mapeada para vários limites, o administrador do sistema terá que adicionar os códigos de limite de todos os limites para os quais a instalação está mapeada, separando-os por vírgulas na célula para adicionar códigos de limite para essa instalação.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Facility Data” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_5",
+    "message": "Desativando Instalações existentes para uma campanha.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_6",
+    "message": "Depois que o usuário tiver baixado o modelo para instalações, se o sistema tiver dados de instalações existentes para serem reutilizados, o modelo será pré-preenchido com essa lista de instalações.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_DESC_7",
+    "message": "Se o usuário optar por não usar instalações específicas, ele poderá excluir as linhas de dados dessas instalações específicas que precisam ser removidas e carregar a planilha apenas com as instalações necessárias para a campanha com os códigos de limite corretos mapeados para essas instalações.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1",
+    "message": "Caso em que não há dados da instalação no sistema:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_1",
+    "message": "Passo 1: Quando não houver dados de instalações no sistema, o modelo “Lista de instalações disponíveis” estará vazio. Para cada instalação adicionada, o usuário precisa inserir o nome da instalação (deve ser exclusivo), tipo de instalação (armazém/instalação de saúde), status da instalação (temporário/permanente), capacidade (entrada de número)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_2",
+    "message": "Passo 2: Para mapear as instalações para um determinado limite, o usuário precisa copiar o Código do Limite correto da planilha “Dados do Limite”. Se houver mais de um limite para o qual uma instalação precisa ser mapeada, o usuário poderá adicionar todos os códigos de limite separados por vírgulas",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_3",
+    "message": "Etapa 3: Para cada instalação, o usuário precisa adicionar Ativo ou Inativo para todas as instalações na coluna “Uso da Instalação”. Todas as Instalações marcadas como “Ativas” serão utilizadas na campanha que está sendo criada, as marcadas como “Inativas” não serão utilizadas na campanha que está sendo criada.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_1_DESC_4",
+    "message": "Passo 4: Depois que todas as facilidades forem adicionadas, o usuário precisa salvar o arquivo em seu sistema e fazer upload do arquivo pressionando a opção “Navegar em Meus Arquivos”.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2",
+    "message": "Caso em que existem dados de instalações existentes no sistema:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_1",
+    "message": "Passo 1: Ao abrir o modelo de instalação baixado, consulte a folha Lista de instalações disponíveis. Para instalações existentes, adicione entradas na coluna Código de limite. Você pode encontrar os códigos de limite na planilha Dados de limite. Se uma instalação mapear vários limites, separe os códigos com vírgulas.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_2",
+    "message": "Etapa 2: nesta etapa, o usuário terá que adicionar entradas na coluna Uso da instalação com entradas válidas sendo Ativas ou Inativas, onde o usuário pode definir o uso de uma instalação como Ativo se a instalação estiver sendo usada para uma campanha ou então pode ser definido como Inativo. As entradas na coluna Uso da Instalação precisam ser adicionadas para todas as entradas.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_3",
+    "message": "Etapa 3: Para adicionar novas instalações que não estão presentes na lista de instalações existentes, o usuário precisa inserir o nome da instalação (deve ser exclusivo), tipo de instalação (armazém/instalação de saúde), status da instalação (temporário/permanente), capacidade (Entrada de número), Código de limite (da Folha de dados de limite) e Uso da instalação (Ativo/Inativo), conforme explicado anteriormente",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_2_SUB_2_DESC_4",
+    "message": "Passo 4: Depois que todas as facilidades forem adicionadas, o usuário precisa salvar o arquivo em seu sistema e fazer upload do arquivo pressionando a opção “Navegar em Meus Arquivos”.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3",
+    "message": "Casos de erros comuns:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Se o usuário tiver removido os códigos de instalação de uma instalação existente na lista, o sistema criará uma instalação duplicada com esses valores de coluna.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Se o usuário excluir alguma coluna da “Lista de Instalações Disponíveis” da planilha e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_HEADER_3_DESC_3",
+    "message": "Se o usuário excluir algum dos cabeçalhos da planilha e carregá-la, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_README_MAINHEADER",
+    "message": "Leia-me as instruções para upload de instalações",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FEMALE",
+    "message": "Fêmea",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FROM",
+    "message": "de",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GENDER",
+    "message": "Gênero",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GREATER_THAN",
+    "message": "maior que",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GREATER_THAN_EQUAL_TO",
+    "message": "maior ou igual a",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_COUNTRY_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POST ADMINISTRATIVO",
+    "message": "Pós Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_POSTO ADMINISTRATIVO",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM-MOZ-HIERARCHY_PROVINCIA",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_AVAILABLE_FACILITIES",
+    "message": "Lista de instalações disponívei",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
+    "message": "Código de limite",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY",
+    "message": "Código de limite (obrigatório)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY_ERROR",
+    "message": "é inválido. Deve ser retirado da planilha 'Dados de limite'",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_CODE_OLD",
+    "message": "Código de limite antigo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
+    "message": "Dados de limite",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITIES",
+    "message": "Lista de instalações",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY",
+    "message": "Capacidade (Unidades: Fardos para redes mosquiteiras/ Blister SPAQ para SMC)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_ERROR",
+    "message": "não deve estar vazio e deve ser um número de 1 a 10 milhões",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN",
+    "message": "Capacidade (Unidades: Fardos para redes mosquiteiras/",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_LLIN-mz",
+    "message": "Capacidade (Unidades: Fardos)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CAPACITY_MICROPLAN_MR-DN",
+    "message": "Capacidade (Unidades: Bolhas)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_CODE",
+    "message": "Código da instalação",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_FIXED_POST_MICROPLAN",
+    "message": "É posto fixo (Sim/Não)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LATITUDE_OPTIONAL_MICROPLAN",
+    "message": "Latitude (opcional)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_LONGITUDE_OPTIONAL_MICROPLAN",
+    "message": "Longitude (opcional)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME",
+    "message": "Nome da instalação",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_NAME_MICROPLAN",
+    "message": "Nome da instalação",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS",
+    "message": "Status da instalação",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_STATUS_MICROPLAN",
+    "message": "Status da instalação",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE",
+    "message": "Tipo de instalação",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_TYPE_MICROPLAN",
+    "message": "Tipo de instalação",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE",
+    "message": "Uso das instalações",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_FACILITY_USAGE_MICROPLAN",
+    "message": "Uso das instalações",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_RESIDING_BOUNDARY_CODE_MICROPLAN",
+    "message": "Código de limite residente",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET",
+    "message": "Alvo do agregado familiar ao nível da aldeia (obrigatório e a ser introduzido pelo utilizador)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_AT_THE_SELECTED_BOUNDARY_LEVEL",
+    "message": "Alvo do agregado familiar ao nível da aldeia (obrigatório e a ser introduzido pelo utilizador)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_1",
+    "message": "Alvo do agregado familiar a nível de aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_IRS_2",
+    "message": "Sala alvo em nível de vila",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LAT_OPT",
+    "message": "Latitude (opcional)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_LONG_OPT",
+    "message": "Longitude (opcional)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "População alvo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "População-alvo (12 a 59 meses de idade)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "População-alvo (3 a 11 meses de idade)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC",
+    "message": "Alvo ao nível da aldeia (obrigatório e a ser inserido pelo usuário)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_12_TO_59",
+    "message": "Alvo ao nível da aldeia - Idade dos 12 aos 59 meses (obrigatório e a inserir pelo utilizador)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TARGET_SMC_AGE_3_TO_11",
+    "message": "Alvo ao nível da aldeia - Idade dos 3 aos 11 meses (obrigatório e a inserir pelo utilizador)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "População total",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMAIL_MICROPLAN",
+    "message": "E-mail",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_EMPLOYMENT_TYPE",
+    "message": "Tipo de emprego (obrigatório)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_LIST",
+    "message": "Criar lista de usuários",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME",
+    "message": "Nome da Pessoa (Obrigatório)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_NAME_MICROPLAN",
+    "message": "Nome",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER",
+    "message": "Número de telefone (obrigatório)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_ERROR",
+    "message": "deve ser fornecido e deve ser um número de telefone de 10 dígitos",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_PHONE_NUMBER_MICROPLAN",
+    "message": "Número de contato",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_ROLE",
+    "message": "Função (obrigatório)",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ADMIN_CONSOLE_USER_USAGE",
+    "message": "Ativo/Inativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_README_SHEETNAME",
+    "message": "Leia-me",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_TIMELINE",
+    "message": "Linha do tempo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_POST ADMINISTRATIVE",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEALTH_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEIGHT",
+    "message": "Altura",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_ADMINISTRATIVEPOST",
+    "message": "Pós-administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_POST ADMINISTRATIVE",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHYTEST_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_CAN_BE_ONLY_APPLIED_ON_ADMIN_LEVEL_ZORO",
+    "message": "Os filtros só podem ser aplicados no nível 0",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ID_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "IN_BETWEEN",
+    "message": "entre",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LESS_THAN",
+    "message": "menor que",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LESS_THAN_EQUAL_TO",
+    "message": "menor ou igual a",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIM_MZ_capacity",
+    "message": "Capacidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIM_mz_capacity",
+    "message": "Capacidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "Se não houver instalações disponíveis para seleção, a aba “Lista de instalações disponíveis” no modelo estará vazia. Para criar novos dados de instalação, adicione o nome do Nome da Instalação, Tipo de Instalação, Status da Instalação, Capacidade. A coluna “Código da Instalação” precisa ser deixada em branco se esta for uma instalação nova. Caso se trate de uma instalação sendo reaproveitada (que fica disponível no template após o download) o usuário só precisa realizar o passo 2.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "Se o usuário excluir algum dos cabeçalhos da planilha e carregá-la, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Para mapear a instalação para o limite correto, o usuário precisa copiar o código de limite correto do limite da planilha “Lista de Limites de Campanha” para a qual a instalação precisa ser mapeada. Se houver uma instalação mapeada para vários limites, o administrador do sistema terá que adicionar os códigos de limite de todos os limites para os quais a instalação está mapeada, separando-os por vírgulas na célula para adicionar códigos de limite para essa instalação.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Facility Data” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Desativando Instalações existentes para uma campanha.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "Após o usuário ter baixado o modelo para Instalações, se o sistema tiver dados de instalações existentes para serem reutilizados, o modelo será pré-preenchido com essa lista de Instalações.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "Se o usuário optar por não usar instalações específicas, ele poderá excluir as linhas de dados dessas instalações específicas que precisam ser removidas e carregar a planilha apenas com as instalações necessárias para a campanha com os códigos de limite corretos mapeados para essas instalações.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "Se o usuário tiver removido códigos de instalação para uma instalação existente na lista, o sistema criará uma instalação duplicada com esses valores de coluna.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "Se o usuário excluir alguma coluna da “Lista de Instalações Disponíveis” da planilha e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_1",
+    "message": "Criação de novos dados de instalações/utilização de dados de instalações existentes após o download do modelo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_HEADER_2",
+    "message": "Casos de erros comuns:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Leia-me as instruções para upload de instalações",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER",
+    "message": "Criar novos dados de instalações/usar dados de instalações existentes após o download do modelo:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_1",
+    "message": "Definir metas após o download do modelo:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_HEADER_2",
+    "message": "Casos de erros comuns:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Leia-me instruções para upload de população",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Vá para a ficha do distrito para o qual deseja definir metas e adicione números na coluna “Metas” para cada Aldeia.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Insira as metas para cada aldeia na ficha de cada distrito na coluna “Meta ao nível do limite seleccionado”. Se alguma aldeia não tiver metas definidas, a ficha terá erros.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_3",
+    "message": "Se o usuário não tiver definido metas para cada aldeia, o sistema gerará um erro com o número da linha onde as metas estão faltando.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_4",
+    "message": "Se o usuário excluir qualquer aldeia da planilha ou excluir uma planilha distrital completa e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_5",
+    "message": "Se o usuário não tiver definido metas para cada aldeia, o sistema gerará um erro com o número da linha onde as metas estão faltando.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_6",
+    "message": "Se o usuário excluir qualquer aldeia da planilha ou excluir uma planilha distrital completa e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_README_POINTS_7",
+    "message": "Se o usuário excluir qualquer um dos cabeçalhos da planilha e fazer upload da planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_mz_capacity",
+    "message": "Capacidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MALE",
+    "message": "Macho",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MH_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ACTIVE",
+    "message": "Ativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVEPOST",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINSTRATIVEPOST",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_BOUNDARY_DATA_SHEET",
+    "message": "Dados de limite",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_COLUMN",
+    "message": "Detalhes do erro",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_COLUMN",
+    "message": "Status",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ERROR_STATUS_INVALID",
+    "message": "INVÁLIDO",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_DATA_SHEET",
+    "message": "Dados da instalação",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_READ_ME_SHEET",
+    "message": "Leia-me",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEMPLATE_README_MAIN_HEADER",
+    "message": "Leia-me instruções para upload de destino",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_1",
+    "message": "Se não houver instalações disponíveis para seleção, a aba “Lista de instalações disponíveis” no modelo estará vazia. Para criar novos dados de instalação, adicione o nome do Nome da Instalação, Tipo de Instalação, Status da Instalação, Capacidade. A coluna “Código da Instalação” precisa ser deixada em branco se esta for uma instalação nova. Caso se trate de uma instalação sendo reaproveitada (que fica disponível no template após o download) o usuário só precisa realizar o passo 2.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_10",
+    "message": "Se o usuário excluir algum dos cabeçalhos da planilha e carregá-la, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_2",
+    "message": "Para mapear a instalação para o limite correto, o usuário precisa copiar o código de limite correto do limite da planilha “Lista de Limites de Campanha” para a qual a instalação precisa ser mapeada. Se houver uma instalação mapeada para vários limites, o administrador do sistema terá que adicionar os códigos de limite de todos os limites para os quais a instalação está mapeada, separando-os por vírgulas na célula para adicionar códigos de limite para essa instalação.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Facility Data” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_5",
+    "message": "Desativando Instalações existentes para uma campanha.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_6",
+    "message": "Após o usuário ter baixado o modelo para Instalações, se o sistema tiver dados de instalações existentes para serem reutilizados, o modelo será pré-preenchido com essa lista de Instalações.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_7",
+    "message": "Se o usuário optar por não usar instalações específicas, ele poderá excluir as linhas de dados dessas instalações específicas que precisam ser removidas e carregar a planilha apenas com as instalações necessárias para a campanha com os códigos de limite corretos mapeados para essas instalações.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_8",
+    "message": "Se o usuário tiver removido códigos de instalação para uma instalação existente na lista, o sistema criará uma instalação duplicada com esses valores de coluna.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITIES_EXCEL_README_POINTS_9",
+    "message": "Se o usuário excluir alguma coluna da “Lista de Instalações Disponíveis” da planilha e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_1",
+    "message": "Criação de novos dados de instalações/utilização de dados de instalações existentes após o download do modelo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_HEADER_2",
+    "message": "Casos de erros comuns:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_FACILITY_EXCEL_MAIN_HEADER",
+    "message": "Leia-me as instruções para upload de instalações",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_1",
+    "message": "Definir metas após o download do modelo:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_HEADER_2",
+    "message": "Casos de erros comuns:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_MAIN_HEADER",
+    "message": "Leia-me instruções para upload de população",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_1",
+    "message": "Vá para a ficha do distrito para o qual deseja definir metas e adicione números na coluna “Metas” para cada Aldeia.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_2",
+    "message": "Insira as metas para cada aldeia na planilha de cada distrito na coluna “Metas”. Se alguma aldeia não tiver metas definidas, a planilha conterá erros.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Target” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_5",
+    "message": "Se o usuário não tiver definido metas para cada aldeia, o sistema gerará um erro com o número da linha onde as metas estão faltando.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_6",
+    "message": "Se o usuário excluir qualquer aldeia da planilha ou excluir uma planilha distrital completa e carregar a planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_README_POINTS_7",
+    "message": "Se o usuário excluir qualquer um dos cabeçalhos da planilha e fazer upload da planilha, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_capacity",
+    "message": "Capacidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW BOUNDARY_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_ALDEIA",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_LOCALIDADE",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_POST ADMINISTRATIVO",
+    "message": "Pós Administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NITISH_STATE",
+    "message": "Estado",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "OTHER_TARGETS",
+    "message": "Outros alvos",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SV_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Svefewg4YCb",
+    "message": "Múrrupula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TARGET_HOUSEHOLDS",
+    "message": "Famílias-alvo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_CITY",
+    "message": "Cidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_REGION",
+    "message": "Região",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_STATE",
+    "message": "Estado",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_WARD",
+    "message": "Ala",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEST BOUNDARY_ZONE",
+    "message": "Zona",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TESTD_DISTRITO",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TO",
+    "message": "para",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1",
+    "message": "Baixando modelos do Excel para criação de usuários:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_1",
+    "message": "Baixe o modelo Excel clicando no botão “Baixar modelo”.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_1_DESC_2",
+    "message": "Abra o modelo Excel que foi baixado na etapa anterior terá 3 planilhas e a primeira planilha que você verá é uma planilha “Leia-me”. A segunda Planilha denominada “Criar Lista de Usuários“ que será uma planilha vazia onde o usuário deverá inserir os dados para criar usuários para a campanha.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2",
+    "message": "Criando usuários para a campanha:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_1",
+    "message": "O administrador do sistema terá que criar uma entrada separada para cada usuário. O administrador do sistema terá que adicionar o nome do usuário (obrigatório), número de telefone (obrigatório), função (obrigatório), tipo de emprego (obrigatório), código de limite (obrigatório).",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_2",
+    "message": "Cada usuário criado precisa ser atribuído a um limite usando o Código de Limite do limite necessário, que pode ser encontrado na “Lista de Limites de Campanha“. Se houver um usuário mapeado para vários limites, o administrador do sistema terá que adicionar os códigos de limite de todos os limites para os quais o usuário está mapeado, separando-os por vírgulas na célula para adicionar códigos de limite para esse usuário.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_3",
+    "message": "Salve a planilha com as metas atualizadas para cada aldeia no modelo Excel.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_2_DESC_4",
+    "message": "Pressione o botão “Browse In My Files” na tela “Upload Target” e selecione o arquivo salvo com todos os alvos do sistema.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3",
+    "message": "Casos de erros comuns:",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_1",
+    "message": "Se o usuário não tiver adicionado códigos de limite para todas as entradas do usuário, o sistema gerará um erro com o número da linha onde o código de limite está faltando",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_HEADER_3_DESC_2",
+    "message": "Se o usuário excluir algum dos cabeçalhos da planilha e carregá-la, o sistema gerará um erro e o usuário terá que baixar o modelo novamente e recarregar a planilha correta com os dados corretos.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERWITHBOUNDARY_README_MAINHEADER",
+    "message": "Leia-me instruções para upload do usuário",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN1",
+    "message": "Função do usuário",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_COLUMN2",
+    "message": "Descrição",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_ROLES",
+    "message": "Funções de usuário",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE1",
+    "message": "Aprovador de estimativa de plano",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE10",
+    "message": "Esta função terá acesso para atribuir a instalação às áreas de influência do limite administrativo atribuído",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE11",
+    "message": "Mapeador de captação de instalação raiz",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE12",
+    "message": "Esta função terá acesso para atribuir e finalizar a instalação para as áreas de influência do país",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE13",
+    "message": "Visualizador de microplano",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE14",
+    "message": "Esta função terá acesso para visualizar estimativas de microplano do limite administrativo atribuído.",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE2",
+    "message": "Esta função terá acesso para editar as suposições do microplano e aprovar a estimativa do microplano para todas as aldeias do limite administrativo atribuído",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE3",
+    "message": "Aprovador de estimativa de plano raiz",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE4",
+    "message": "Esta função terá acesso para editar as suposições do microplano, aprovar e finalizar a estimativa do microplano para todas as aldeias do país",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE5",
+    "message": "Aprovador de dados populacionais",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE6",
+    "message": "Esta função terá acesso para validar e aprovar os dados populacionais das aldeias da fronteira administrativa atribuída",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE7",
+    "message": "Aprovador de dados populacionais raiz",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE8",
+    "message": "Esta função terá acesso para validar, aprovar e finalizar os dados populacionais de todas as aldeias do país",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MICROPLAN_SHEET_VALUE9",
+    "message": "Mapeador de captação de instalações",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_POST ADMINISTRATIVE",
+    "message": "Pós-administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UY_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VFTw0jbRf1y",
+    "message": "Cavina1",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WEIGHT",
+    "message": "Peso",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "f5F6xAskA05",
+    "message": "Nampula",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "facilityUsage",
+    "message": "Uso das instalações",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_Country",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_District",
+    "message": "Distrito",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_Locality",
+    "message": "Localidade",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_Post administrative",
+    "message": "Pós-administrativo",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_Province",
+    "message": "Província",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_Village",
+    "message": "Aldeia",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mobile_country",
+    "message": "País",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "mz",
+    "message": "Moçambique",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "w22L4En0Zgg",
+    "message": "Nihessiue",
+    "module": "rainmaker-hcm-admin-schemas",
+    "locale": "pt_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/pt_MZ/rainmaker-hr.json
+++ b/localisation/Microplanning/v0.1/pt_MZ/rainmaker-hr.json
@@ -1,0 +1,8 @@
+[
+  {
+    "code": "HEALTH_HRMS_EMAIL_CODE",
+    "message": "<h2>Credenciais de login do painel</h2><p>Olá,  {User's name},<br>Seu perfil foi criado para acessar o painel. Encontre suas credenciais de login abaixo -<br>URL: {website URL}<br>Username: {Username}<br>Password: {Password}<br>Senha: <br>{Implementation partner}</p>",
+    "module": "rainmaker-hr",
+    "locale": "pt_MZ"
+  }
+]

--- a/localisation/Microplanning/v0.1/pt_MZ/rainmaker-microplanning.json
+++ b/localisation/Microplanning/v0.1/pt_MZ/rainmaker-microplanning.json
@@ -1,0 +1,9494 @@
+[
+  {
+    "code": " FINALIZED_MIDDLE_MASSAGE",
+    "message": "instalações e o",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " HCM_SELECTED",
+    "message": "Selecionado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " MICROPLAN_SELECTED_PLURAL",
+    "message": "Selecionado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": " SECURITY_LEVEL_Q1",
+    "message": "A sua aldeia é propensa a distúrbios civis, como protestos violentos, motins, etc.?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "1",
+    "message": "1",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "2",
+    "message": "2",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "3",
+    "message": "3",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "4",
+    "message": "4",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "5",
+    "message": "5",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACCESSIBILITY_DETAILS_UPDATE_SUCCESS",
+    "message": "Os detalhes de acessibilidade foram atualizados com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION",
+    "message": "Ação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTIONS",
+    "message": "Ação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_MY_MICROPLAN",
+    "message": "Meus Microplanos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_OPEN_MICROPLAN",
+    "message": "Microplano aberto",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_SETUP_MICROPLAN",
+    "message": "Configurar Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTION_TEST_USER_MANAGEMENT",
+    "message": "Gerenciamento de usuários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ACTIVA",
+    "message": "Ativo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD",
+    "message": "Adicionar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADDITION",
+    "message": "Adição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_ASSUMPTION",
+    "message": "Adicionar suposição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_ASSUMPTION_CAMPAIGN_VEHICLES",
+    "message": "Adicionar veículo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_FORMULA",
+    "message": "Adicionar fórmula",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_NEW_FORMULA",
+    "message": "Adicionar fórmula",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADD_ROW",
+    "message": "Adicionar linha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMINISTRATIVEPOST",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMINISTRATIVE_BOUNDARY",
+    "message": "Área Administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMINISTRATIVE_HIERARCHY",
+    "message": "Hierarquia Administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ADMIN_PROVINCIA",
+    "message": "Província",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ALERT_HEADER_CAMPAIGN",
+    "message": "Tem certeza de que deseja prosseguir?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ALERT_HEADER_MICROPLAN",
+    "message": "Tem certeza de que deseja prosseguir?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ALERT_MESSAGE_CAMPAIGN",
+    "message": "Os detalhes da campanha não podem ser alterados depois de salvos. Certifique-se de finalizar os detalhes da campanha antes de continuar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ALERT_MESSAGE_MICROPLAN",
+    "message": "Os detalhes da campanha não podem ser alterados depois de salvos. Certifique-se de finalizar os detalhes da campanha antes de continuar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ALL",
+    "message": "Todos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ALL_THE_TIME",
+    "message": "O tempo todo (pelo menos uma vez por mês)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ALREADY_HAVE_IT",
+    "message": "Já tenho",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ALREDY_HAVE_IT",
+    "message": "Já tenho",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AND",
+    "message": "e",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ANSWER_TO_PROVIDE_ESTIMATE",
+    "message": "Responda às seguintes perguntas com respostas apropriadas para que possamos fornecer um formulário de estimativa de estimativa ideal para você.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "APPROVE",
+    "message": "Aprovar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGN",
+    "message": "Atribuir",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGNED_SUCCESSFULLY",
+    "message": "O usuário foi atribuído à função selecionada com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGNED_SUCESS",
+    "message": "Aldeias foram atribuídas com sucesso à Instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGNED_TO_ALL",
+    "message": "Atribuído a todos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGNED_TO_ME",
+    "message": "Atribuído a mim",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGN_FACILITIES_TO_VILLAGE",
+    "message": "Atribuir instalações à vila",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGN_FACILITIES_TO_VILLAGES",
+    "message": "Atribuir instalações às aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGN_FACILITY_CATCHMENT_MAPPER",
+    "message": "Atribuir atribuidor de limite de instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGN_MICROPLAN_VIEWER",
+    "message": "Atribuir visualizador de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGN_PLAN_ESTIMATION_APPROVER",
+    "message": "Atribuir aprovador de estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGN_POPULATION_DATA_APPROVER",
+    "message": "Atribuir aprovador de dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGN_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Atribuir Designador de Limite da Instalação Nacional",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGN_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Atribuir aprovador nacional de estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSIGN_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Atribuir aprovador nacional de dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSUMPTION_NAME",
+    "message": "Nome da suposição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ASSUMPTION_VEHICLE_DESCRIPTION",
+    "message": "Insira o valor das suposições de carga do veículo adicionando veículos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ATLEAST_ONE_FORMULA",
+    "message": "Pelo menos uma fórmula deve estar presente para avançar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ATLEAST_ONE_MDMS_ASSUMPTION",
+    "message": "Pelo menos um dos campos de entrada de suposição pré-preenchidos nesta categoria deve estar presente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ATLEAST_ONE_MDMS_FORMULA",
+    "message": "Pelo menos um dos campos de entrada de fórmula pré-preenchidos nesta categoria deve estar presente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_CHILDREN_REACHED_BY_ONE_TEAM_PER_DAY",
+    "message": "Número médio de crianças alcançadas por uma equipe por dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_HOUSEHOLDS_COVERED_BY_ONE_DISTRIBUTOR",
+    "message": "Número médio de domicílios atendidos por uma distribuidora",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_HOUSEHOLDS_COVERED_BY_ONE_SPRAY_TECHNICIAN",
+    "message": "Número médio de domicílios cobertos por técnico de pulverização",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AVERAGE_NUMBER_OF_HOUSEHOLD_COVERED_BY_ONE_DISTRIBUTORS",
+    "message": "Número médio de domicílios atendidos por uma distribuidora",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "Pessoas médias em uma família",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "AVERAGE_PEOPLE_PER_HH",
+    "message": "Média de pessoas por domicílio",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BACK",
+    "message": "Voltar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BACK_TO_HOME",
+    "message": "Volte para casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BAD_REQUEST",
+    "message": "Houve algum erro. Por favor, tente novamente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOLERO",
+    "message": "Bolero",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MP_README_HEADER_1_DESC_1",
+    "message": "Os campos obrigatórios, como população total e dados da população alvo, devem ser um número inteiro (por exemplo, a população pode ser 1234 e não 123,5).",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_MP_README_HEADER_1_DESC_2",
+    "message": "Os campos Latitude e Longitude devem conter dados em Graus Decimais e Graus Minuto Segundos (o valor deve ser 12,3455 e não 12° 20' 43,7994').",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BOUNDARY_SELECTION",
+    "message": "Selecione o limite da campanha para microplanejamento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BUFFER",
+    "message": "Tampão",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BULK_UPLOAD_USERS",
+    "message": "Usuários de upload em massa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BUTTON",
+    "message": "botão",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BUTTON_BACK",
+    "message": "Voltar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BUTTON_DOWNLOAD",
+    "message": "Download",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "BUTTON_FILTER_BY_BOUNDARY",
+    "message": "Filtrar por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGNS_ASSIGNED",
+    "message": "Campanha atribuída",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE",
+    "message": "Tipo de beneficiário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPEHOUSEHOLD",
+    "message": "Doméstico",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPEINDIVIDUAL",
+    "message": "Individual",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE_HOUSEHOLD",
+    "message": "Doméstico",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BENEFICIARY_TYPE_INDIVIDUAL",
+    "message": "Individual",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY",
+    "message": "Limite da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_ADMIN_MO",
+    "message": "Administrador",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_CAMP",
+    "message": "Limite da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_BOUNDARY_MZ",
+    "message": "Moçambique",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_COMMODITIES",
+    "message": "Premissas de commodities",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DATE",
+    "message": "Data da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DETAILS",
+    "message": "Detalhes da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_DISEASE",
+    "message": "Doença de campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_END_DATE",
+    "message": "Data de término da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_NAME",
+    "message": "Nome da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Os limites são as áreas administrativas definidas nas quais você deseja executar uma campanha. Comece a selecionar os limites do primeiro nível para que os limites presentes no próximo nível estejam disponíveis para seleção.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SELECT_BOUNDARY",
+    "message": "Selecione os limites onde deseja veicular a campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_SETUP_DETAILS",
+    "message": "O nome que você digitou já foi usado. Por favor, tente um nome diferente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_START_DATE",
+    "message": "Data de início da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE",
+    "message": "Tipo de campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE-SMC",
+    "message": "SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_IRS_MZ",
+    "message": "Campanha do IRS",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN-MZ",
+    "message": "LLIN-MZ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN-mz",
+    "message": "LLIN-MZ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN_DEFAULT_TESTING",
+    "message": "Campanha de teste padrão LLIN",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN_MOZ",
+    "message": "MILD-Moz",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_LLIN_MZ",
+    "message": "Campanha de redes mosquiteiras",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_MR-DN",
+    "message": "MR-DN",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_MR_DN",
+    "message": "Campanha SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_SMC",
+    "message": "SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_TYPE_XVZ",
+    "message": "Campanha XVZ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAMPAIGN_VEHICLES",
+    "message": "Suposições do veículo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CANCEL",
+    "message": "Cancelar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CANCLE",
+    "message": "Cancelar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAPACITY_OF_VEHICLE_1_BALES",
+    "message": "Capacidade do veículo 1 (fardos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CAPACITY_OF_VEHICLE_2_BALES",
+    "message": "Capacidade do veículo 2 (fardos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CATEGORY_",
+    "message": "Categoria-",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CATEGORY_1",
+    "message": "Categoria 1",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CATEGORY_2",
+    "message": "Categoria 2",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TARGET_POPULATION",
+    "message": "População-alvo confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "População-alvo confirmada (12 a 59 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "População-alvo confirmada (de 3 a 11 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_CONFIRMED_TOTAL_POPULATION",
+    "message": "População Total Confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_DATA_APPROVAL_IN_PROGRESS",
+    "message": "Validação em andamento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_DATA_APPROVED",
+    "message": "Validação em andamento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TARGET_POPULATION",
+    "message": "População-alvo enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "População-alvo enviada (de 12 a 59 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "População-alvo enviada (de 3 a 11 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_UPLOADED_TOTAL_POPULATION",
+    "message": "População total enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CENSUS_VALIDATED_LABEL",
+    "message": "Dados Populacionais Finalizados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHOOSE_ASSUMPTION",
+    "message": "Escolha a suposição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHOOSE_VEHICLE",
+    "message": "Escolha o veículo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CHOROPLETH_INDEX_COVERAGE",
+    "message": "Cobertura",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CLEAR",
+    "message": "Claro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CLEAR_ALL",
+    "message": "Limpar tudo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CLEAR_ALL_CONFIRMATION_MSG",
+    "message": "Tem certeza de que deseja limpar todas as seleções?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CLEAR_ALL_FILTERS",
+    "message": "Limpar todos os filtros",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CLEAR_FILTER",
+    "message": "Limpar filtro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CLOSE",
+    "message": "Fechar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CMAPAIGN_DISEASE",
+    "message": "Doença de campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COLUMNS",
+    "message": "Colunas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COLUMNS_IN_TEMPLATE",
+    "message": "Coluna no modelo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COLUMNS_IN_USER_UPLOAD",
+    "message": "Coluna no seu arquivo enviado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COMMENT_PREFIX",
+    "message": "Comentário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COMMON_NO_RESULTS_FOUND",
+    "message": "Nenhum resultado encontrado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COMMON_SELECTED",
+    "message": "Selecionado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COMPLETE_MAPPING",
+    "message": "Mapeamento completo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONCRETE",
+    "message": "Concreto",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "População-alvo confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "População-alvo confirmada (12 a 59 meses de idade)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "População-alvo confirmada (3 a 11 meses de idade)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "População total confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIRM_NEW_ASSUMPTION",
+    "message": "Tem certeza de que deseja adicionar uma suposição?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIRM_NEW_ASSUMPTION_CAMPAIGN_VEHICLES",
+    "message": "Tem certeza de que deseja adicionar um veículo?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIRM_NEW_FORMULA",
+    "message": "Tem certeza de que deseja adicionar uma fórmula?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONFIRM_TO_DELETE",
+    "message": "Tem certeza de que deseja excluir?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CONTACT_NUMBER",
+    "message": "Número de contato",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CORE_COMMON_EMAIL_ID",
+    "message": "Endereço de email",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CORE_COMMON_NAME",
+    "message": "Nome",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CORE_COMMON_STATUS",
+    "message": "Status da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CORE_COMMON_STATUS_LABEL",
+    "message": "Status da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CORE_SOMETHING_WENT_WRONG",
+    "message": "Algo deu errado!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COUNTRY",
+    "message": "País",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "COVERAGE_PERCENTAGE",
+    "message": "Porcentagem de cobertura",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE_MICROPLAN",
+    "message": "Criar microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE_MICROPLAN_GUIDELINES",
+    "message": "Aviso/Instruções antes de começar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CREATE_NEW_MICROPLAN",
+    "message": "Criar novo microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_COMMON_ROWS_PER_PAGE",
+    "message": "Linhas por página",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "CS_INBOX_SEARCH",
+    "message": "Procurar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Camapaign Type",
+    "message": "Tipo de campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DATA_MGMT",
+    "message": "Gerenciamento de dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DATA_VALIDATION_RULE",
+    "message": "Regra de validação de dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DELETE",
+    "message": "Excluir",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DESERT",
+    "message": "Deserto",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DEVIDED_BY",
+    "message": "Dividido por",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DIGIT_CLOSE",
+    "message": "Fechar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DIGIT_CONFIRM_SELECTION",
+    "message": "Confirmar seleção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DIGIT_SELECT",
+    "message": "Selecionado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DIRT",
+    "message": "Sujeira",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAYING_DATA_ONLY_FOR_UPLOADED_BOUNDARIES",
+    "message": "Exibindo dados apenas para os limites para os quais os dados foram carregados.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_capacity",
+    "message": "Capacidade (Obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityCode",
+    "message": "Código da instalação (obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityName",
+    "message": "Nome da instalação (obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityStatus",
+    "message": "Status da instalação (obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_facilityType",
+    "message": "Tipo de instalação (obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_lat",
+    "message": "Lat (opcional)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_long",
+    "message": "Longo (opcional)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_targetHouseholds",
+    "message": "Domicílios-alvo (obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_targetPopulation",
+    "message": "População alvo (Obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_targetPopulationAge3To11",
+    "message": "População alvo (Idade 3 meses - 11 meses) (Obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_targetpopulationAge12To59",
+    "message": "População alvo (Idade 12 meses - 59 meses) (Obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISPLAY_totalTargetPopulation",
+    "message": "População alvo total (Obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISTIRBUTION_STRATEGY",
+    "message": "Estratégia de Distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISTRIBUTION_PROCESS",
+    "message": "Como está acontecendo o processo de distribuição da campanha?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DIVIDED_BY",
+    "message": "Dividido por",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOADING",
+    "message": "Baixando",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_DESC",
+    "message": "Baixe os dados do usuário da lista abaixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_IT",
+    "message": "Baixe",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_MICROPLAN",
+    "message": "Baixar microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_TEMPLATE",
+    "message": "Baixar modelo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DOWNLOAD_USER_DATA",
+    "message": "Baixar dados do usuário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DRAFT",
+    "message": "Configuração elaborada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "DRAFTED_SETUP",
+    "message": "Configuração elaborada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Data Mgmt",
+    "message": "Gerenciamento de dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Enviado para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EDIT_AND_VALIDATE",
+    "message": "Validar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EDIT_POPULATION",
+    "message": "Editar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EDIT_ROW",
+    "message": "Editar linha {{rowNumber}}",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EMAIL",
+    "message": "Endereço de email",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EMPLOYEES_NOT_FOUND",
+    "message": "Atribua os usuários para seguir em frente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND",
+    "message": "Atribua os usuários para seguir em frente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Atribua pelo menos um usuário para a função de atribuidor de limites da instalação nacional",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Atribua pelo menos um usuário para a função de aprovador de estimativa de microplano nacional",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EMPLOYESS_NOT_FOUND_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Atribua pelo menos um usuário para a função de aprovador de dados populacionais nacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_ADDITIONAL_PROPERTIES",
+    "message": "Os dados enviados têm campos adicionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_BOUNDARY_DATA_COLUMNS_ABSENT",
+    "message": "Faltam dados de limite parciais ou completos. Não remova ou altere os dados de limite no modelo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_BOUNDARY_SELECTION",
+    "message": "Selecione os limites até o nível da Aldeia.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_CAMPAIGN_DETAILS_MANDATORY",
+    "message": "Preencha todos os campos obrigatórios para avançar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_CANNOT_DELETE_LAST_HYPOTHESIS",
+    "message": "A exclusão da última hipótese não é proibida",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_COLUMNS_DO_NOT_MATCH_TEMPLATE",
+    "message": "As colunas {{columns}} não atendem aos requisitos do modelo!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_CONTENT_NAMING_CONVENSION",
+    "message": "O sistema não será capaz de processar este arquivo. Consulte a convenção de nomenclatura, renomeie os subarquivos e depois carregue",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_CORRUPTED_FILE",
+    "message": "O arquivo enviado está corrompido. Faça upload de um arquivo válido.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_DATA_EXCEEDS_LIMIT_CONSTRAINTS",
+    "message": "Insira os dados nos limites indicados.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_DATA_INCOMPLETE",
+    "message": "Preencha todos os campos antes de passar para a próxima etapa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_DATA_NOT_PRESENT",
+    "message": "Dados incorretos ou ausentes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_DATA_NOT_SAVED",
+    "message": "Dados não salvos. Certifique-se de que todas as seções obrigatórias sejam preenchidas, que o arquivo seja carregado, que a hipótese esteja definida e que o mecanismo de regras esteja configurado.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_DATA_TYPE",
+    "message": "Por favor insira um número",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_DBF_MISSING",
+    "message": "Consulte as diretrizes de upload de dados. O subarquivo DBF está faltando no shapefile carregado. Por favor, verifique e reenvie.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_DOWNLOADING_TEMPLATE",
+    "message": "Erro ao baixar o modelo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_DUPLICATE_MICROPLAN_NAME",
+    "message": "O nome que você digitou já foi usado. Por favor, tente um nome diferente",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_EXCEL_EXTENSION",
+    "message": "Faça upload de um arquivo .xlsx com a convenção de nomenclatura correta",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_FEATURECOLLECTION",
+    "message": "O elemento de nível superior deve ser do tipo “FeatureCollection”",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_FIELD_LENGTH",
+    "message": "Consulte as diretrizes de upload de dados. O comprimento mínimo para qualquer campo deve ser 2.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_FIELD_NAME",
+    "message": "Os nomes dos campos não devem exceder 10 caracteres.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_FILE_SIZE",
+    "message": "Consulte as diretrizes de upload de dados. O tamanho do arquivo excede o limite de 2 GB. Faça upload de um arquivo menor.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_GEOJSON_EXTENSION",
+    "message": "Faça upload de um arquivo .geojson com a convenção de nomenclatura correta",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_HYPOTHESIS_VALUE_SHOULD_NOT_BE_ZERO",
+    "message": "O valor da hipótese deve ser maior que 0",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_INCORRECT_FORMAT",
+    "message": "Consulte as diretrizes de upload de dados. Formato GeoJSON inválido. Revise e corrija o formato.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_INCORRECT_LOCATION_COORDINATES",
+    "message": "Os campos Latitude e Longitude devem ter dados em Graus Decimais e Graus Minuto Segundos (o valor deve ser 12,3455 e não 12° 20' 43,7994')",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_INVALID_GEOJSON",
+    "message": "O formato GeoJSON fornecido é inválido. Revise e tente novamente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MANDATORY_FIELDS",
+    "message": "Preencha todos os campos obrigatórios para avançar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MANDATORY_FIELDS_CANT_BE_EMPTY",
+    "message": "O campo obrigatório não pode ficar vazio",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MANDATORY_FIELDS_FOR_SUBMIT",
+    "message": "Não há nenhuma planilha Excel carregada. Faça o upload e clique no botão 'Enviar'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MAP_OBJECT_MISSING",
+    "message": "Erro ao carregar o mapa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_DETAILS_MANDATORY",
+    "message": "Preencha o campo obrigatório 'Nome do microplano' para prosseguir.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_NAME_ALREADY_EXISTS",
+    "message": "O nome que você digitou já foi usado. Por favor, tente um nome diferente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_NAME_CRITERIA",
+    "message": "O nome que você digitou não corresponde à convenção de nomenclatura. Por favor, tente um nome diferente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MICROPLAN_NAME_INVALID",
+    "message": "O nome que você digitou não corresponde à convenção de nomenclatura. Por favor, tente um nome diferente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MISSING_LOCATION_COORDINATES",
+    "message": "As coordenadas de localização estão faltando para alguns/todos os pontos de dados. Você não poderá visualizar esses dados no mapa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MISSING_PROPERTY",
+    "message": "As seguintes propriedades obrigatórias estão faltando: {{properties}}",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MULTIPLE_GEOMETRY_TYPES",
+    "message": "Vários tipos de geometria detectados. Certifique-se de que o arquivo contenha apenas um tipo de geometria.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MUST_BE_A_NUMBER",
+    "message": "deve ser um número",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MUST_BE_A_NUMBER ",
+    "message": "deve ser um número",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_MUST_BE_A_STRING",
+    "message": "deve ser uma corda",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_NAMING_CONVENSION",
+    "message": "O sistema não será capaz de processar este arquivo. Consulte a convenção de nomenclatura, renomeie o arquivo e faça upload",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_PARSING_FILE",
+    "message": "Erro ao analisar o arquivo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_REFER_UPLOAD_PREVIEW_TO_SEE_THE_ERRORS",
+    "message": "Para visualizar erros detalhados, por favor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_REGISTRATION_AND_DISTRIBUTION_ARE_SAME",
+    "message": "O processo de distribuição e registro não pode ser o mesmo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_SHAPE_FILE_EXTENSION",
+    "message": "Faça upload de um arquivo .zip com a convenção de nomenclatura correta",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_SHP_MISSING",
+    "message": "Consulte as diretrizes de upload de dados. O subarquivo SHP está faltando no shapefile carregado. Por favor, verifique e reenvie.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_SHX_MISSING",
+    "message": "Consulte as diretrizes de upload de dados. O subarquivo SHX está faltando no shapefile carregado. Por favor, verifique e reenvie.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_UNHANDLED_NEXT_OPERATION",
+    "message": "Erro não tratado na próxima operação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_UNKNOWN",
+    "message": "Erro desconhecido, entre em contato com o administrador",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_UNKNOWN_FILETYPE",
+    "message": "Erro de tipo de arquivo desconhecido. Certifique-se de ter selecionado um tipo de arquivo compatível e tente novamente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_UPLOADED_DATA_IS_EMPTY",
+    "message": "O arquivo enviado não contém dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_UPLOADED_FILE",
+    "message": "Erro com arquivo enviado.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_UPLOADING_FILE",
+    "message": "Falha no upload. Por favor carregue novamente",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_UPLOAD_DATA_ENUM",
+    "message": "O valor deve ser {{allowedValues}}",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_UPLOAD_DATA_LOCATION_AND_MESSAGE",
+    "message": "Dados na linha {{rowNumber}}: {{columnName}}: {{error}} na planilha {{sheetName}}.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_UPLOAD_EXCEL_LOCATION_DATA_MISSING",
+    "message": "as coordenadas de localização estão faltando para alguns/todos os pontos de dados. Você não poderá visualizar esses dados no mapa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_VALIDATION_SCHEMA_ABSENT",
+    "message": "Consulte as diretrizes de upload de dados. Esquema de validação ausente. Entre em contato com o administrador",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_VALID_MANDATORY_FILES",
+    "message": "Faça upload de um arquivo Excel válido para prosseguir.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_VALUE_NOT_ALLOWED",
+    "message": "Insira um valor permitido",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_VIEW_DETAIL_ERRORS",
+    "message": "Ver erro e detalhes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_WHILE_UPDATING_PLANFACILITY",
+    "message": "Ocorreu algum erro durante a atribuição da instalação. Por favor, tente novamente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERROR_WRONG_PRJ",
+    "message": "Consulte as diretrizes de upload de dados. Projeção errada. Use WGS 1984.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_ATLEAST_ONE_MANDATORY_FIELD",
+    "message": "Deve haver pelo menos uma suposição na categoria. Não deveria estar vazio.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_ATLEAST_ONE_MANDATORY_FORMULA",
+    "message": "Deve haver pelo menos uma fórmula para seguir em frente",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_DECIMAL_PLACES_LESS_THAN_TWO",
+    "message": "Insira um valor numérico positivo válido com 2 casas decimais e apenas até 1000.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_FORMULA_ENTER_FORMULA_NAME",
+    "message": "Insira o nome da fórmula.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_FORMULA_SELECT_OPTION",
+    "message": "Selecione a fórmula",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_INCORRECT_FIELD",
+    "message": "Insira um valor numérico positivo válido com 2 casas decimais e apenas até 1000.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_MANDATORY_FIELD",
+    "message": "Preencha todos os campos obrigatórios para avançar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_MANDATORY_FIELD_SAME_OPERAND",
+    "message": "Os operadores não podem ser 'Subtração' quando as entradas são iguais.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_MIN_LENGTH_CAMPAIGN_NAME",
+    "message": "São necessários no mínimo 2 caracteres",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_PLS_ENTER_VALID_ASSUMPTION_VALUE",
+    "message": "Insira um valor numérico positivo válido com 2 casas decimais e apenas até 1000.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_SHOULD_NOT_EXCEED_999.99",
+    "message": "Insira um valor de suposição válido que não deve exceder 1.000",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ERR_SKIP_STEP",
+    "message": "Pular a etapa não é permitido",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ESTIMATION_ASSUMPTIONS",
+    "message": "Suposições do Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_APPLY_FILTER",
+    "message": "Aplicar filtro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_APPLY_FILTERS",
+    "message": "Aplicar filtro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_ALL",
+    "message": "LIMPAR TUDO",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_FILTER",
+    "message": "Claro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_CLEAR_SEARCH",
+    "message": "Claro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_FILTER",
+    "message": "Procurar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_NA",
+    "message": "NA",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_PLEASE_ENTER_ALL_MANDATORY_FIELDS",
+    "message": "Por favor preencha os campos obrigatórios.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_COMMON_SEARCH",
+    "message": "Procurar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ES_MORE",
+    "message": "Mais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EVERYDAY",
+    "message": "Diariamente",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EVERYDAY1",
+    "message": "Diariamente",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EXAMPLE",
+    "message": "Exemplo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EXCEL",
+    "message": "Excel",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EXECUTION_IN_PROGRESS",
+    "message": "Validação em andamento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "EXECUTION_TO_BE_DONE",
+    "message": "Configuração concluída",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES",
+    "message": "Instalações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_GUIDELINE_POINTS_1",
+    "message": "O nome do arquivo deve ser 'Facilities.xlsx'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_EXCEL_GUIDELINE_POINTS_2",
+    "message": "Os campos Latitude e Longitude devem ter dados em Graus Decimais e Graus Minuto Segundos (o valor deve ser 12,3455 e não 12° 20' 43,7994')",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_1",
+    "message": "O arquivo GeoJSON deve atender à especificação {{link}}.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_2",
+    "message": "O nome do arquivo deve ser 'Facilities.geojson'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_3",
+    "message": "Todos os recursos no arquivo devem ter geometrias do mesmo tipo (ou seja, todos devem ser pontos ou todos devem ser multipolígonos e assim por diante).",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_4",
+    "message": "As coordenadas devem estar no intervalo válido de latitude e longitude (o intervalo válido para latitude é -90 a +90 e o intervalo válido de longitude é -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_5",
+    "message": "Todos os recursos do arquivo devem ter propriedades com o mesmo conjunto de chaves.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_6",
+    "message": "As características do arquivo devem ter chaves importantes como 'Código da instalação', 'Nome da instalação', 'Tipo de instalação', 'Status da instalação', 'Capacidade', 'Código de limite'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_GUIDELINE_POINTS_7",
+    "message": "No objeto Propriedades, os valores dos campos que representam um Valor Numérico não devem ser colocados entre aspas duplas (ou seja, o código da instalação 10.000 deve ser representado como “código da instalação”: 10000 e não “código da instalação”: “10.0000 ”",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_GEOJSON_SPECIFICATION",
+    "message": "RFC 7946 GeoJSON",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_1",
+    "message": "O usuário deve compactar todos os arquivos no formato .zip e carregá-los no sistema. No mínimo, o sistema precisa de arquivos .shp, .shx e .dbf compactados.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_2",
+    "message": "O nome do arquivo zip deve ser 'Facilities.zip'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_3",
+    "message": "O shapefile deve estar no sistema de coordenadas lat-long WGS 84 para que o sistema aceite.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_4",
+    "message": "As coordenadas devem estar no intervalo válido de latitude e longitude (o intervalo válido para latitude é -90 a +90 e o intervalo válido de longitude é -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_5",
+    "message": "O arquivo shape deve conter pontos de dados importantes, como 'Código da instalação', 'Nome da instalação', 'Tipo de instalação', 'Status da instalação', 'Capacidade', 'Código de limite'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITIES_SHAPEFILE_GUIDELINE_POINTS_6",
+    "message": "O tamanho total do arquivo compactado não deve exceder 2 GB.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITY",
+    "message": "Instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MP_README_HEADER_1_DESC_1",
+    "message": "Todos os campos são obrigatórios e não podem ficar vazios, exceto os campos Latitude e Longitude.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITYWITHBOUNDARY_MP_README_HEADER_1_DESC_2",
+    "message": "Os campos Latitude e Longitude devem conter dados em Graus Decimais e Graus Minuto Segundos (o valor deve ser 12,3455 e não 12° 20' 43,7994').",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHEMENT_DONE_LABEL",
+    "message": "Atribuição de instalação finalizada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER",
+    "message": "Atribuidor de limites da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER_DESCRIPTION",
+    "message": "Esta função de usuário terá acesso para atribuir a instalação às áreas de influência do limite administrativo atribuído.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FACILITY_CATCHMENT_MAPPER_POPUP_HEADING",
+    "message": "Selecione o atribuidor do limite da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FILE_UPLOADED_SUCCESSFULLY",
+    "message": "Arquivo enviado com sucesso.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FILE_UPLOADING",
+    "message": "Carregando arquivo....",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FILTER",
+    "message": "Filtro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FILTERS",
+    "message": "Filtro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FINALISED_MICROPLAN_SUCCESSFUL",
+    "message": "Microplan finalizado com sucesso!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FINALIZED_MIDDLE_MASSAGE",
+    "message": "instalações e o",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FIXED",
+    "message": "Posto Fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FIXED_POST",
+    "message": "Posto Fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FIXED_POST_DISTRIBUTION",
+    "message": "Suposições de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FIXED_POST_REGISTRATION",
+    "message": "Suposições de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FIXED_POST_REGISTRATIONS",
+    "message": "Suposições de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FOREST",
+    "message": "Floresta",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_CAMPAIGN_COMMODITIES",
+    "message": "Estimativas de commodities",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_CAMPAIGN_VEHICLES",
+    "message": "Estimativas de veículos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_CONFIGURATION",
+    "message": "Configuração de fórmula",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_CONFIGURATION_DESCRIPTION",
+    "message": "Configure a fórmula com relação às premissas consideradas para estimativa de recursos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_FIXED_POST_DISTRIBUTION",
+    "message": "Estimativas de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_FIXED_POST_REGISTRATION",
+    "message": "Estimativas de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_GENERAL_ESTIMATION",
+    "message": "Estimativas gerais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_CAMPAIGN_COMMODITIES",
+    "message": "Estimativas de commodities",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_CAMPAIGN_VEHICLES",
+    "message": "Estimativas de veículos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_FIXED_POST_DISTRIBUTION",
+    "message": "Estimativas de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_FIXED_POST_REGISTRATION",
+    "message": "Estimativas de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_GENERAL_ESTIMATION",
+    "message": "Estimativas gerais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_HOUSEHOLD_DISTRIBUTION",
+    "message": "Estimativas de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_HEADER_HOUSEHOLD_REGISTRATION",
+    "message": "Estimativas de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_HOUSEHOLD_DISTRIBUTION",
+    "message": "Estimativas de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_HOUSEHOLD_REGISTRATION",
+    "message": "Estimativas de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "Isso indica a estimativa para a população média de uma família.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BALES_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de fardos necessários.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BEDNETS_PER_BALE",
+    "message": "Isto indica a estimativa do número total de mosquiteiros necessários.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de mosquiteiros necessários.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "Isto indica a estimativa do número total de equipes de inscrição necessárias para todos os dias da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Isto indica a estimativa do número total de equipes de registro necessárias se a campanha durar um dia.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Isto indica a estimativa do número total de equipes de distribuição de postos fixos necessárias se a campanha durar um dia.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Isto indica a estimativa do número total de equipas de distribuição de postos fixos necessárias para todos os dias de campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de membros da equipe de distribuição de postos fixos necessários para todos os dias da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "Isto indica a estimativa para o número total de supervisores necessários para as equipes de distribuição de postos fixos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Isto indica a estimativa do número total de equipas de pós-registro fixas necessárias se a campanha durar um dia.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Isto indica a estimativa do número total de equipas de registo de postos fixos necessárias para todos os dias de campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de membros da equipe de pós-registro fixo necessários para todos os dias da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de supervisores necessários para as equipas de registo de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Isto indica a estimativa para o número total de domicílios.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Isso indica a estimativa do número total de equipes de distribuição necessárias se a campanha durar um dia.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Isto indica a estimativa do número total de equipes de distribuição necessárias para todos os dias da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Isso indica a estimativa do número total de membros da equipe de distribuição necessários para todos os dias da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Isto indica a estimativa do número total de equipes de registro necessárias se a campanha durar um dia.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Isto indica a estimativa do número total de equipes de inscrição necessárias para todos os dias da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Indica a estimativa do número total de monitores necessários para as equipes de inscrição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de membros da equipe de registro necessários para todos os dias da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isto indica a estimativa do número total de membros da equipe de registro necessários para todos os dias da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MONITORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de monitores necessários para as equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MONITORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Indica a estimativa do número total de monitores necessários para as equipes de inscrição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Isto indica a estimativa para o número total de supervisores necessários para os monitores da equipe de registro.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_PEOPLE_PER_BEDNET",
+    "message": "Isto indica a estimativa do número total de fardos necessários.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_STICKERS_ROLLS_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de rolos de adesivos necessários por limite.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_FIXED_POST_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de supervisores necessários para as equipas de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_FIXED_POST_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de supervisores necessários para as equipas de registo de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de supervisores necessários para as equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NO_OF_SUPERVISORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Isto indica a estimativa do número total de supervisores necessários para as equipes de registro.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Isto indica a estimativa do número total de equipas de distribuição de postos fixos necessárias para todos os dias de campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Isto indica a estimativa do número total de equipas de registo de postos fixos necessárias para todos os dias de campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Isto indica a estimativa do número total de equipes de distribuição de postos fixos necessárias se a campanha durar um dia.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Isto indica a estimativa do número total de equipas de pós-registro fixas necessárias se a campanha durar um dia.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Isto indica a estimativa do número total de supervisores necessários para as equipas de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Isto indica a estimativa do número total de supervisores necessários para equipas de registo de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isto indica a estimativa do número total de membros da equipe de distribuição de postos fixos necessários para todos os dias da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isto indica a estimativa do número total de membros da equipe de pós-registro fixo necessários para todos os dias da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isto indica a estimativa do número total de malas necessárias por fronteira para equipas de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isto indica a estimativa do número total de malas necessárias por fronteira para equipas de registo de posto fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Isto indica a estimativa do número total de sacos necessários por fronteira para as equipas de distribuição de casa em casa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isto indica a estimativa do número total de sacos necessários por fronteira para as equipas de registo porta a porta.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isto indica a estimativa do número total de gizes necessários por fronteira para equipes de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isto indica a estimativa do número total de gizes necessários por limite para equipas de registo de posto fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Isto indica a estimativa do número total de gizes necessários por limite para as equipas de distribuição de casa em casa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isto indica a estimativa do número total de gizes necessários por limite para as equipas de registo de casa em casa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isto indica a estimativa do número total de baias necessárias por fronteira para equipes de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isto indica a estimativa do número total de baias necessárias por limite para equipas de registo de posto fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Isto indica a estimativa do número total de currais necessários por limite para as equipas de distribuição porta a porta.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isto indica a estimativa do número total de parques necessários por limite para as equipas de registo porta a porta.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS",
+    "message": "Isto indica a estimativa do SPAQ necessário para a faixa etária alvo de 3 a 11 meses.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS_WITH_BUFFER",
+    "message": "Isto indica a estimativa do buffer para o SPAQ necessário para a faixa etária alvo de 3 a 11 meses.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS",
+    "message": "Isto indica a estimativa do SPAQ necessário para a faixa etária alvo de 12 a 59 meses.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "Isto indica a estimativa do buffer para o SPAQ necessário para a faixa etária alvo de 12 a 59 meses.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_REQUIRED",
+    "message": "Isso indica a estimativa do SPAQ total necessário.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_SPAQ_REQUIRED_WITH_BUFFER",
+    "message": "Isso indica a estimativa de buffer para o SPAQ total necessário.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_MESSAGE_FOR_TOTAL_TARGET_POPULATION",
+    "message": "Isto indica uma estimativa para a população-alvo total.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_NAME",
+    "message": "Nome da fórmula",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FORMULA_PERMANENT_DELETE_CUSTOM",
+    "message": "Excluir um item de linha excluirá a fórmula. Tem certeza de que deseja excluir a fórmula?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FOR_CONFIRM_TO_DELETE",
+    "message": "Tem certeza de que deseja excluir?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FOR_PERMANENT_DELETE",
+    "message": "Excluir um item de linha excluirá a fórmula. No entanto, você poderá recuperá-lo clicando em",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Formula Name",
+    "message": "Nome da fórmula",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "FormulaConfigScreen",
+    "message": "Configuração de fórmula",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GENERAL_ESTIMATION",
+    "message": "Suposições gerais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GENERAL_INFORMATION",
+    "message": "Informações gerais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GENERATED",
+    "message": "Gerado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GENERATE_MICROPLAN",
+    "message": "Gerar microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GEOJSON",
+    "message": "Geojson",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GEOSPATIAL_MAP_VIEW",
+    "message": "Visualização do mapa geoespacial",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GO_BACK_HOME",
+    "message": "Volte para casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GO_BACK_TO_HOME",
+    "message": "Volte para casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GO_BACK_TO_MY_MICROPLAN",
+    "message": "Voltar para meu microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GO_BACK_TO_USER_MANAGEMENT",
+    "message": "Volte para o gerenciamento de usuários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GO_TO_HCM",
+    "message": "Ir para a campanha HCM",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GRAVEL",
+    "message": "Cascalho",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "GUIDELINES_NEXT",
+    "message": "Criar microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BACK",
+    "message": "Voltar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_BOUNDARY_MESSAGE",
+    "message": "Preencha o modelo baixado com informações populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_CHILD_NOT_PRESENT",
+    "message": "abaixo da jurisdição não estão presentes.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS_DESC",
+    "message": "Insira os detalhes necessários para prosseguir com a configuração do microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DETAILS_HEADER",
+    "message": "Insira os detalhes da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_DISEASE",
+    "message": "Doença de campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_FOR",
+    "message": "Para Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_RESOURCE_DIST_STRAT",
+    "message": "Estratégia de campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CAMPAIGN_TYPE_OF",
+    "message": "Tipo de campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_CLEAR_ALL",
+    "message": "Limpar tudo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_DISEASE_TYPE",
+    "message": "Doença identificada para a campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_ERROR_FILE_UPLOAD_FAILED",
+    "message": "Houve algum erro interno. Por favor, carregue o arquivo novamente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FACILITY_MESSAGE",
+    "message": "Preencha o modelo baixado com informações da instalação e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_FILE_UPLOAD_ERROR",
+    "message": "Faça upload do arquivo válido novamente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLANNING_COMMENT_CHAR_LENGTH_ERROR_TOAST_MESSAGE",
+    "message": "O comentário não pode ter mais de 140 caracteres.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLANNING_COMMENT_TOAST_MESSAGE",
+    "message": "Lista de cessionários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADD_COMMENT_LABEL",
+    "message": "Adicionar comentários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADD_COMMENT_REQUIRED",
+    "message": "Comentário é obrigatório",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADMINISTRATIVEPOST_LABEL",
+    "message": "Posto administrativo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ADMIN_POST_LABEL",
+    "message": "Postagem administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ASSIGNED_DATA_APPROVER_LABEL",
+    "message": "Aprovador de dados atribuído",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_COMMENT_LOG_HEADING",
+    "message": "Registros de comentários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_COMMENT_LOG_VIEW_LINK_LABEL",
+    "message": "Ver registros de comentários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONCRETE",
+    "message": "Concreto",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59_LABEL",
+    "message": "População-alvo confirmada (12 a 59 meses de idade)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11_LABEL",
+    "message": "População-alvo confirmada (3 a 11 meses de idade)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_LABEL",
+    "message": "População-alvo confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION_LABEL",
+    "message": "População total confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_TARGET_POPULATION",
+    "message": "Confirmar a população alvo da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_TARGET_POPULATION_LABEL",
+    "message": "População-alvo confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_TOTAL_POPULATION_LABEL",
+    "message": "População total confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_CONFIRM_VILLAGE_POPULATION",
+    "message": "Confirme a população total da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_COUNTRY_LABEL",
+    "message": "País",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DATA_UPLOAD_GUIDELINES",
+    "message": "Diretrizes para upload de dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DESERT",
+    "message": "Deserto",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DIRT",
+    "message": "Sujeira",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DISCRICT_LABEL",
+    "message": "Distrito",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_DISTRICT_LABEL",
+    "message": "Distrito",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_CONFIRM_POPULATION_LABEL",
+    "message": "Editar população confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_CLOSE",
+    "message": "Cancelar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_COMMENT_LABEL",
+    "message": "Aprovar dados para aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_COMMENT_SUBMIT_LABEL",
+    "message": "Enviar para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Enviar para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_EDIT_AND_VALIDATE",
+    "message": "Enviar e validar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_LABEL",
+    "message": "Editar população da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_POPULATION_SEND_FOR_APPOVAL",
+    "message": "Enviar para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_TARGET_POPULATION",
+    "message": "População-alvo enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_VILLAGE",
+    "message": "Nome da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_VILLAGE_POPULATION",
+    "message": "População da aldeia carregada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_EDIT_WORKFLOW_UPDATED_SUCCESSFULLY",
+    "message": "Os dados das aldeias selecionadas foram enviados com sucesso para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "Insira a população-alvo confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "Insira a população-alvo confirmada (de 12 a 59 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "Insira a população-alvo confirmada (de 3 a 11 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "Insira a população total confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_TARGET_POPULATION",
+    "message": "Insira a população-alvo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ENTER_VILLAGE_POPULATION",
+    "message": "Insira a população da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ERRORS_FOUND",
+    "message": "encontrado no arquivo carregado!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FACILITY_ACTION_ASSIGNMENT",
+    "message": "Atribuir",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FACILITY_VIEW_ASSIGNMENT",
+    "message": "Ver tarefa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT",
+    "message": "Prossiga para finalizar a atribuição da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_HEADING",
+    "message": "Tem certeza de que deseja finalizar a atribuição da instalação?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_MESSAGE",
+    "message": "Por favor, certifique-se de ter verificado minuciosamente a atribuição de instalações para todas as instalações e áreas administrativas sob os limites da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_PREFIX_MESSAGE",
+    "message": "Certifique-se de ter verificado minuciosamente a atribuição da instalação para todos os",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_SUFFIX_MESSAGE",
+    "message": " administrativas sob os limites da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_CANCEL_ACTION",
+    "message": "Quero verificar novamente",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_HEADING_LABEL",
+    "message": "Finalizar a atribuição da instalação à aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_SUBMIT_ACTION",
+    "message": "Quero Finalizar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_SUBMIT_LABEL",
+    "message": "Atribuir instalações às aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN",
+    "message": "Prossiga para finalizar a estimativa do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_HEADING",
+    "message": "Tem certeza de que deseja finalizar a estimativa do microplano?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_MESSAGE",
+    "message": "Por favor, certifique-se de ter verificado minuciosamente a estimativa do microplano para todas as áreas administrativas sob os limites da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_PREFIX_MESSAGE",
+    "message": "Por favor, certifique-se de ter verificado minuciosamente a estimativa do microplano para todos os",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_ALERT_SUFFIX_MESSAGE",
+    "message": " administrativas sob os limites da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_CANCEL_ACTION",
+    "message": "Quero verificar novamente",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_HEADING_LABEL",
+    "message": "Finalizar estimativas de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_MICROPLAN_SUBMIT_LABEL",
+    "message": "Quero Finalizar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_MESSAGE",
+    "message": "Por favor, certifique-se de ter verificado minuciosamente os dados populacionais de todas as áreas administrativas sob os limites da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_PREFIX_MESSAGE",
+    "message": "Por favor, certifique-se de ter verificado minuciosamente os dados populacionais de todos os ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_PREFIX_MESSAGE 11 HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_SUFFIX_MESSAGE",
+    "message": "Por favor, certifique-se de ter verificado minuciosamente os dados populacionais de todas as 11 áreas administrativas sob os limites da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_DESCRIPTION_SUFFIX_MESSAGE",
+    "message": "administrativas sob os limites da campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_HEADING_MESSAGE",
+    "message": "Tem certeza de que deseja finalizar os dados populacionais?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_ALERT_MESSAGE",
+    "message": "Tem certeza de que deseja finalizar os dados populacionais das aldeias?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA",
+    "message": "Prossiga para finalizar os dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA_CANCEL_ACTION",
+    "message": "Quero verificar novamente",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA_LABEL",
+    "message": "Finalizar os dados populacionais das aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FINALIZE_POPULATION_DATA_SUBMIT_ACTION",
+    "message": "Quero Finalizar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_FOREST",
+    "message": "Floresta",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_GRAVEL",
+    "message": "Cascalho",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_HCM_ADMIN_CONSOLE_TARGET_LAT_OPT_LABEL",
+    "message": "Latitude",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_HCM_ADMIN_CONSOLE_TARGET_LONG_OPT_LABEL",
+    "message": "Longitude",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_LOCALITY_LABEL",
+    "message": "Localidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_MICROPLAN_NAME_LABEL",
+    "message": "Nome do Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_MOUNTAIN",
+    "message": "Montanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_NOT_ABLE_TO_FETCH_DETAILS",
+    "message": "Há algum problema. Os detalhes do limite não estão sendo obtidos. ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_NO_ROAD",
+    "message": "Sem estrada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ONLY_POSITIVE_NUMBERS",
+    "message": "Insira um valor numérico positivo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_ONLY_POSITIVE_NUMBERS_MAX_LIMIT_VALIDATION_ERROR",
+    "message": "O valor deve ser um número inteiro maior que 0 e menor que 1.00.000.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLAIN",
+    "message": "Simples",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLAN_INBOX_BACK_BUTTON",
+    "message": "Volte para casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLAN_INBOX_TOTAL_ASSIGNEES",
+    "message": "Lista de cessionários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLURAL_ERROR",
+    "message": "Erros",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PLURAL_ERRORS",
+    "message": "Erros",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_POPULATION_DATA_HEADING",
+    "message": "Dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_POP_INBOX_BACK_BUTTON",
+    "message": "Vá para a página inicial",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_POP_INBOX_TOTAL_ASSIGNEES",
+    "message": "Lista de cessionários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PROCESSED_FILE",
+    "message": "Planilha enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_PROVINCE_LABEL",
+    "message": "Província",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SEARCH_JURISDICTION_INFO_DESCRIPTION",
+    "message": "Selecione os campos suspensos 'Hierarquia administrativa' e depois 'Área administrativa' para pesquisar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SECURITY_AND_ACCESSIBILITY_HEADING",
+    "message": "Segurança e acessibilidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SERVING_FACILITY",
+    "message": "Nome da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_SINGLE_ERROR",
+    "message": "Erro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_STATUS_LOG_FOR_LABEL",
+    "message": "Registros de status para ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_STATUS_LOG_LABEL",
+    "message": "Registros de status",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_TARGET_CANNOT_EXCEED_TOTAL",
+    "message": "A 'População Alvo Confirmada' não deve exceder o valor da 'População Total Confirmada'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_TOTAL_CANNOT_BE_LESS_THAN_TARGET",
+    "message": "A 'População Alvo Confirmada' não deve exceder o valor da 'População Total Confirmada'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59_LABEL",
+    "message": "População-alvo enviada (12 a 59 meses de idade)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11_LABEL",
+    "message": "População-alvo enviada (3 a 11 meses de idade)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_LABEL",
+    "message": "População-alvo enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION_LABEL",
+    "message": "População total enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_TARGET_POPULATION_LABEL",
+    "message": "População-alvo enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_UPLOADED_TOTAL_POPULATION_LABEL",
+    "message": "População total enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VALIDATE_AND_APPROVE_MICROPLAN_ESTIMATIONS",
+    "message": "Validar e aprovar estimativas de microplanos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VIEW_VILLAGE_BACK",
+    "message": "Voltar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_CLOSE_LABEL",
+    "message": "Fechar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_DETAIL_EDIT_LINK",
+    "message": "Editar detalhes de acessibilidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_DETAIL_LINK",
+    "message": "Insira os detalhes de acessibilidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_DETAIL_VIEW_LINK",
+    "message": "Ver detalhes de acessibilidade da vila",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_LABEL",
+    "message": "Acessibilidade da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ACCESSIBILITY_SAVE_LABEL",
+    "message": "Salvar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_HIERARCHY_LABEL",
+    "message": "Detalhes da hierarquia de limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_LABEL",
+    "message": "Aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_ROAD_CONDITION_LABEL",
+    "message": "Estado da estrada da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_CLOSE_LABEL",
+    "message": "Fechar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_DETAIL_LINK",
+    "message": "Insira os detalhes de segurança",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_EDIT_LINK",
+    "message": "Editar detalhes de segurança",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_LABEL",
+    "message": "Segurança da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_LEVEL_LABEL",
+    "message": "Nível de segurança da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_SAVE_LABEL",
+    "message": "Salvar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_SECURITY_VIEW_LINK",
+    "message": "Ver detalhes de segurança da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_TERRAIN_LABEL",
+    "message": "Terreno da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_MICROPLAN_VILLAGE_TRANSPORTATION_MODE_LABEL",
+    "message": "Modo de transporte",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_NEXT",
+    "message": "Próximo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_SELECTED",
+    "message": "Selecionado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_BOUNDARY_MICROPLAN",
+    "message": "População",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_DATA",
+    "message": "Gerenciar dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_UPLOAD_FACILITY_MICROPLAN",
+    "message": "Instalações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_VALIDATION_COMPLETED",
+    "message": "O arquivo foi validado com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HCM_VIEW_ERROR",
+    "message": "Ver erros",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DATA_UPLOAD_GUIDELINES",
+    "message": "Diretrizes para upload de dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DATA_WAS_UPDATED_WANT_TO_SAVE",
+    "message": "Os dados da seção foram atualizados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DELETE_FILE_CONFIRMATION",
+    "message": "Tem certeza de que deseja excluir?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Baixe o modelo Excel para instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Baixe o modelo Geojson para instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_SHAPEFILES",
+    "message": "Baixe o modelo Shapefiles para instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_EXCEL",
+    "message": "Baixe o modelo Excel para instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_GEOJSON",
+    "message": "Baixe o modelo Geojson para instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_SHAPEFILES",
+    "message": "Baixe o modelo Shapefiles para instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATEEXCEL",
+    "message": "Baixe o modelo Excel para taxa de incidentes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_GEOJSON",
+    "message": "Baixe o modelo Geojson para taxa de incidentes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_SHAPEFILES",
+    "message": "Baixe o modelo Shapefiles para taxa de incidentes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Baixe o modelo Excel para população",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Baixe o modelo Geojson para população",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_SHAPEFILES",
+    "message": "Baixe o modelo Shapefiles para população",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_EXCEL",
+    "message": "Baixe modelo Excel para armazéns",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_GEOJSON",
+    "message": "Baixe o modelo Geojson para armazéns",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_SHAPEFILES",
+    "message": "Baixe o modelo Shapefiles para armazéns",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Baixe o modelo Excel para instalações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Baixe o modelo Geojson para instalações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_FACILITIES_SHAPE_FILES",
+    "message": "Baixe o modelo Shapefile para instalações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Baixe modelo Excel para população",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Baixe o modelo Geojson para população",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_DOWNLOAD_TEMPLATE_FOR_POPULATION_SHAPE_FILES",
+    "message": "Baixe o modelo Shapefile para população",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITIES_EXCEL",
+    "message": "Carregar Excel para dados de instalações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITIES_GEOJSON",
+    "message": "Carregar Geojson para dados de instalações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITIES_SHAPE_FILES",
+    "message": "Carregar Shapefile para dados de instalações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITY_EXCEL",
+    "message": "Baixe o modelo Excel para instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITY_GEOJSON",
+    "message": "Baixe o modelo GeoJSON para instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_FACILITY_SHAPE_FILES",
+    "message": "Baixe o modelo Shapefiles para instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_INCIDENT_RATE_EXCEL",
+    "message": "Carregar Excel para dados de taxa de incidentes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_INCIDENT_RATE_GEOJSON",
+    "message": "Carregar Geojson para dados de taxa de incidentes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_INCIDENT_RATE_SHAPE_FILES",
+    "message": "Carregar Shapefile para dados de taxa de incidentes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POLULATION_EXCEL",
+    "message": "Carregar Excel para dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POLULATION_GEOJSON",
+    "message": "Carregar Geojson para dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POLULATION_SHAPE_FILES",
+    "message": "Carregar Shapefile para dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POPULATION_EXCEL",
+    "message": "Carregar Excel para dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POPULATION_GEOJSON",
+    "message": "Carregar Geojson para dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_POPULATION_SHAPE_FILES",
+    "message": "Carregar Shapefile para dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_WARE_HOUSES_EXCEL",
+    "message": "Carregar dados do Excel para armazéns",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_WARE_HOUSES_GEOJSON",
+    "message": "Carregar dados do Geojson para armazéns",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_FILE_UPLOAD_WARE_HOUSES_SHAPE_FILES",
+    "message": "Carregar Shapefile para dados de armazéns",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_HYPOTHESIS",
+    "message": "Proponha seus parâmetros para estimar metas e recursos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_MICROPLAN_GENERATION_CONFIRMATION",
+    "message": "Gerar microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_PROCEED_WITH_NEW_HYPOTHESIS",
+    "message": "Você quer prosseguir com a nova hipótese?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_REUPLOAD_FILE_CONFIRMATION",
+    "message": "Tem certeza de que deseja reenviar os dados?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_RULE_ENGINE",
+    "message": "Configurar a regra",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_SPATIAL_DATA_PROPERTY_MAPPING",
+    "message": "Mapeie suas colunas adequadamente para corresponder ao modelo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_FACILITIES",
+    "message": "Selecione qualquer um dos formatos para carregar dados de instalações.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_FACILITY",
+    "message": "Carregar dados da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_INCIDENT_RATE",
+    "message": "Selecione qualquer um dos formatos para fazer upload de dados de taxa de incidentes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_POPULATION",
+    "message": "Selecione qualquer um dos formatos para fazer upload de dados populacionais.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HEADING_UPLOAD_DATA_WARE_HOUSES",
+    "message": "Selecione qualquer um dos formatos para fazer upload de dados de armazéns",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_HYPOTHESIS_ADD_BUTTON",
+    "message": "Clique em “adicionar mais” para configurar uma nova hipótese. Os valores suspensos são configurados por tipo de campanha. Se um novo valor for necessário, pergunte à equipe de suporte L1/L2",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_HYPOTHESIS_DELETE_BUTTON",
+    "message": "Clique em “excluir” para excluir uma hipótese configurada que não seja relevante para este microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_HYPOTHESIS_INTERACTABLE_SECTION",
+    "message": "Esta página ajuda você a definir valores para suposições/hipóteses usadas em um microplano. Na próxima etapa, você poderá usar esses valores para configurar regras ou fórmulas. Esses valores serão utilizados no mecanismo de cálculo para chegar à quantidade de recursos. Poucas hipóteses são preenchidas por padrão de acordo com o tipo de campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_BASE_MAP",
+    "message": "Clique aqui para selecionar uma camada - isso irá ajudá-lo a visualizar ruas, estradas, corpos d'água com base nos dados disponíveis",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_BOUNDARY_SELECTION",
+    "message": "Clique aqui para selecionar um limite/geografia para o qual você gostaria de ver os detalhes no mapa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_FILTER",
+    "message": "Clique no filtro para ver pontos de interesse e pontos de atendimento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_MAP_GEOMETRIES",
+    "message": "Passe o mouse ou selecione um limite no mapa para visualizar as metas, estimativas de recursos e equipes/pessoas atribuídas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_MAPPING_VIRTUALIZATION",
+    "message": "Clique em 'Visualizações' para ver um mapa coroplético da propriedade selecionada.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_MICROPLAN_DETAILS_CAMPAIGN_DETAILS",
+    "message": "Os detalhes da campanha são exibidos aqui.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_MICROPLAN_DETAILS_EDIT_ROWS",
+    "message": "Para editar um microplano, clique duas vezes em qualquer linha e na próxima seção configure novos valores dos recursos calculados e clique em Salvar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_MICROPLAN_DETAILS_MICROPLAN_NAME",
+    "message": "Você pode inserir o nome do microplano aqui.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_ADD_BUTTON",
+    "message": "Clique em “adicionar mais” para configurar uma nova fórmula. Os valores suspensos são configurados por tipo de campanha. Se você acha que é necessária uma nova fórmula, pergunte à equipe de suporte L1/L2",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_DELETE_BUTTON",
+    "message": "Clique em “excluir” para excluir uma fórmula configurada que não seja relevante para este microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_INPUT",
+    "message": "Clique em “entrada” para selecionar uma opção que foi obtida com base nos dados enviados e nas regras anteriores.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_RULE_ENGINE_INTERACTABLE_SECTION",
+    "message": "Esta página ajuda você a definir valores para fórmulas usadas em um microplano. Essas fórmulas serão utilizadas no mecanismo de cálculo para chegar à quantidade de recursos. Poucas fórmulas ou regras são preenchidas automaticamente com base no tipo de campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HELP_UPLOAD_FILETYPE_OPTION_CONTAINER",
+    "message": "Selecione um formato para upload. Na próxima etapa, leia as diretrizes de dados relacionadas a cada formato na próxima etapa. Se você encontrar algum erro durante o upload, verifique o arquivo de entrada ou entre em contato com a equipe de suporte L1/L2. ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HIERARCHY",
+    "message": "Hierarquia Administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HOME",
+    "message": "Lar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HOUSEHOLD_DISTRIBUTION",
+    "message": "Suposições de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HOUSEHOLD_REGISTRATION",
+    "message": "Suposições de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HOUSEHOLD_REGISTRATION_INFORMATION",
+    "message": "Informações de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HOUSE_TO_HOUSE",
+    "message": "De casa em casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "Isso indica a média de pessoas em uma família. Isso será usado para estimar o número de domicílios.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de malas necessárias por equipa por ciclo para equipas de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Indica o número de malas necessárias por equipe por ciclo para equipes de pós-registro fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de sacos necessários por equipa e por ciclo para as equipas de distribuição domiciliar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isto indica o número de sacos necessários por equipa e por ciclo para as equipas de registo de agregados familiares.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BEDNETS_PER_BALE",
+    "message": "Isso indica o tamanho de um fardo. Isso será usado para estimar o número total de fardos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Indica o número total de beneficiários a serem atendidos por uma equipe de distribuição por dia e por ciclo. Isso será usado para estimar o total de equipes de distribuição necessárias.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Indica o número total de beneficiários a serem atendidos por uma equipe de distribuição por dia e por ciclo. Isso será usado para estimar o total de equipes de distribuição necessárias.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "Isto indica o número de beneficiários ou agregados familiares a serem registados por uma equipa de registo por dia. Isso será usado para estimar o número de equipes de inscrição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de gizes necessários por equipe e por ciclo para equipes de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isto indica o número de gizes necessários por equipe por ciclo para equipes de pós-registro fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de gizes necessários por equipa e por ciclo para as equipas de distribuição aos agregados familiares.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isto indica o número de gizes necessários por equipa e por ciclo para as equipas de registo de agregados familiares.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Isso indica o número total de dias para distribuição. Isso será usado para estimar o número total de equipes de distribuição necessárias.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Isto indica o número total de dias para distribuição domiciliar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Isso indica o número total de dias para registro. Isso será usado para estimar o número total de equipes de registro necessárias.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Isto indica o número de equipas de distribuição de postos fixos geridas por um supervisor. Isto será utilizado para estimar o número total de supervisores para a equipa de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Isto indica o número de equipas de registo de postos fixos geridas por um supervisor. Isto será usado para estimar o número de supervisores para equipas de registo de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "Isto indica o número de domicílios por rolo de adesivos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Isso indica o número de equipes de distribuição que podem ser gerenciadas por um supervisor. Isso será usado para estimar o número total de supervisores necessários para as equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Indica o número de equipes de registro sob um monitor. Isso será usado para estimar o número total de monitores das equipes de inscrição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Indica o número de equipes de registro que podem ser gerenciadas por um supervisor. Isso será usado para estimar o número total de supervisores necessários para as equipes de registro.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isso indica o tamanho da equipe de distribuição. Isso será usado para estimar o total de membros das equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isso indica o tamanho da equipe de uma equipe de pós-registro fixo. Isso será usado para estimar o total de membros das equipes de inscrição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Isto indica o tamanho da equipe de distribuição domiciliar. Isso será usado para estimar o total de membros das equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isto indica o tamanho de uma equipe de registro. Isso será usado para estimar o número total de membros da equipe de registro.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Indica o número de monitores gerenciados por um supervisor. Isto será usado para estimar o número total de supervisores para equipes de registro.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de baias necessárias por equipe e por ciclo para equipes de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isto indica o número de baias necessárias por equipe e por ciclo para equipes de pós-registro fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de baias necessárias por equipa e por ciclo para as equipas de distribuição aos agregados familiares.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isto indica o número de baias necessárias por equipa e por ciclo para as equipas de registo de agregados familiares.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NO_OF_PEOPLE_PER_BEDNET",
+    "message": "Isto indica o número de pessoas a serem acomodadas numa rede mosquiteira. Isto será usado para estimar o número total de mosquiteiros.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Isto indica o número de mosquiteiros a serem distribuídos por uma equipa de distribuição por dia. Isso será usado para estimar o número de equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Indica o número de beneficiários ou agregados familiares a registar por dia no ponto de distribuição de postos fixos. Isto será usado para estimar o número de equipes de registro de postos fixos necessárias.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Isso indica o número de dias de registro. Isto será usado para estimar o número total de equipes de registro de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Isso indica o número de equipes de distribuição sob um monitor. Isso será usado para estimar o número total de monitores para equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isso indica o tamanho de uma equipe de distribuição. Isso será usado para estimar o número total de membros da equipe de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_TOTAL_BUFFER_MULTIPLIER",
+    "message": "Isto indica a percentagem de buffer que será utilizada para calcular o total de recursos necessários em excesso.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHEISIS_MESSAGE_FOR_TOTAL_CYCLES_OF_SMC",
+    "message": "Isto indica o número total de ciclos na campanha SMC. Isso será usado para estimar o número total de SPAQ necessários.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS",
+    "message": "Hipótese",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_INSTRUCTIONS_DELETE_ENTRY_CONFIRMATION",
+    "message": "A exclusão de um item de linha excluirá permanentemente a estimativa. Você não será capaz de recuperá-lo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_KEY_HELP_TEXT",
+    "message": "Esta é uma suposição de quantas pessoas constituem uma família.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_AVERAGE_PEOPLE_IN_A_HOUSEHOLD",
+    "message": "Isso indica a média de pessoas em uma família. Isso será usado para estimar o número de domicílios.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Indica a quantidade de sacolas necessárias por equipe por ciclo para distribuição em posto fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Indica a quantidade de sacolas necessárias por equipe por ciclo para inscrição em posto fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de sacos por equipa por ciclo para distribuição de casa em casa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Indica o número de sacolas por equipe por ciclo para inscrição casa a casa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BEDNETS_PER_BALE",
+    "message": "Isso indica o tamanho de um fardo. Isso será usado para estimar o número total de fardos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BEDNETS_TO_BE_DISTRIBUTED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY",
+    "message": "Isto indica o número de mosquiteiros a serem distribuídos por uma equipa de distribuição por dia. Isso será usado para estimar o número de equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Indica o número total de beneficiários a serem atendidos por uma equipe de distribuição por dia e por ciclo. Isso será usado para estimar o total de equipes de distribuição necessárias.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_CATERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Indica o número de beneficiários a serem atendidos por dia no ponto de distribuição de posto fixo. Isto será utilizado para estimar o número de equipas de distribuição no ponto de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "Isto indica o número de beneficiários ou agregados familiares a serem registados por uma equipa de registo por dia. Isso será usado para estimar o número de equipes de inscrição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Indica o número de beneficiários a registar por dia no ponto de distribuição de postos fixos. Isto será utilizado para estimar o número de equipas de registo no ponto fixo de distribuição de postos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de gizes necessários por equipe por ciclo para distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isto indica o número de gizes necessários por equipe por ciclo para registro de posto fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de gizes necessários por equipa por ciclo para distribuição de casa em casa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isto indica o número de gizes necessários por equipa e por ciclo para o registo de casa em casa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Isso indica o número de dias de distribuição. Isto será usado para estimar o número total de equipes de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Isso indica o número de dias de registro. Isto será usado para estimar o número total de equipes de registro de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Isso indica o número de dias de distribuição. Isso será usado para estimar o número total de equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Isso indica o número de dias de registro. Isso será usado para estimar o número total de equipes inscritas.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Isto indica o número de equipas de registo de postos fixos geridas por um supervisor. Isto será utilizado para estimar o número total de supervisores para a equipa de registo de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Isto indica o número de equipas de registo de postos fixos geridas por um supervisor. Isto será utilizado para estimar o número total de supervisores para a equipa de registo de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "Isto indica o número de domicílios por rolo de adesivos. Isso será usado para estimar as necessidades de rolos de adesivos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_MONITOR",
+    "message": "Isso indica o número de equipes de distribuição sob um monitor. Isso será usado para estimar o número total de monitores para equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Isso indica o número de equipes de distribuição que podem ser gerenciadas por um supervisor. Isso será usado para estimar o número total de supervisores necessários para as equipes de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Indica o número de equipes de registro sob um monitor. Isso será usado para estimar o número total de monitores das equipes de inscrição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Indica o número de equipes de registro que podem ser gerenciadas por um supervisor. Isso será usado para estimar o número total de supervisores necessários para as equipes de registro.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isso indica o tamanho de uma equipe fixa de distribuição de postos. Isso será usado para estimar o número total de membros da equipe de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isto indica o tamanho de uma equipe fixa de registro de postos. Isso será usado para estimar o número total de membros da equipe de registro de posto fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": " Isso indica o tamanho de uma equipe de distribuição. Isso será usado para estimar o número total de membros da equipe de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isso indica o tamanho de uma equipe de registro. Isso será usado para estimar o número total de membros da equipe de registro.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_FIXED_POST_REGISTRATION",
+    "message": "Indica o número de monitores gerenciados por um supervisor. Isto será utilizado para estimar o número total de supervisores para a equipa de registo de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Indica o número de monitores gerenciados por um supervisor. Isso será usado para estimar o número total de supervisores para a equipe de distribuição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Indica o número de monitores gerenciados por um supervisor. Isso será usado para estimar o número total de supervisores para a equipe de registro.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de baias necessárias por equipe e por ciclo para distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isto indica o número de baias necessárias por equipe por ciclo para inscrição em posto fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Isto indica o número de baias necessárias por equipa e por ciclo para distribuição de casa em casa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Isto indica o número de baias necessárias por equipa e por ciclo para registo casa a casa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NO_OF_PEOPLE_PER_BEDNET",
+    "message": "Isto indica o número de pessoas a serem acomodadas numa rede mosquiteira. Isto será usado para estimar o número total de mosquiteiros.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_AT_THE_FIXES_POST_DISTRIBUTION_POINT_PER_DAY",
+    "message": "Isto indica o número de mosquiteiros a serem distribuídos no ponto de distribuição de postes fixos por dia. Isto será utilizado para estimar o número de equipas de distribuição no ponto de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Isto indica o número de mosquiteiros a serem distribuídos no ponto de distribuição do posto fixo por dia. Isto será utilizado para estimar o número de equipas de distribuição no ponto de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Indica o número de beneficiários ou agregados familiares a registar por dia no ponto de distribuição de postos fixos. Isto será utilizado para estimar o número de equipas de registo no ponto fixo de distribuição de postos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Isso indica o número de dias de distribuição. Isto será usado para estimar o número total de equipes de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Isso indica o número de dias de registro. Isto será usado para estimar o número total de equipes de registro de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_MANAGED_BY_A_SUPERVISOR",
+    "message": "Isto indica o número de equipas de distribuição de postos fixos geridas por um supervisor. Isto será utilizado para estimar o número total de supervisores para a equipa de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Isto indica o número de equipas de distribuição de postos fixos geridas por um supervisor. Isto será utilizado para estimar o número total de supervisores para a equipa de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Isto indica o número de equipas de registo de postos fixos geridas por um supervisor. Isto será utilizado para estimar o número total de supervisores para a equipa de registo de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Isso indica o tamanho de uma equipe fixa de distribuição de postos. Isso será usado para estimar o número total de membros da equipe de distribuição de postos fixos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_NUMBER_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Isto indica o tamanho de uma equipe fixa de registro de postos. Isso será usado para estimar o número total de membros da equipe de registro de posto fixo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_TOTAL_BEDNET_WASTAGE",
+    "message": "Isto indica o factor de desperdício total dos mosquiteiros.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_TOTAL_BUFFER_MULTIPLIER",
+    "message": "Isto indica a percentagem de buffer que será utilizada para calcular o total de recursos necessários em excesso.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_MESSAGE_FOR_TOTAL_CYCLES_OF_SMC",
+    "message": "Isto indica o número total de ciclos na campanha SMC. Isso será usado para estimar o número total de SPAQ necessários.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYPOTHESIS_VALUE_HELP_TEXT",
+    "message": "Defina um valor para calcular os recursos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYP_CONFIRM_TO_DELETE",
+    "message": "Tem certeza de que deseja excluir?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYP_PERMANENT_DELETE",
+    "message": "Excluir um item de linha excluirá a suposição. No entanto, você poderá recuperá-lo clicando em",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "HYP_PERMANENT_DELETE_CUSTOM",
+    "message": "Excluir um item de linha excluirá a suposição. Tem certeza de que deseja excluir a suposição?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Home",
+    "message": "Lar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_ASSIGNEE",
+    "message": "Cessionário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "População-alvo confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "População-alvo confirmada (12 a 59 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "População-alvo confirmada (12 a 59 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "População-alvo confirmada (de 3 a 11 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "População-alvo confirmada (de 3 a 11 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_CONFIRMED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "População Total Confirmada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_EDITPOPULATION",
+    "message": "Editar população",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_STATUSLOGS",
+    "message": "Registros de status",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_TOTAL_POPULATION",
+    "message": "População total",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "População-alvo enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "População-alvo enviada (de 12 a 59 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12_TO_59",
+    "message": "População-alvo enviada (de 12 a 59 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "População-alvo enviada (de 3 a 11 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3_TO_11",
+    "message": "População-alvo enviada (de 3 a 11 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_UPLOADED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "População total enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INBOX_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INCIDENT_RATE",
+    "message": "Taxa de incidentes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INCORRECT_FIELDS",
+    "message": "Insira um valor numérico positivo válido com 2 casas decimais e apenas até 1000.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INFO",
+    "message": "Informações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INFORMATION_DESCRIPTION",
+    "message": "De acordo com as diretrizes padrão de upload de dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INFORMATION_DESCRIPTION_LINK",
+    "message": "aqui",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INITIATE",
+    "message": "Dados enviados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_FACILITIES",
+    "message": "Selecione qualquer um dos seguintes formatos para carregar os dados das instalações necessários para o seu microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_FACILITY",
+    "message": "Selecione qualquer um dos seguintes formatos para carregar os dados da instalação necessários para o seu microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_INCIDENT_RATE",
+    "message": "Selecione qualquer um dos formatos a seguir para carregar os dados da taxa de incidentes necessários para o seu microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_POPULATION",
+    "message": "Selecione qualquer um dos seguintes formatos para carregar os dados populacionais necessários para o seu microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DATA_UPLOAD_OPTIONS_WARE_HOUSES",
+    "message": "Selecione qualquer um dos seguintes formatos para carregar os dados de armazéns necessários para o seu microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DELETE_FILE_CONFIRMATION",
+    "message": "Excluir o arquivo enviado irá apagá-lo permanentemente. Você não será capaz de recuperá-lo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Baixe o modelo Excel para instalações. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Baixe o modelo Geojson para instalações. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITIES_SHAPEFILES",
+    "message": "Baixe o modelo Shapefiles para instalações. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_EXCEL",
+    "message": "Baixe o modelo Excel para Instalação. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_GEOJSON",
+    "message": "Baixe o modelo Geojson para Instalação. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_FACILITY_SHAPEFILES",
+    "message": "Baixe o modelo Shapefiles para Facility. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATEEXCEL",
+    "message": "Baixe o modelo Excel para Taxa de Incidentes. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_GEOJSON",
+    "message": "Baixe o modelo Geojson para taxa de incidentes. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_INCIDENT_RATE_SHAPEFILES",
+    "message": "Baixe o modelo Shapefiles para Taxa de Incidentes. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Baixe o modelo Excel que contém a hierarquia de limites. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Baixe o modelo Geojson para população. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_POPULATION_SHAPEFILES",
+    "message": "Baixe o modelo Shapefiles para população. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_EXCEL",
+    "message": "Baixe o modelo Excel para Armazéns. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_GEOJSON",
+    "message": "Baixe o modelo Geojson para Armazéns. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_EXCEL_TEMPLATE_FOR_WARE_HOUSES_SHAPEFILES",
+    "message": "Baixe o modelo Shapefiles para Armazéns. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_FACILITIES_EXCEL",
+    "message": "Baixe o modelo Excel que contém a hierarquia de limites. Depois de fazer o download, preencha o modelo com os dados das instalações e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_FACILITIES_GEOJSON",
+    "message": "Baixe o modelo Geojson que contém a hierarquia de limites. Depois de fazer o download, preencha o modelo com os dados das instalações e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_FACILITIES_SHAPE_FILES",
+    "message": "Baixe o modelo Shapefile que contém a hierarquia de limites. Depois de fazer o download, preencha o modelo com os dados das instalações e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_POPULATION_EXCEL",
+    "message": "Baixe o modelo Excel que contém a hierarquia de limites. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_POPULATION_GEOJSON",
+    "message": "Baixe o modelo Geojson que contém a hierarquia de limites. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_DOWNLOAD_TEMPLATE_FOR_POPULATION_SHAPE_FILES",
+    "message": "Baixe o modelo Shapefile que contém a hierarquia de limites. Depois de fazer o download, preencha o modelo com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_FACILITIES",
+    "message": "Preencha o modelo baixado com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_FACILITY",
+    "message": "Preencha o modelo baixado com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_INCIDENT_RATE",
+    "message": "Preencha o modelo baixado com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_POPULATION",
+    "message": "Preencha o modelo baixado com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_FILE_UPLOAD_FROM_TEMPLATE_WARE_HOUSES",
+    "message": "Preencha o modelo baixado com dados populacionais e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_MICROPLAN_GENERATION_CONFIRMATION",
+    "message": "Tem certeza que deseja executar o microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_REUPLOAD_FILE_CONFIRMATION",
+    "message": "Reenviar o arquivo apagará o arquivo enviado anteriormente e você não poderá recuperá-lo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UNLOAD_EXCEL",
+    "message": "Arraste e solte sua planilha Excel preenchida ou navegue pelos meus arquivos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UNLOAD_GEOJSON",
+    "message": "Arraste e solte seu arquivo GeoJSON preenchido ou navegue pelos meus arquivos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UNLOAD_SHAPE_FILES",
+    "message": "Arraste e solte seus Shapefiles preenchidos ou navegue pelos meus arquivos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_BROWSE_FILES",
+    "message": "Navegue em meus arquivos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_EXCEL",
+    "message": "Arraste e solte sua planilha Excel preenchida ou",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_FACILITIES",
+    "message": "Arraste e solte seu arquivo geojson preenchido ou",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_GEOJSON",
+    "message": "Arraste e solte seu arquivo geojson preenchido ou",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTIONS_UPLOAD_SHAPE_FILES",
+    "message": "Arraste e solte seu arquivo geojson preenchido ou",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_DATA_WAS_UPDATED_WANT_TO_SAVE",
+    "message": "Quer salvá-lo?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_HYPOTHESIS",
+    "message": "As chaves sugeridas são pré-preenchidas. Insira valores para as chaves para formular sua hipótese. Isso será usado para estimativa de recursos. ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_1",
+    "message": "Você está na aba Clientes BI na tela de edição de características nas ferramentas de modelagem do BW. Você escolheu Formas ou Formas e dados de pontos como tipo geográfico.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_2",
+    "message": "Escolha Carregar Shapefiles em Ações. Escolha Ir. O back-end do BW/4 é aberto.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_3",
+    "message": "Selecione seus shapefiles. Você precisa dos três shapefiles a seguir: .dbf, .shp, .shx. Os shapefiles devem estar na Referência Espacial ID 4326 e devem ter todos o mesmo nome antes do final.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_4",
+    "message": "Escolha Atualizar tabela geográfica em Ações. Escolha Ir. Você pode escolher Atualização Delta ou Atualização Completa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_POINTS_5",
+    "message": "As formas carregadas são transformadas e armazenadas no SRID (Spatial Reference ID) 3857. Portanto, não é possível utilizar formas no SAC se elas excederem as limitações deste sistema de referência espacial. Isso significa que não devem ter graus de latitude superiores a 85,06° e -85,06°.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PREREQUISITES_1",
+    "message": "Você adicionou uma coluna ou campo com o nome da característica aos shapefiles para os quais deseja carregar formas. Se estiver usando características compostas, você adicionou diversas colunas. Mais informações:",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PREREQUISITES_2",
+    "message": "Para atualizar a tabela geográfica com formas que são carregadas no Business Document Server, você precisa do SAP HANA 2.0 Rev 45.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PREREQUISITES_LINK",
+    "message": "Preparando arquivos de forma",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_PROCEED_WITH_NEW_HYPOTHESIS",
+    "message": "Sua hipótese foi alterada em relação à proposta anteriormente. Você não poderá editar ou alterar sua hipótese depois que o microplano for gerado.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_RULE_ENGINE",
+    "message": "Configure sua fórmula para o microplano definindo sua entrada, operadores, valor e chaves.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INSTRUCTION_SPATIAL_DATA_PROPERTY_MAPPING",
+    "message": "O arquivo Geojson ou shape que você carregou tem nomes de tags diferentes conforme o esperado. Por favor, realize um pequeno exercício de mapeamento para que possamos saber em quais colunas mapeá-lo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INTERNAL_SERVER_ERROR",
+    "message": "Erro do Servidor Interno",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INVALID_MOBILE_NUMBER",
+    "message": "Insira um número de celular válido.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "INVALID_MOBILE_NUMBER_LENGTH",
+    "message": "Insira um número de contato válido para pesquisar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "KEY",
+    "message": "Chaves",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LAYERS",
+    "message": "Camadas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_GUIDELINE_POINTS_1",
+    "message": "O nome do arquivo deve ser 'Population.xlsx'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_EXCEL_GUIDELINE_POINTS_2",
+    "message": "Os campos Latitude e Longitude devem ter dados em Graus Decimais e Graus Minuto Segundos (o valor deve ser 12,3455 e não 12° 20' 43,7994')",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_1",
+    "message": "O arquivo GeoJSON deve atender à especificação {{link}}.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_2",
+    "message": "O nome do arquivo deve ser 'Population.geojson'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_3",
+    "message": "Todos os recursos no arquivo devem ter geometrias do mesmo tipo (ou seja, todos devem ser pontos ou todos devem ser multipolígonos e assim por diante).",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_4",
+    "message": "As coordenadas devem estar no intervalo válido de latitude e longitude (o intervalo válido para latitude é -90 a +90 e o intervalo válido de longitude é -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_5",
+    "message": "Todos os recursos do arquivo devem ter propriedades com o mesmo conjunto de chaves.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_6",
+    "message": "As características do arquivo devem ter chaves importantes como 'País', 'Província', 'Distrito', 'Posto administrativo', 'Localidade', 'Aldeia', 'Código de limite', 'População alvo'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_GUIDELINE_POINTS_7",
+    "message": "No objeto Propriedades, os valores dos campos que representam um Valor Numérico não devem ser colocados entre aspas duplas (ou seja, uma população de 10.000 deve ser representada como “população”: 10.000 e não “população”: “10.0000”",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_GEOJSON_SPECIFICATION",
+    "message": "RFC 7946 GeoJSON",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_1",
+    "message": "O usuário deve compactar todos os arquivos no formato .zip e carregá-los no sistema. No mínimo, o sistema precisa de arquivos .shp, .shx e .dbf compactados.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_2",
+    "message": "O nome do arquivo zip deve ser 'Population.zip'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_3",
+    "message": "O shapefile deve estar no sistema de coordenadas lat-long WGS 84 para que o sistema aceite.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_4",
+    "message": "As coordenadas devem estar no intervalo válido de latitude e longitude (o intervalo válido para latitude é -90 a +90 e o intervalo válido de longitude é -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_5",
+    "message": "O arquivo shape deve conter pontos de dados importantes, como 'País', 'Província', 'Distrito', 'Posto administrativo', 'Localidade', 'Aldeia', 'Limite', 'código', 'População-alvo'",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LLIN_MZ_POPULATION_SHAPEFILE_GUIDELINE_POINTS_6",
+    "message": "O tamanho total do arquivo compactado não deve exceder 2 GB.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LOADING",
+    "message": "Carregando...",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LOADING_MAP",
+    "message": "Carregando mapa...",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "LOGGED_IN_AS",
+    "message": "Logado como",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MALARIA",
+    "message": "Malaria",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MAPPING",
+    "message": "Mapeamento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_BOUNDARIES",
+    "message": "Limites",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_HEADING",
+    "message": "Filtro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_INSTRUCTIONS",
+    "message": "As chaves sugeridas são pré-preenchidas. Insira valores para as chaves para formular sua hipótese. ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_LAYERS",
+    "message": "Camadas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MAPPING_FILTER_VIRTUALISATIONS",
+    "message": "Virtualização",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MAPPING_NO_DATA_TO_SHOW",
+    "message": "Nenhum dado de localização foi carregado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MAPPING_PARTIAL_DATA_TO_SHOW",
+    "message": "Faltam coordenadas de localização em alguns pontos de dados. Faça upload das coordenadas de localização de todos os pontos de dados para visualizá-los no mapa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLANS",
+    "message": "Meus microplanos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVEPOST",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVE_AREA",
+    "message": "Área Administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVE_BOUNDARY",
+    "message": "Área Administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINISTRATIVE_HIERARCHY",
+    "message": "Hierarquia Administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ADMINSTRATIVEPOST",
+    "message": "Posto Administrativo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGN",
+    "message": "Atribuir",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGNED_FACILITIES",
+    "message": "Aldeias Atribuídas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGNMENT_FACILITY",
+    "message": "Designação da aldeia de captação para",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGN_CATCHMENT_VILLAGES",
+    "message": "Atribuir aldeias de captação para as instalações ou pontos de serviços",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSIGN_FACILITY",
+    "message": "Adicionar à instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ASSUMPTIONS",
+    "message": "Suposições do Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_BOUNDARY_IS_EMPTY_WARNING",
+    "message": "Selecione os campos suspensos 'Hierarquia administrativa' e depois 'Área administrativa' para pesquisar.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_CAPACITY",
+    "message": "Capacidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_CLOSE_BUTTON",
+    "message": "Fechar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_COUNTRY",
+    "message": "País",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_DATA_CONFIGURATION_HEADING",
+    "message": "Gerenciamento de dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_DETAILS",
+    "message": "Detalhes da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISEASE_MALARIA",
+    "message": "Malaria",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRIBUTION_FIXED_POST",
+    "message": "Posto Fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRIBUTION_HOUSE_TO_HOUSE",
+    "message": "De casa em casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRIBUTION_MIXED",
+    "message": "Posto Fixo e Casa a Casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_ESTIMATION_ASSUMPTIONS_HEADING",
+    "message": "Suposições do Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_EXECUTED",
+    "message": "Microplano finalizado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITYNAME",
+    "message": "Nome da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITYSTATUS",
+    "message": "Status da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITYTYPE",
+    "message": "Tipo de instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_ACTION",
+    "message": "Ação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_ASSIGNED_VILLAGES",
+    "message": "Aldeias Atribuídas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_CAPACITY",
+    "message": "Capacidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_FIXEDPOST",
+    "message": "Posto Fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_LLIN-mz_CAPACITY",
+    "message": "Capacidade (fardos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_MR-DN_CAPACITY",
+    "message": "Capacidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_NAME",
+    "message": "Nome da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_NAME_LABEL",
+    "message": "Nome da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_RESIDINGVILLAGE",
+    "message": "Área Administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_SERVINGPOPULATION",
+    "message": "Atendendo à População",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_STATUS",
+    "message": "Status da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_TYPE",
+    "message": "Tipo de instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FACILITY_TYPE_LABEL",
+    "message": "Tipo de instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FIXEDPOST",
+    "message": "Posto Fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_FORMULA_CONFIGURATION_HEADING",
+    "message": "Configuração de fórmula",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY",
+    "message": "Microplan gerado com sucesso!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY_DESCRIPTIION",
+    "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incidente ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea comodo consequat.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY_ID_LABEL",
+    "message": "ID do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATED_SUCCESSFULLY_NAME_LABEL",
+    "message": "Nome do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_GENERATION",
+    "message": "Geração de microplanos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_MODULE_PROCESS",
+    "message": "Processo Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_MODULE_SETUP",
+    "message": "Configuração do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAME",
+    "message": "Nome do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAME_INPUT_PLACEHOLDER",
+    "message": "Exemplo: Microplan-Country-CampaignType-Date",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINTS",
+    "message": "Restrições de nomenclatura de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINT_1",
+    "message": "O nome deve ter no mínimo duas letras.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINT_2",
+    "message": "Apenas valores numéricos não são permitidos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONSTRAINT_3",
+    "message": "Caracteres especiais -, _, (, ) só são permitidos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION",
+    "message": "Formato de nomenclatura do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_1",
+    "message": "O nome deve ter no mínimo 3 caracteres e no máximo 64 caracteres de comprimento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_2",
+    "message": "Apenas valores numéricos não são permitidos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_3",
+    "message": "Caracteres especiais -, _, (, )& só são permitidos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NAMING_CONVENTION_4",
+    "message": "Somente caracteres especiais como (-, _-) não são permitidos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NO_OF_BALES_PER_BOUNDARY",
+    "message": "Fardos totais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NO_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Total de mosquiteiros",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_NO_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Total de domicílios",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_PLEASE_FILL_ALL_THE_FIELDS_AND_RESOLVE_ALL_THE_ERRORS",
+    "message": "Preencha todos os campos obrigatórios e resolva todos os erros antes de avançar para a próxima etapa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_APPLY",
+    "message": "Aplicar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_CREATE_BY",
+    "message": "Criado por dev-super1",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_HYPOTHESIS",
+    "message": "Hipótese",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_HYPOTHESIS_HEADING",
+    "message": "Configurar a hipótese ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_PREVIEW_HYPOTHESIS_INSTRUCTIONS",
+    "message": "Atualize a hipótese para recalcular a estimativa de recursos para a campanha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_RESIDINGVILLAGE",
+    "message": "Vila Residencial",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_RESIDING_VILLAGE",
+    "message": "Área Administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_RESIDING_VILLAGE_LABEL",
+    "message": "Áreas administrativas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_SEARCH",
+    "message": "Microplanos abertos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECTED",
+    "message": "selecionado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECTED_PLURAL",
+    "message": "Selecionado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Os limites são as áreas administrativas definidas nas quais você deseja executar uma campanha. Comece a selecionar os limites do primeiro nível para que os limites presentes no próximo nível estejam disponíveis para seleção.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_SELECT_BOUNDARY",
+    "message": "Selecione os limites onde deseja veicular a campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_SERVINGPOPULATION",
+    "message": "Atendendo à População",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS",
+    "message": "Status",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_CENSUS_DATA_APPROVAL_IN_PROGRESS",
+    "message": "Validação em andamento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_CENSUS_DATA_APPROVED",
+    "message": "Validação em andamento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_COLUMN_DRAFT",
+    "message": "Rascunho",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_COLUMN_GENERATED",
+    "message": "Gerado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_DRAFT",
+    "message": "Configuração elaborada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_EXECUTION_TO_BE_DONE",
+    "message": "Configuração concluída",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_RESOURCE_ESTIMATIONS_APPROVE",
+    "message": "Microplano finalizado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_RESOURCE_ESTIMATIONS_APPROVED",
+    "message": "Microplano finalizado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_STATUS_RESOURCE_ESTIMATION_IN_PROGRESS",
+    "message": "Validação em andamento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_SUCCESS",
+    "message": "Validar e aprovar estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_SUM_TOTAL_TARGET_POPULATION",
+    "message": "População-alvo total",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEST",
+    "message": "Mensagem de teste",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_TEST2",
+    "message": "Mensagem de teste",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_TYPE_LLIN_MZ",
+    "message": "Campanha de redes mosquiteiras",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_TYPE_MR_DN",
+    "message": "Campanha SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_UNASSIGNED_FACILITIES",
+    "message": "Aldeias não atribuídas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_UNASSIGN_FACILITY",
+    "message": "Remover de",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_UNASSIGN_FACILITY IRS",
+    "message": "Remover de",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_VIEWER",
+    "message": "Visualizador de estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_VIEWER_DESCRIPTION",
+    "message": "Esta função terá acesso para visualizar estimativas de microplano do limite administrativo atribuído.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_VIEWER_POPUP_HEADING",
+    "message": "Selecione visualizadores de estimativa de microplano ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_VILLAGES_SELECTED",
+    "message": "selecionado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_in",
+    "message": "abas presentes em",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MICROPLAN_tabs",
+    "message": "Guias de planilha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MIXED",
+    "message": "Posto Fixo e Casa a Casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MONITORS",
+    "message": "Monitores",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MOUNTAIN",
+    "message": "Montanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MPAIGN_SELECT_BOUNDARIES_DESCRIPTION",
+    "message": "Os limites são as áreas administrativas nas quais você deseja executar um microplano. Comece a selecionar os limites do primeiro nível para que os limites estejam disponíveis no próximo nível para seleção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ACK",
+    "message": "OK",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ACTIONS_EDIT_SETUP",
+    "message": "Editar configuração",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ACTIONS_FOR_MICROPLAN_SEARCH",
+    "message": "Ações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ACTIONS_VIEW_SUMMARY",
+    "message": "Ver resumo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ADMINISTRATIVEPOST",
+    "message": "Posto administrativo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ASSUMPTIONS_INVALIDATION_MESSAGE",
+    "message": "Depois de alterá-lo, você terá que preencher os detalhes das suposições novamente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ASSUMPTION_NAME_INVALID",
+    "message": "O nome da suposição é inválido. Insira um nome alfanumérico válido.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_BACK",
+    "message": "Voltar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_BOUNDARY_SELECTION",
+    "message": "Seleção de limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_SETUP_DETAILS",
+    "message": "Detalhes do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_HEADER",
+    "message": "Baixe o modelo Excel para população",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_BOUNDARY_DATA_MODAL_TEXT",
+    "message": "Baixe o modelo Excel que contém os dados de limite selecionados. Depois de fazer o download, preencha o modelo com os dados de destino corretos e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_HEADER",
+    "message": "Baixe o modelo Excel para instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_FACILITY_DATA_MODAL_TEXT",
+    "message": "Baixe o modelo Excel que contém a lista de instalações permanentes e a lista de dados de limites selecionados. Depois de fazer o download, preencha o modelo com os dados corretos da instalação e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_CAMPAIGN_UPLOAD_SKIP",
+    "message": "Pular",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_COMPLETE_SETUP",
+    "message": "Configuração completa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_DISTRICT",
+    "message": "Distrito",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION",
+    "message": "Insira o valor da suposição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION_CAMPAIGN_VEHICLES",
+    "message": "Insira a capacidade do veículo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION_CAMPAIGN_VEHICLES_LLIN-mz",
+    "message": "Capacidade do veículo (em fardos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ENTER_ASSUMPTION_CAMPAIGN_VEHICLES_MR-DN",
+    "message": "Capacidade do veículo (em blisters)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_FACILITY_TOTALPOPULATION",
+    "message": "População-alvo aprovada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_FACILITY_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_FAILED_USER_CREATION",
+    "message": "A criação do usuário falhou. Por favor, tente reenviar o arquivo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_FILES_INVALIDATION_MESSAGE",
+    "message": "A atualização dos limites afetará os dados carregados da população e das instalações (se carregados). Atualize com cautela.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_FOOTER",
+    "message": "Por favor, dê um nome ao microplano. Este nome será utilizado para referência e identificação nas próximas etapas.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_FORMULA_NAME_INVALID",
+    "message": "O nome da fórmula é inválido. Insira um nome alfanumérico válido.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_INPROGRESS_USER_CREATION",
+    "message": "A criação do usuário está em andamento. Por favor, espere um pouco.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_LOCALITY",
+    "message": "Localidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_MANAGING_DATA",
+    "message": "Gerenciamento de dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_NAME_OF_MICROPLAN_MY_MICROPLANS",
+    "message": "Nome do Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_NAME_OF_MICROPLAN_OPEN_MICROPLANS",
+    "message": "Nome do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_NEXT",
+    "message": "Próximo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_PLAN_ASSIGNED_TO_ALL",
+    "message": "Atribuído a todos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_PLAN_MICROPLAN_NAME",
+    "message": "Nome do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_POP_ASSIGNED_TO_ALL",
+    "message": "Atribuído a todos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_POP_ASSIGNED_TO_ALL ",
+    "message": "Atribuído a todos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_BOUNDARY_MANAGER",
+    "message": "Administrador do sistema",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_CAMPAIGN_MANAGER",
+    "message": "Gerente de campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_FACILITY_CATCHMENT_ASSIGNER",
+    "message": "Atribuidor de limites da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_FACILITY_CATCHMENT_MAPPER",
+    "message": "Atribuidor de limites da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_MICROPLAN_ADMIN",
+    "message": "Administrador do Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_MICROPLAN_APPROVER",
+    "message": "Aprovador de estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_MICROPLAN_VIEWER",
+    "message": "Visualizador de estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_PLAN_ESTIMATION_APPROVER",
+    "message": "Aprovador de estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_POPULATION_DATA_APPROVER",
+    "message": "Aprovador de dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Atribuidor de limites de instalações nacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Aprovador nacional de estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Aprovador de dados populacionais nacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_ROLE_SYSTEM_ADMINISTRATOR",
+    "message": "Administrador do sistema",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_SAVE_PROCEED",
+    "message": "Salvar e prosseguir",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_UM_FILTER",
+    "message": "Filtro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_UPLOAD_USER",
+    "message": "Carregar usuários em massa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_USER_CREATION",
+    "message": "Criação de usuário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_USER_DATA_UPLOADED_WILL_BE_AVAILABLE",
+    "message": "Os dados do usuário carregados estarão disponíveis na atribuição de usuário do seu microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_EMAIL",
+    "message": "E-mail",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_FILTER",
+    "message": "Filtro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_MOBILE_NO",
+    "message": "Número de contato",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_NAME",
+    "message": "Nome",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_USER_MANAGEMENT_ROLE",
+    "message": "Papel",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_USER_MESSAGE",
+    "message": "Preencha o modelo baixado com os dados do usuário e carregue a planilha.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_USER_TAG_CLEAR",
+    "message": "Claro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_USER_TAG_SEARCH",
+    "message": "Procurar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_VILLAGE_ACCESSIBILITY_LEVEL",
+    "message": "Nível de acessibilidade da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_VILLAGE_SECURITY_LEVEL",
+    "message": "Nível de segurança da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_WARNING_ASSUMPTIONS_FORM",
+    "message": "Tem certeza de que deseja alterar as respostas do questionário de premissas do microplano?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MP_WARNING_BOUNDARIES_FORM",
+    "message": "Aviso!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR-DN",
+    "message": "Campanha SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_GUIDELINE_POINTS_1",
+    "message": "O nome do arquivo deve ser 'Population.xlsx'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_EXCEL_GUIDELINE_POINTS_2",
+    "message": "Os campos Latitude e Longitude devem ter dados em Graus Decimais e Graus Minuto Segundos (o valor deve ser 12,3455 e não 12° 20' 43,7994')",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_1",
+    "message": "O arquivo GeoJSON deve atender à especificação {{link}}.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_2",
+    "message": "O nome do arquivo deve ser 'Population.geojson'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_3",
+    "message": "Todos os recursos no arquivo devem ter geometrias do mesmo tipo (ou seja, todos devem ser pontos ou todos devem ser multipolígonos e assim por diante).",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_4",
+    "message": "As coordenadas devem estar no intervalo válido de latitude e longitude (o intervalo válido para latitude é -90 a +90 e o intervalo válido de longitude é -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_5",
+    "message": "Todos os recursos do arquivo devem ter propriedades com o mesmo conjunto de chaves.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_6",
+    "message": "As características do arquivo devem ter chaves importantes como 'País', 'Província', 'Distrito', 'Posto administrativo', 'Localidade', 'Aldeia', 'Código de limite', 'População alvo (idade 3 meses - 11 meses) ', 'População-alvo (Idade 12 meses - 59 meses)', 'População-alvo total'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_GUIDELINE_POINTS_7",
+    "message": "No objeto Propriedades, os valores dos campos que representam um Valor Numérico não devem ser colocados entre aspas duplas (ou seja, uma população de 10.000 deve ser representada como “população”: 10.000 e não “população”: “10.0000”",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_GEOJSON_SPECIFICATION",
+    "message": "RFC 7946 GeoJSON",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_1",
+    "message": "O usuário deve compactar todos os arquivos no formato .zip e carregá-los no sistema. No mínimo, o sistema precisa de arquivos .shp, .shx e .dbf compactados.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_2",
+    "message": "O nome do arquivo zip deve ser 'Population.zip'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_3",
+    "message": "O shapefile deve estar no sistema de coordenadas lat-long WGS 84 para que o sistema aceite.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_4",
+    "message": "As coordenadas devem estar no intervalo válido de latitude e longitude (o intervalo válido para latitude é -90 a +90 e o intervalo válido de longitude é -180 a +180).",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_5",
+    "message": "O arquivo shape deve conter pontos de dados importantes, como 'País', 'Província', 'Distrito', 'Posto administrativo', 'Localidade', 'Aldeia', 'Código de limite', 'População alvo (idade 3 meses - 11 meses)', 'População-alvo (Idade 12 meses - 59 meses)', 'População-alvo total'.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MR_DN_POPULATION_SHAPEFILE_GUIDELINE_POINTS_6",
+    "message": "O tamanho total do arquivo compactado não deve exceder 2 GB.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MULTIPLIED_BY",
+    "message": "Multiplicado por",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MY_MICROPLAN",
+    "message": "Todos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MY_MICROPLANS",
+    "message": "Meus Microplanos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "MY_MICROPLANS_HEADING",
+    "message": "Meus Microplanos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Microplan Country",
+    "message": "País",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NAME",
+    "message": "Nome",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NAME_OF_MICROPLAN",
+    "message": "Nome do Microplan",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NAME_OF_MP",
+    "message": "Nome do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NAME_YOUR_MP",
+    "message": "Digite o nome do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEVER",
+    "message": "Nunca",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEVER1",
+    "message": "Nunca",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW_ASSUMPTION",
+    "message": "Adicionar nova suposição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW_FORMULA",
+    "message": "Adicionar nova fórmula",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEW_VALUE",
+    "message": "Novo valor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NEXT",
+    "message": "Próximo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO",
+    "message": "Não",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_CAMPAIGN_DETAILS_FOUND_FOR_GIVEN_CAMPAIGN_ID",
+    "message": "Houve algum problema. Por favor, tente novamente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_DATA",
+    "message": "NA",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_DATA_AVAILABLE",
+    "message": "Não há dados disponíveis. Por favor, carregue dados válidos, se você já os tiver e ainda não aparecerem aqui, entre em contato com o administrador",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_NAME_AVAILABLE",
+    "message": "Nenhum nome disponível",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Número de malas por equipe por ciclo para equipe de distribuição de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Número de sacolas por equipe por ciclo para equipe de pós-registro fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Número de sacolas por equipe e por ciclo para equipe de distribuição de casa em casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BAGS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Número de sacolas por equipe por ciclo para equipe de registro porta a porta",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BALES_PER_BOUNDARY",
+    "message": "Número total de fardos por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_PER_BALE",
+    "message": "Número de mosquiteiros por fardo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Número total de mosquiteiros por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_PER_HOUSEHOLD",
+    "message": "Número de mosquiteiros por domicílio",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_REQUIRED",
+    "message": "Número de mosquiteiros necessários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNETS_TO_BE_DISTRIBUTED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY",
+    "message": "Número de mosquiteiros a serem distribuídos por uma equipe de distribuição por dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNET_PER_HOUSEHOLD",
+    "message": "Número de mosquiteiros por domicílio",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BEDNET_REQUIRED",
+    "message": "Número de mosquiteiros necessários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Número de beneficiários a serem atendidos por uma equipe de distribuição por dia e por ciclo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_CATERED_BY_A_HOUSEHOLD_DISTRIBUTION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Número de beneficiários a serem atendidos pela equipe de distribuição por dia e por ciclo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_CATERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Quantidade de beneficiários a serem atendidos por equipe por dia no posto fixo de distribuição por ciclo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY",
+    "message": "Número de beneficiários ou agregados familiares a serem registados por uma equipa de registo por dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_REGISTERED_BY_A_HOUSEHOLD_REGISTRATION_TEAM_PER_DAY_PER_CYCLE",
+    "message": "Número de beneficiários a serem cadastrados por uma equipe de cadastramento por dia e por ciclo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Número de beneficiários a registar por equipa por dia no ponto de distribuição de postos fixos por ciclo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Número de gizes por equipe por ciclo para equipe de distribuição de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Número de gizes por equipe por ciclo para equipe de pós-registro fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Número de gizes por equipe por ciclo para equipe de distribuição de casa em casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_CHALKS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Número de gizes por equipe por ciclo para equipe de registro de casa em casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_CYCLES",
+    "message": "Número de ciclos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Número de dias para distribuição de correio fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Número de dias para registro de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Número de dias para distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Número de dias para registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_DAYS_OF_THE_CAMPAIGN_AT_THAT_BOUNDRY_LEVEL",
+    "message": "Número de dias da campanha nesse nível de limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_DISTRIBUTORS",
+    "message": "Número de distribuidores",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_DISTRIBUTORS_PER_BOUNDARY",
+    "message": "Número de distribuidores por fronteira",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_DISTRIBUTORS_PER_MONITOR",
+    "message": "Número de distribuidores por monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Número total de equipes de distribuição de postos fixos por fronteira durante 1 dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Número total de equipes de distribuição de postos fixos por limite para a campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Número de equipes de distribuição de postos fixos por supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Número total de membros da equipe de distribuição de postagem fixa por limite da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_DISTRIBUTION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "Número total de supervisores da equipe de distribuição de postos fixos por fronteira",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Número total de equipes de registro de posto fixo por fronteira durante 1 dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Número total de equipes de registro de postos fixos por limite para a campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Número de equipes de registro de cargos fixos por supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Número total de membros da equipe de registro de posto fixo por limite da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_FIXED_POST_REGISTRATION_TEAM_SUPERVISORS_PER_BOUNDARY",
+    "message": "Número total de supervisores da equipe de registro de posto fixo por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD",
+    "message": "Número de domicílios",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Número total de domicílios por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "Número de domicílios por rolo de adesivos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Número total de equipes de distribuição por limite durante 1 dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Número total de equipes de distribuição por limite da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_MONITOR",
+    "message": "Número de equipes de distribuição por monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Número de equipes de distribuição por supervisores",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Número total de membros da equipe de distribuição por limite da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_ONE_DAY",
+    "message": "Número total de equipes de registro por limite durante 1 dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Número total de equipes de inscrição por limite para a campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Quantidade de equipes cadastradas por monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Número de equipes cadastradas por supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Número total de membros da equipe de registro por limite da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_HOUSEHOLD_TO_BE_COVERED",
+    "message": "Número de domicílios a serem cobertos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Número de membros por equipe de distribuição de postos fixos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Número de membros por equipe de registro de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Número de membros por equipe de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_MEMBERS_PER_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Número de membros por equipe de inscrição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Número total de monitores da equipe de distribuição por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Número total de monitores da equipe de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_DISTRIBUTION",
+    "message": "Número de monitores por supervisor para distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_MONITORS_PER_SUPERVISOR_FOR_HOUSEHOLD_REGISTRATION",
+    "message": "Número de monitores por supervisor para inscrição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Número de baias por equipe por ciclo para equipe de distribuição de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Número de baias por equipe por ciclo para equipe de pós-registro fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Número de currais por equipe e por ciclo para equipe de distribuição de casa em casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_PENS_PER_TEAM_PER_CYCLE_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Número de baias por equipe por ciclo para equipe de registro porta a porta",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_PEOPLE_PER_BEDNET",
+    "message": "Número de pessoas por mosquiteiro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_PEOPLE_PER_HOUSEHOLD",
+    "message": "Número de pessoas por domicílio",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_POPULATION_TARGETTED_FOR_COVERAGE",
+    "message": "Número de população visada para cobertura",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_POPULATION_TO_BE_COVERED",
+    "message": "Número de população a ser coberta",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SOAK_PITS",
+    "message": "Número de poços de imersão",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_1_REQUIRED_FOR_AGE_3_TO_11_MONTHS",
+    "message": "Total de SPAQ-1 necessário para idades de 3 meses a 11 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_1_REQUIRED_FOR_AGE_3_TO_11_MONTHS_WITH_BUFFER",
+    "message": "Total de SPAQ-1 necessário para idade de 3 meses a 11 meses com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_2_REQUIRED_FOR_AGE_12_TO_59_MONTHS",
+    "message": "Total de SPAQ-2 necessário para idades de 12 meses a 59 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_2_REQUIRED_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "Total de SPAQ-2 necessário para idade de 12 meses - 59 meses com buffer ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_1",
+    "message": "Número de SPAQs necessários por ciclo para o grupo demográfico 1",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_1_WITH_BUFFER",
+    "message": "Número de SPAQs necessários por ciclo para o grupo demográfico 1 com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_2",
+    "message": "Número de SPAQs necessários por ciclo para o grupo demográfico 1",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQS_REQUIRED_PER_CYCLE_FOR_DEMOGRAPHIC_2_WITH_BUFFER",
+    "message": "Número de SPAQs necessários por ciclo para o grupo demográfico 2 com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SPAQ_PER_CYCLE",
+    "message": "Número de SPAQ por ciclo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_STICKERS_ROLLS_PER_BOUNDARY",
+    "message": "Número total de rolos de adesivos por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES",
+    "message": "Número de estruturas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES_PER_UNIT_OF_INSECTICIDE",
+    "message": "Número de estruturas pulverizadas por dia por operador",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES_SPRAYED_PER_DAY_PER_OPERATOR",
+    "message": "Número de operadores de pulverização por monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_STRUCTURES_THAT_ARE_SPRAYABLE",
+    "message": "Número de estruturas que podem ser pulverizadas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERIORS",
+    "message": "Número de superiores",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS",
+    "message": "Número de supervisores",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS_FOR_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Número total de supervisores da equipe de distribuição por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Número total de supervisores da equipe de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_SUPERVISORS_PER_BOUNDARY",
+    "message": "Número de supervisores por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_TEAMS_PER_BOUNDARY",
+    "message": "Número de equipes por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_OF_TEAMS_PER_BOUNDARY_IF_CAMPAIGN_RUNS_FOR_1_DAY",
+    "message": "Número de equipes por limite se a campanha durar 1 dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_RESULTS_FACILITY_CATCHMENT_MAPPER",
+    "message": "Não há atribuidores de limites da Instalação atribuídos para este microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_RESULTS_FOUND",
+    "message": "Nenhum resultado encontrado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_RESULTS_MICROPLAN_VIEWER",
+    "message": "Não há visualizadores de estimativa de microplano atribuídos para este microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_RESULTS_PLAN_ESTIMATION_APPROVER",
+    "message": "Não há aprovadores de estimativa de Microplan atribuídos para este microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_RESULTS_POPULATION_DATA_APPROVER",
+    "message": "Não há aprovadores de dados populacionais atribuídos para este microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_RESULTS_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Não há atribuidores de limites de instalações nacionais atribuídos para este microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_RESULTS_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Não há aprovadores nacionais de estimativas de microplanos designados para este microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_RESULTS_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Não há Aprovadores de dados populacionais nacionais atribuídos para este microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_ROAD",
+    "message": "Sem estrada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_FACILITY_CATCHMENT_MAPPER",
+    "message": "Nenhum resultado encontrado para determinados critérios de pesquisa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_MICROPLAN_VIEWER",
+    "message": "Nenhum resultado encontrado para determinados critérios de pesquisa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_PLAN_ESTIMATION_APPROVER",
+    "message": "Nenhum resultado encontrado para determinados critérios de pesquisa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_POPULATION_DATA_APPROVER",
+    "message": "Nenhum resultado encontrado para determinados critérios de pesquisa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Nenhum resultado encontrado para determinados critérios de pesquisa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Nenhum resultado encontrado para determinados critérios de pesquisa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NO_SEARCH_RESUTS_ROOT_POPULATION_DATA_APPROVER",
+    "message": "Nenhum resultado encontrado para determinados critérios de pesquisa.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BALES_PER_BOUNDARY",
+    "message": "Número de fardos por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BEDNETS_PER_BALE",
+    "message": "Número de mosquiteiros por fardo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BEDNETS_TO_BE_DISTRIBUTED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Número de mosquiteiros a serem distribuídos por equipe e por dia no ponto de distribuição de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BEDNETS_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Número de mosquiteiros a registar por equipa e por dia no ponto de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BED_NETS_PER_BOUNDARY",
+    "message": "Número de mosquiteiros por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BENEFICIARIES_PER_TEAM",
+    "message": "Número de beneficiários por equipe",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BENEFICIARIES_PER_TEAM_PER_DAY",
+    "message": "Número de beneficiários por equipe por dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_BENEFICIARIES_TO_BE_REGISTERED_PER_TEAM_PER_DAY_AT_THE_FIXED_POST_DISTRIBUTION_POINT",
+    "message": "Número de beneficiários ou agregados familiares a registar por equipa e por dia no ponto de distribuição de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_CAMPAIGN_DAYS",
+    "message": "Número de dias de campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DAYS_FOR_CAMPAIGN",
+    "message": "Número de dias da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DAYS_FOR_FIXED_POST_DISTRIBUTION",
+    "message": "Número de dias para distribuição de correio fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DAYS_FOR_FIXED_POST_REGISTRATION",
+    "message": "Número de dias para registro de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DISTRIBUTORES_PER_SUPERVISOR",
+    "message": "Número de distribuidores por supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_DISTRIBUTORS_IF_CAMPAIGN_RUNS_FOR_1_DAY",
+    "message": "Número de distribuidores se a campanha durar 1 dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_DISTRIBUTION_TEAMS_PER_SUPERVISOR",
+    "message": "Número de equipes de distribuição de postos fixos por supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_CAMPAIGN",
+    "message": "Número de equipes de inscrição por limite para a campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_BOUNDARY_ONE_DAY",
+    "message": "Número de equipes de registro por limite por 1 dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAMS_PER_SUPERVISOR",
+    "message": "Número de equipes de registro de cargos fixos por supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Número de membros da equipe de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_FIXED_POST_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Número de membros da equipe de posto fixo por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_BOUNDARY",
+    "message": "Número de domicílios por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_FIXED_POST_TEAM",
+    "message": "Número de domicílios por equipe de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Número de domicílios por equipe de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLDS_PER_STICKER_ROLL",
+    "message": "Número de domicílios por rolo de adesivos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_CAMPAIGN",
+    "message": "Número de equipes de distribuição por limite para a campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_DISTRIBUTION_TEAMS_PER_BOUNDARY_ONE_DAY",
+    "message": "Número de equipes de distribuição por limite durante 1 dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_DISTRIBUTION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Número de membros da equipe de distribuição por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY",
+    "message": "Número de equipes de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_1_DAY",
+    "message": "Número de equipes de registro por limite por 1 dia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAMS_PER_BOUNDARY_FOR_THE_CAMPAIGN",
+    "message": "Número de equipes de inscrição por limite para a campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Número de membros da equipe de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Número de membros por equipe de distribuição de postos fixos ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Número de membros por equipe de registro de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_REGISTRATION_TEAM",
+    "message": "Número de membros por equipe de inscrição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MEMBERS_PER_TEAM",
+    "message": "Número de membros por equipe",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Número de monitores da equipe de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_FIXED_POST_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Número de monitores da equipe de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_FIXED_POST_TEAM_PER_BOUNDARY",
+    "message": "Número de monitores por equipe de posto fixo por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_HOUSEHOLD_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Número de monitores da equipe de distribuição por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_SUPERVISOR_FOR_REGISTRATION",
+    "message": "Número de monitores por supervisor para inscrição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_MONITORS_PER_TEAM",
+    "message": "Quantidade de monitores por equipe",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_PERSON_PER_BEDNET",
+    "message": "Número de pessoas por mosquiteiro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_REGISTRATION_TEAMS_PER_MONITOR",
+    "message": "Quantidade de equipes cadastradas por monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SPRAY_TECHNICIAN_PER_SUPERVISOR",
+    "message": "Número de técnicos de pulverização por supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_FOR_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Número de supervisores da equipe de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_PER_DISTRIBUTION_TEAM_PER_BOUNDARY",
+    "message": "Número de supervisores da equipe de distribuição por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_PER_FIXED_POST_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Número de supervisores da equipe de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_SUPERVISORS_PER_FIXED_POST_TEAM_PER_BOUNDARY",
+    "message": "Número de supervisores por equipe de posto fixo por fronteira",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "NUMBER_OF_TEAMS_PER_SUPERVISOR",
+    "message": "Número de equipes por supervisor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Name",
+    "message": "Nome",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Number",
+    "message": "Número de contato",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "OFTEN",
+    "message": "Frequentemente (pelo menos uma vez por ano)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "OFTEN1",
+    "message": "Frequentemente (pelo menos uma vez por semana)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "OLD_VALUE",
+    "message": "Valor antigo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "OPEN_MICROPLANS",
+    "message": "Microplanos abertos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "OTHER",
+    "message": "Outro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PENDING_FOR_APPROVAL",
+    "message": "Pendente para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PENDING_FOR_VALIDATION",
+    "message": "Pendente para validação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PERMAENENT",
+    "message": "Permanente",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PERMANENT_DELETE",
+    "message": "Excluir um item de linha excluirá a suposição. No entanto, você poderá recuperá-lo clicando no botão ‘Adicionar Suposição’.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAIN",
+    "message": "Simples",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_APPROVE_CENSUS_DATA",
+    "message": "Dados Populacionais Finalizados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Enviado para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_EDIT_AND_VALIDATE",
+    "message": "Validado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_FINALIZE_CATCHMENT_MAPPING",
+    "message": "Finalizada a atribuição de instalações às aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_INITIATE",
+    "message": "Dados enviados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_SEND_BACK_FOR_CORRECTION",
+    "message": "Enviado de volta para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_START_DATA_APPROVAL",
+    "message": "Finalizando Dados Populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ACTIONS_VALIDATE",
+    "message": "Validado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER",
+    "message": "Aprovador de estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER_DESCRIPTION",
+    "message": "Esta função de usuário terá acesso para editar as suposições do microplano e aprovar a estimativa do microplano do limite administrativo atribuído.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_ESTIMATION_APPROVER_POPUP_HEADING",
+    "message": "Selecione aprovadores de estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_INBOX",
+    "message": "Validar e aprovar estimativas de microplanos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_HEADING_LABEL",
+    "message": "Enviar de volta para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_SUBMIT_LABEL",
+    "message": "Enviar para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_VALIDATE_HEADING_LABEL",
+    "message": "Validar dados para aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_SEND_FOR_VALIDATE_SUBMIT_LABEL",
+    "message": "Validar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_WORKFLOW_FOR_SEND_BACK_FOR_CORRECTION_UPDATE_SUCCESS",
+    "message": "As estimativas para as aldeias selecionadas são enviadas com sucesso para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_WORKFLOW_FOR_VALIDATE_UPDATE_SUCCESS",
+    "message": "As estimativas para aldeias selecionadas são validadas com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLAN_INBOX_WORKFLOW_UPDATE_SUCCESS",
+    "message": "A ação ocorreu com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLS_ENTER_ASSUMPTION_NAME",
+    "message": "Insira o nome das suposições.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PLS_SELECT_ASSUMPTION",
+    "message": "Selecione uma das opções suspensas.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POPULATION",
+    "message": "População",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POPULATION_COUNT_DEMOGRAPHIC_1_PER_BOUNDARY",
+    "message": "Contagem populacional para grupo demográfico 1 por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POPULATION_COUNT_DEMOGRAPHIC_2_PER_BOUNDARY",
+    "message": "Contagem populacional para o grupo demográfico 2 por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER",
+    "message": "Aprovador de dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER_DESCRIPTION",
+    "message": "Esta função de usuário terá acesso para validar e aprovar os dados populacionais das aldeias da fronteira administrativa atribuída.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POPULATION_DATA_APPROVER_POPUP_HEADING",
+    "message": "Selecione aprovadores de dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POPULATION_FINALISED_SUCCESSFUL",
+    "message": "Os dados populacionais foram finalizados com sucesso!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POPULATION_FINALISE_SUCCESS",
+    "message": "Validar e aprovar dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POPULATION_OF_THE_BOUNDARY",
+    "message": "População da fronteira",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_APPROVE",
+    "message": "Aprovado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_EDIT_AND_SEND_FOR_APPROVAL",
+    "message": "Enviado para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_EDIT_AND_VALIDATE",
+    "message": "Validado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_INITIATE",
+    "message": "Dados enviados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_ROOT_APPROVE",
+    "message": "Aprovado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_SEND_BACK_FOR_CORRECTION",
+    "message": "Enviado para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_ACTIONS_VALIDATE",
+    "message": "Validado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX",
+    "message": "Validar e aprovar dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_HEADING_LABEL",
+    "message": "Envie dados da aldeia para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_LABEL",
+    "message": "Envie e valide os dados da população",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_SUBMIT_LABEL",
+    "message": "Enviar para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_HCM_MICROPLAN_EDIT_WORKFLOW_UPDATED_SUCCESSFULLY",
+    "message": "Os dados das aldeias selecionadas foram enviados com sucesso para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_APPROVE_HEADING_LABEL",
+    "message": "Aprovar dados para aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_APPROVE_SUBMIT_LABEL",
+    "message": "Aprovar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_ROOT_APPROVE_HEADING_LABEL",
+    "message": "Aprovar dados para aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_ROOT_APPROVE_SUBMIT_LABEL",
+    "message": "Aprovar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_HEADING_LABEL",
+    "message": "Enviar dados para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_SEND_BACK_FOR_CORRECTION_SUBMIT_LABEL",
+    "message": "Enviar para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_VALIDATE_HEADING_LABEL",
+    "message": "Validar dados para aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_SEND_FOR_VALIDATE_SUBMIT_LABEL",
+    "message": "Validar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_APPROVE_UPDATE_SUCCESS",
+    "message": "Os dados das aldeias selecionadas foram aprovados com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_ROOT_APPROVE_UPDATE_SUCCESS",
+    "message": "Os dados das aldeias selecionadas foram aprovados com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_SEND_BACK_FOR_CORRECTION_UPDATE_SUCCESS",
+    "message": "Os dados das aldeias selecionadas são enviados de volta com sucesso para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_FOR_VALIDATE_UPDATE_SUCCESS",
+    "message": "Os dados das aldeias selecionadas foram validados com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_OR_ROOT_APPROVE_UPDATE_SUCCESS",
+    "message": "A ação ocorreu com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "POP_INBOX_WORKFLOW_UPDATE_SUCCESS",
+    "message": "A ação ocorreu com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PREREQUISITES",
+    "message": "Pré-requisitos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PREVIOUS",
+    "message": "Anterior",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PROCEDURE",
+    "message": "Procedimento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PROVIDE_DETAILS",
+    "message": "Forneça os seguintes detalhes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "PROVINCE",
+    "message": "Província",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "P_CAMPAIGN_SETUP_DETAILS",
+    "message": "Nome do Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Please configure the formula with respect to the assumptions considered for resource estimation",
+    "message": "Configure a fórmula com relação às premissas consideradas para estimativa de recursos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Procurar",
+    "message": "Procurar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "QUANTITY_OF_INSECTICIDE_REQUIRED",
+    "message": "Quantidade de inseticida necessária",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RAISE_TO",
+    "message": "Elevar para (potência)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RARELY",
+    "message": "Raramente (uma vez a cada 2-3 anos)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RARELY1",
+    "message": "Raramente (uma vez por mês)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "REFER",
+    "message": "Consulte a diretriz de dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "REGISTRATION_AND_DISTRIBUTION",
+    "message": "O processo de registro e distribuição ocorre em conjunto ou separadamente?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "REGISTRATION_PROCESS",
+    "message": "Como está acontecendo o processo de registro da campanha?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_CALCULATION",
+    "message": "Insira os valores para cada premissa declarada abaixo para cálculo de recursos.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_DISTRIBUTION_STRATEGY",
+    "message": "Estratégia de distribuição de recursos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_ESTIMATIONS_APPROVED",
+    "message": "Microplano finalizado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_ESTIMATION_IN_PROGRESS",
+    "message": "Validação em andamento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_NO_OF_HOUSEHOLD_REGISTRATION_TEAM_MEMBERS_PER_BOUNDARY",
+    "message": "Número total de membros da equipe de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_NO_OF_SUPERVISORS_FOR_HOUSEHOLD_REGISTRATION_TEAM_PER_BOUNDARY",
+    "message": "Número total de supervisores da equipe de registro por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Número total de malas necessárias por limite para registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Número total de gizes necessários por limite para a equipe de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS",
+    "message": "Total de SPAQ-1 necessário com buffer (Idade de 3 a 11 meses)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "Total de SPAQ-2 necessário com buffer (Idade de 12 a 59 meses)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_SPAQ_REQUIRED_WITH_BUFFER",
+    "message": "Total de SPAQ necessário com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RESOURCE_TYPE_TOTAL_TARGET_POPULATION",
+    "message": "População-alvo total",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROLES",
+    "message": "Papel",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROLE_ACCESS_CONFIGURATION",
+    "message": "Gerenciamento de acesso de usuário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_APPROVE",
+    "message": "Aprovar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_APPRROVE",
+    "message": "Aprovar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER",
+    "message": "Atribuidor de limites de instalações nacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER_DESCRIPTION",
+    "message": "Esta função de usuário terá acesso para atribuir e finalizar a instalação para a atribuição da área de influência do limite administrativo atribuído.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_FACILITY_CATCHMENT_MAPPER_POPUP_HEADING",
+    "message": "Atribuir atribuidor de limite de instalação nacional",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER",
+    "message": "Aprovador nacional de estimativa de microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER_DESCRIPTION",
+    "message": "Esta função de utilizador terá acesso para validar, aprovar e finalizar a estimativa do microplano para as aldeias da fronteira administrativa atribuída.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_PLAN_ESTIMATION_APPROVER_POPUP_HEADING",
+    "message": "Designar aprovadores nacionais de estimativas de microplanos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER",
+    "message": "Aprovador de dados populacionais nacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER_DESCRIPTION",
+    "message": "Esta função de usuário terá acesso para validar, aprovar e finalizar os dados populacionais das aldeias da fronteira administrativa atribuída.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_POPULATION_DATA_APPROVER_POPUP_HEADING",
+    "message": "Atribuir aprovadores nacionais de dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_HEADING_LABEL",
+    "message": "Enviar e validar dados para aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_POP_INBOX_HCM_MICROPLAN_EDIT_POPULATION_COMMENT_SUBMIT_LABEL",
+    "message": "Enviar e validar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROOT_POP_INBOX_HCM_MICROPLAN_EDIT_WORKFLOW_UPDATED_SUCCESSFULLY",
+    "message": "Os dados das aldeias selecionadas foram validados com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "ROWS",
+    "message": "Linhas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RULE_ENGINE",
+    "message": "Mecanismo de regras",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INFORMATION_DESCRIPTION",
+    "message": "Visão dinâmica de como as fórmulas ajudarão a calcular as estimativas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INPUT",
+    "message": "Entrada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INPUT_HELP_TEXT",
+    "message": "Pode ser a população ou o número de domicílios ou o número de recursos com base no tipo de campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_INSTRUCTIONS_DELETE_ENTRY_CONFIRMATION",
+    "message": "A exclusão de um item de linha excluirá permanentemente a configuração da fórmula. Você não será capaz de recuperá-lo.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_KEY_HELP_TEXT",
+    "message": "Esta é a chave que foi configurada na etapa anterior como hipótese",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_OPERATOR",
+    "message": "Operador",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_OPERATOR_HELP_TEXT",
+    "message": " ",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "RULE_ENGINE_VALUE_HELP_TEXT",
+    "message": "Indica o valor a ser calculado para estimativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SAVED_MICROPLANS",
+    "message": "Meus microplanos salvos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SAVED_MICROPLANS_TEXT",
+    "message": "Microplanos salvos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SAVE_CHANGES",
+    "message": "Salvar alterações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SAVE_PROCEED",
+    "message": "Salvar e prosseguir",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEARCH",
+    "message": "Procurar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEARCH_ALL",
+    "message": "Microplanos abertos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEARCH_All",
+    "message": "Microplanos abertos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEARCH_MICROPLANS",
+    "message": "Microplanos abertos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SECURITY_DETAILS_UPDATE_SUCCESS",
+    "message": "Os detalhes de segurança foram atualizados com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SECURITY_LEVEL_Q1",
+    "message": "A sua aldeia é propensa a distúrbios civis, como protestos violentos, motins, etc.?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SECURITY_LEVEL_Q1_",
+    "message": "A sua aldeia é propensa a distúrbios civis, como protestos violentos, motins, etc.?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SECURITY_LEVEL_Q2",
+    "message": "Com que frequência as forças de segurança patrulham a aldeia?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT",
+    "message": "Selecione",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECTED",
+    "message": "Selecionado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECTED_BOUNDARY",
+    "message": "Área Administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY",
+    "message": "Selecione Atividade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_ASSIGN_FACILITIES_TO_VILLAGE",
+    "message": "Esta actividade permitir-lhe-á atribuir e finalizar instalações às suas aldeias de influência.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_GEOSPATIAL_MAP_VIEW",
+    "message": "Esta atividade permitirá visualizar a estimativa do microplano em um mapa geoespacial.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_VALIDATE_N_APPROVE_MICROPLAN_ESTIMATIONS",
+    "message": "Esta atividade permitirá validar e aprovar as estimativas do microplano.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_ACTIVITY_TOOLTIP_CONTENT_VALIDATE_N_APPROVE_POPULATION_DATA",
+    "message": "Esta atividade permitirá validar e aprovar os dados populacionais a serem considerados para o microplanejamento.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_ALL",
+    "message": "Selecionar tudo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_AN_ACTIVITY_TO_CONTINUE",
+    "message": "Selecione uma atividade para continuar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_ASSUMPTION_ALREADY_ADDED",
+    "message": "Este nome de suposição já existe. Adicione outro nome de suposição.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_ASSUMPTION_NAME_LONG_THAN_100",
+    "message": "O nome da suposição não deve ter mais de 100 caracteres.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_A_BOUNDARY",
+    "message": "Selecione um limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_A_BOUNDARY_TOOLTIP",
+    "message": "Aqui você pode selecionar o limite dos dados enviados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_BOUNDARIES",
+    "message": "Selecione a área administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_CAMPAIGN",
+    "message": "Selecione uma campanha para criar microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_FORMULA",
+    "message": "Selecione a fórmula",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_FORMULA_NAME_LONG_THAN_100",
+    "message": "O nome da fórmula não deve ter mais de 100 caracteres.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_HIERARCHY",
+    "message": "Selecione hierarchy",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_HIERARCHY_LEVEL",
+    "message": "Selecione a hierarquia administrativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SELECT_OPTION",
+    "message": "Selecione uma opção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEND_BACK_FOR_CORRECTION",
+    "message": "Enviar de volta para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEND_FOR_APPROVAL",
+    "message": "Enviar para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEND_FOR_APPROVE",
+    "message": "Aprovar dados para aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEND_FOR_Approve",
+    "message": "Enviar para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEND_FOR_ROOT_APPROVE",
+    "message": "Aprovar dados para aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEND_FOR_SEND_BACK_FOR_CORRECTION",
+    "message": "Enviar dados para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEND_FOR_Send Back For Correction",
+    "message": "Enviar dados para correção",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEND_FOR_VALIDATE",
+    "message": "Validar dados para aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEND_FOR_Validate",
+    "message": "Validar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SEPARATELY",
+    "message": "Separadamente",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SETUP_COMPLETED",
+    "message": "Configuração do Microplan concluída!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SETUP_COMPLETED_RESPONSE",
+    "message": "Configuração concluída",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SETUP_COMPLETE_FAILED_DUE_TO_API_INTEGRATION",
+    "message": "Esta ação já foi feita. Atualize e tente novamente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SETUP_MICROPLAN",
+    "message": "Configurar Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SETUP_MICROPLAN_SUCCESS_NAME",
+    "message": "Nome do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SETUP_MICROPLAN_SUCCESS_RESPONSE_DESC",
+    "message": "Configuração do Microplan concluída.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SHAPE_FILES",
+    "message": "Arquivo de forma",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SHOW_ON_ESTIMATION_DASHBOARD",
+    "message": "Mostrar no painel de estimativa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "START",
+    "message": "Iniciar validação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "START_DATA_APPROVAL",
+    "message": "Dados editados e enviados para aprovação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "STRAT_FIXED_POST",
+    "message": "Posto Fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "STRAT_HOUSE_TO_HOUSE",
+    "message": "De casa em casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "STRAT_HOUSE_TO_HOUSE_FIXED_POST",
+    "message": "Posto Fixo e Casa a Casa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUBMIT",
+    "message": "Enviar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUBSTRACTION",
+    "message": "Subtração",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUB_HEADING_CAMPAIGN_COMMODITIES",
+    "message": "Estimativas de commodities",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUB_HEADING_CAMPAIGN_VEHICLES",
+    "message": "Estimativas de veículos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUB_HEADING_FIXED_POST_DISTRIBUTION",
+    "message": "Estimativas de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUB_HEADING_FIXED_POST_REGISTRATION",
+    "message": "Estimativas de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUB_HEADING_GENERAL_ESTIMATION",
+    "message": "Estimativas Gerais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUB_HEADING_HOUSEHOLD_DISTRIBUTION",
+    "message": "Estimativas de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUB_HEADING_HOUSEHOLD_REGISTRATION",
+    "message": "Estimativas de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUCCESS_DATA_SAVED",
+    "message": "Dados salvos com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUMMARY",
+    "message": "Resumo do Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "SUMMARY_SCREEN",
+    "message": "Resumo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TEMPORARY",
+    "message": "Temporário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOGETHER",
+    "message": "Junto",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_BALES",
+    "message": "Fardos totais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_BEDNETS",
+    "message": "Total de mosquiteiros",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_BUFFER_MULTIPLIER",
+    "message": "Porcentagem total de buffer (%)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_BUFFER_PERCENTAGE",
+    "message": "Porcentagem total de buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_CYCLES_OF_SMC",
+    "message": "Ciclos totais de SMC",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_FACILITIES_WITH_MAPPED_VILLAGES",
+    "message": "Instalações atribuídas às aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Número total de malas necessárias por fronteira para equipe de distribuição de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Número total de malas necessárias por limite para equipe de registro de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Total não. de sacolas necessárias por limite para a equipe de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_BAGS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Número total de malas necessárias por limite para a equipe de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Número total de gizes necessários por limite para a equipe de distribuição de postos fixos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Número total de gizes necessários por limite para equipe de registro de posto fixo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Total não. de giz necessários por limite para a equipe de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_CHALKS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Número total de gizes necessários por limite para a equipe de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_DISTRIBUTION_TEAM",
+    "message": "Número total de baias necessárias por limite para a equipe de distribuição de postos fixos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_FIXED_POST_REGISTRATION_TEAM",
+    "message": "Número total de baias necessárias por equipe de registro de posto fixo de fronteira",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_DISTRIBUTION_TEAM",
+    "message": "Total não. de baias necessárias por limite para a equipe de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NO_OF_PENS_REQUIRED_PER_BOUNDARY_FOR_HOUSEHOLD_REGISTRATION_TEAM",
+    "message": "Número total de baias necessárias por limite para a equipe de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_BEDNETS_PER_BOUNDARY",
+    "message": "Número total de mosquiteiros por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_DISTRIBUTORS",
+    "message": "Número total de distribuidores",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_HOUSEHOLDS",
+    "message": "Número total de domicílios",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_NUMBER_OF_TEAMS",
+    "message": "Número total de equipes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_POPULATION_OF_BOUNDARY",
+    "message": "Número de fardos por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_PROPORTION_WITH_BUFFER",
+    "message": "Proporção total de buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_QUANTITY",
+    "message": "Quantidade total",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_FOR_AGE_12_59_MONTHS",
+    "message": "SPAQ-1 total para idade de 12 a 59 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_FOR_AGE_12_59_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-1 total para idade de 12 a 59 meses com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_FOR_AGE_3_11_MONTHS",
+    "message": "Total SPAQ-1 para idades de 3 a 11 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ1_WITH_BUFFER",
+    "message": "SPAQ-1 total para idades de 3 a 11 meses com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ2_FOR_AGE_12_59_MONTHS",
+    "message": "Total SPAQ-2 para idades de 12 a 59 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQA_REQUIRED_PER_CYCLE",
+    "message": "Total de SPAQs necessários por ciclo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQS_REQUIRED_PER_CYCLE",
+    "message": "Total de SPAQs necessários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_59_MONTHS",
+    "message": "SPAQ-1 total para idade de 12 a 59 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_59_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-1 total para idade de 12 a 59 meses com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_TO_59_MONTHS",
+    "message": "SPAQ-1 total para idade de 12 a 59 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-1 total para idade de 12 a 59 meses com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_3_11_MONTHS",
+    "message": "Total SPAQ-1 para idades de 3 a 11 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS",
+    "message": "Total SPAQ-1 para idades de 3 a 11 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_FOR_AGE_3_TO_11_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-1 total para idades de 3 a 11 meses com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_1_WITH_BUFFER",
+    "message": "SPAQ-1 total para idades de 3 a 11 meses com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_2_FOR_AGE_12_59_MONTHS",
+    "message": "Total SPAQ-2 para idades de 12 a 59 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS",
+    "message": "Total SPAQ-2 para idades de 12 a 59 meses",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_2_FOR_AGE_12_TO_59_MONTHS_WITH_BUFFER",
+    "message": "SPAQ-2 total para idade de 12 a 59 meses com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_REQUIRED",
+    "message": "Total de SPAQ necessário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_SPAQ_REQUIRED_WITH_BUFFER",
+    "message": "Total de SPAQ necessário com buffer",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION",
+    "message": "População-alvo total",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_12_TO_59_MONTH_OF_BOUNDARY",
+    "message": "População-alvo total (12 a 59 meses de idade) do limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_3_11_MONTHS",
+    "message": "População-alvo total (3 a 11 meses de idade)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_3_TO_11_MONTHS",
+    "message": "População-alvo total (3 a 11 meses de idade)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_AGE_3_TO_11_MONTH_OF_BOUNDARY",
+    "message": "População-alvo total (3 a 11 meses de idade) do limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_TARGET_POPULATION_OF_BOUNDARY",
+    "message": "Número de fardos por limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "TOTAL_VILLAGES_WITH_FACILITY_ASSIGNED",
+    "message": "Aldeias atribuídas a instalações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UNASSIGN",
+    "message": "Cancelar atribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UNASSIGNED_SUCCESSFULLY",
+    "message": "O usuário foi desatribuído da função selecionada com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UNASSIGNED_SUCESS",
+    "message": "Aldeias foram desmarcadas com sucesso da Instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOAD",
+    "message": "Carregar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION",
+    "message": "População-alvo enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_12TO59",
+    "message": "População-alvo enviada (12 a 59 meses de idade)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TARGET_POPULATION_AGE_3TO11",
+    "message": "População-alvo enviada (3 a 11 meses de idade)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOADED_HCM_ADMIN_CONSOLE_TOTAL_POPULATION",
+    "message": "População total enviada",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOAD_DATA",
+    "message": "Carregar dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOAD_GUIDELINE_INFO_CARD_INSTRUCTION",
+    "message": "Faça upload dos dados de acordo com as diretrizes de dados",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOAD_USER",
+    "message": "Usuários de upload em massa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "UPLOAD_USER_SUCCESS",
+    "message": "Gerenciamento de usuários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERTAG_CONFIRM_TO_UNASSIGN",
+    "message": "Tem certeza de que deseja cancelar a atribuição do usuário à função escolhida?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USERTAG_CONFIRM_TO_UNASSIGN_DESC",
+    "message": "Depois que um usuário tiver a atribuição de uma função cancelada, você poderá reatribuir o mesmo usuário a uma função no módulo Gerenciamento de acesso de usuário. Deseja cancelar a atribuição do usuário?",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_ACCESS_MANAGEMENT",
+    "message": "Gerenciamento de acesso de usuário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_ACCESS_MGMT",
+    "message": "Gerenciamento de acesso de usuário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_DATA_UPLOAD_SUCCESSFUL",
+    "message": "Dados do usuário enviados com sucesso!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_DIRECTIONS_FOR_ERROR_MESSAGE",
+    "message": "Passe o mouse sobre a célula destacada para ver os erros.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_DOWNLOAD",
+    "message": "Baixar dados do usuário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "USER_MANAGEMENT",
+    "message": "Gerenciamento de usuários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "User data upload successful",
+    "message": "Dados do usuário enviados com sucesso!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VALIDATE",
+    "message": "Validar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VALIDATED",
+    "message": "Validado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VALIDATE_APPROVE_POPULATIONDATA",
+    "message": "Validar e aprovar dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VALIDATE_N_APPROVE_MICROPLAN_ESTIMATIONS",
+    "message": "Validar e aprovar estimativas de microplanos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VALIDATE_N_APPROVE_POPULATION_DATA",
+    "message": "Validar e aprovar dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VALUE",
+    "message": "Valor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VIEW_DETAILS",
+    "message": "Ver detalhes",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VIEW_LESS",
+    "message": "Ver menos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VIEW_LOGS",
+    "message": "Ver registros",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VIEW_MICROPLAN_ESTIMATIONS",
+    "message": "Ver estimativas do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VIEW_MORE",
+    "message": "Ver mais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VIEW_SUMMARY",
+    "message": "Ver resumo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VILLAGE",
+    "message": "Aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VILLAGE_ASSIGNED_TO_FACILITIES_SUCCESSFUL",
+    "message": "Aldeias atribuídas a instalações com sucesso!",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VILLAGE_FINALISE_SUCCESS",
+    "message": "Atribuir instalações às aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VILLAGE_ROAD_CONDITION",
+    "message": "Estado da estrada da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VILLAGE_TARNSPORTATION_MODE",
+    "message": "Modo de transporte de aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VILLAGE_TERRAIN",
+    "message": "Terreno da aldeia",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VILLAGE_VIEW",
+    "message": "Detalhes da vila",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "VISUALIZATIONS",
+    "message": "Visualizações",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "Validate and approve population data",
+    "message": "Validar e aprovar dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WARE_HOUSES",
+    "message": "Armazéns",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WARNING_INCOMPLETE_MAPPING",
+    "message": "Conclua o mapeamento antes de continuar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD",
+    "message": "Download",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_DOWNLOAD_MICROPLAN",
+    "message": "Baixar estimativas",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_EDIT",
+    "message": "Editar",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_FAILED",
+    "message": "Fracassado",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_INPROGRESS",
+    "message": "Em andamento",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_UPLOADED_BY",
+    "message": "Enviado por",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_FACILITY_MICROPLAN",
+    "message": "Carregar Excel para instalações ou pontos de serviços",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WBH_UPLOAD_TARGET_MICROPLAN",
+    "message": "Carregar Excel para dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WORKFLOW_INTEGRATION_ERROR",
+    "message": "Esta ação já foi feita. Atualize e tente novamente.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "WORKFLOW_UPDATE_SUCCESS",
+    "message": "A ação ocorreu com sucesso",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "YES",
+    "message": "Sim",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "_CAMPAIGN_SETUP_DETAILS",
+    "message": "Detalhes do microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "_HCM_MICROPLAN_FINALIZE_FACILITY_TO_VILLAGE_ASSIGNMENT_ALERT_SUFFIX_MESSAGE",
+    "message": "áreas administrativas sob o limite da campanha",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "admin",
+    "message": "Administrador",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "admin.*",
+    "message": "Administrador.*",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "assign-facilities-to-villages",
+    "message": "Atribuir instalações às aldeias",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "boundaryCode",
+    "message": "Código de limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "boundaryData",
+    "message": "Dados de limite",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "capacity",
+    "message": "Capacidade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "children",
+    "message": "Crianças",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "facilityCode",
+    "message": "Código da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "facilityData",
+    "message": "Dados da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "facilityName",
+    "message": "Nome da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "facilityStatus",
+    "message": "Status da instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "facilityType",
+    "message": "Tipo de instalação",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "lat",
+    "message": "Lat.",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "long",
+    "message": "Longo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "microplan-search",
+    "message": "Microplanos abertos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "my-microplans",
+    "message": "Meus Microplanos",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "numberOfMonitors",
+    "message": "Não do monitor",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "numberOfMonitors ",
+    "message": "Número de monitores",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "parent",
+    "message": "Pai",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "pop-inbox",
+    "message": "Validar e aprovar dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "population-finalise-success",
+    "message": "Validar e aprovar dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "select-activity",
+    "message": "Escolha a atividade",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "selectedDistributionProcess",
+    "message": "Processo de distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "selectedRegistrationDistributionMode",
+    "message": "Modo de registro e distribuição",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "selectedRegistrationProcess",
+    "message": "Processo de registro",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "setup-completed-response",
+    "message": "Criar Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "setup-microplan",
+    "message": "Criar Microplano",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "targetHouseholds",
+    "message": "Famílias-alvo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "targetPopulation",
+    "message": "População alvo",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "targetPopulationAge3To11",
+    "message": "População alvo (Idade 3 meses - 11 meses) (Obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "targetPopulationDemo1",
+    "message": "Demonstração da população-alvo 1",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "targetPopulationToReachPerCycleAgainstTheBoundaryInColumnHTotal",
+    "message": "População-alvo a atingir por ciclo em relação ao limite da coluna H Total",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "targetpopulationAge12To59",
+    "message": "População alvo (Idade 12 meses - 59 meses) (Obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "targetpopulationDemo2",
+    "message": "Demonstração da população-alvo 2",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "terrain",
+    "message": "Terreno",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "totalTargetPopulation",
+    "message": "População alvo total (Obrigatório)",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "upload-user",
+    "message": "Usuários de upload em massa",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "upload-user-success",
+    "message": "Criação de usuários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "user-download",
+    "message": "Baixar dados do usuário",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "user-management",
+    "message": "Gerenciamento de usuários",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  },
+  {
+    "code": "village-view",
+    "message": "Aprovar dados populacionais",
+    "module": "rainmaker-microplanning",
+    "locale": "pt_MZ"
+  }
+]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added localization support for the "hcm-admin-schemas", "rainmaker-common", and "rainmaker-hr" modules in English, French, and Portuguese for Mozambique.
	- Introduced comprehensive user guidelines and error handling messages for various administrative terms and user roles.
	- Enhanced user experience with localized messages for login credentials and operational instructions.

- **Bug Fixes**
	- Improved error handling messages for user input issues across different locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->